### PR TITLE
Fixed an issue with MetalClips.

### DIFF
--- a/src/com/projectkorra/ProjectKorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/MetalClips.java
@@ -226,7 +226,8 @@ public class MetalClips
 			return;
 		}
 		
-		if(!Methods.getBoundAbility(player).equalsIgnoreCase("MetalClips"))
+		if(Methods.getBoundAbility(player) == null ||
+				!Methods.getBoundAbility(player).equalsIgnoreCase("MetalClips"))
 		{
 			remove();
 			return;


### PR DESCRIPTION
Using MetalClips then switching to a slot without a bound ability would
cause a null pointer.

That's it right now...
