### PR TITLE
Added support for 1.8 particles!

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,17 +2,18 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/LocalServer/BukkitForPlugins.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/Factions.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/GriefPrevention.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/LWC.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/MassiveCore.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/NoCheatPlus.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/PreciousStones.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/TagAPI.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/Towny.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/WorldEdit.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/Bending Plugins/WorldGuard.jar"/>
-	<classpathentry kind="lib" path="C:/Users/Shawn/Documents/LocalServer/plugins/KorraRPG.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Desktop/Korra/bukkit-1.8-R0.1-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/Factions.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/GriefPrevention.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/LWC.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/MassiveCore.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/NoCheatPlus.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/PreciousStones.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/TagAPI.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/Towny.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Desktop/Amestria/plugins/WorldEdit.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/WorldGuard.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Downloads/KorraRPG.jar"/>
+	<classpathentry kind="lib" path="C:/Users/Brendan/Desktop/Korra/craftbukkit-180.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/com/projectkorra/ProjectKorra/Methods.java
+++ b/src/com/projectkorra/ProjectKorra/Methods.java
@@ -1444,7 +1444,7 @@ public class Methods {
 			if (gpp != null && respectGriefPrevention) {
 				Material type = player.getWorld().getBlockAt(location).getType();
 				if (type == null) type = Material.AIR;
-				String reason = GriefPrevention.instance.allowBuild(player, location, type);
+				String reason = GriefPrevention.instance.allowBuild(player, location);
 
 				if (ignite.contains(ability)) {
 

--- a/src/com/projectkorra/ProjectKorra/MetricsLite.java
+++ b/src/com/projectkorra/ProjectKorra/MetricsLite.java
@@ -284,7 +284,7 @@ public class MetricsLite {
 		boolean onlineMode = Bukkit.getServer().getOnlineMode(); // TRUE if online mode is enabled
 		String pluginVersion = description.getVersion();
 		String serverVersion = Bukkit.getVersion();
-		int playersOnline = Bukkit.getServer().getOnlinePlayers().length;
+		int playersOnline = Bukkit.getServer().getOnlinePlayers().size();
 
 		// END server software specific section -- all code below does not use any code outside of this class / Java
 

--- a/src/com/projectkorra/ProjectKorra/RevertChecker.java
+++ b/src/com/projectkorra/ProjectKorra/RevertChecker.java
@@ -1,6 +1,7 @@
 package com.projectkorra.ProjectKorra;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -43,7 +44,7 @@ public class RevertChecker implements Runnable {
 		@Override
 		public ArrayList<Chunk> call() throws Exception {
 			ArrayList<Chunk> chunks = new ArrayList<Chunk>();
-			Player[] players = server.getOnlinePlayers();
+			Collection<? extends Player> players = server.getOnlinePlayers();
 
 			for (Player player : players) {
 				Chunk chunk = player.getLocation().getChunk();

--- a/src/com/projectkorra/ProjectKorra/Utilities/ParticleEffect.java
+++ b/src/com/projectkorra/ProjectKorra/Utilities/ParticleEffect.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import net.minecraft.server.v1_8_R1.EnumParticle;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -217,8 +219,8 @@ public enum ParticleEffect {
 		for (ParticleEffect p : values())
 			NAME_MAP.put(p.name, p);
 		try {
-			packetPlayOutWorldParticles = ReflectionHandler.getConstructor(PacketType.PLAY_OUT_WORLD_PARTICLES.getPacket(), String.class, float.class, float.class, float.class, float.class, float.class,
-					float.class, float.class, int.class);
+			packetPlayOutWorldParticles = ReflectionHandler.getConstructor(PacketType.PLAY_OUT_WORLD_PARTICLES.getPacket(), net.minecraft.server.v1_8_R1.EnumParticle.class, boolean.class, float.class, float.class, float.class, float.class, float.class,
+					float.class, float.class, int.class, int[].class);
 			getHandle = ReflectionHandler.getMethod("CraftPlayer", SubPackageType.ENTITY, "getHandle");
 			playerConnection = ReflectionHandler.getField("EntityPlayer", PackageType.MINECRAFT_SERVER, "playerConnection");
 			sendPacket = ReflectionHandler.getMethod(playerConnection.getType(), "sendPacket", ReflectionHandler.getClass("Packet", PackageType.MINECRAFT_SERVER));
@@ -288,11 +290,69 @@ public enum ParticleEffect {
 		if (amount < 1)
 			throw new PacketInstantiationException("Amount cannot be lower than 1");
 		try {
-			return packetPlayOutWorldParticles.newInstance(name, (float) center.getX(), (float) center.getY(), (float) center.getZ(), offsetX, offsetY, offsetZ, speed, amount);
+			return packetPlayOutWorldParticles.newInstance(getEnumParticle(name), false, (float) center.getX(), (float) center.getY(), (float) center.getZ(), offsetX, offsetY, offsetZ, speed, amount, new int[0]);
 		} catch (Exception e) {
 			throw new PacketInstantiationException("Packet instantiation failed", e);
 		}
 	}
+	
+	public static EnumParticle getEnumParticle(String name)
+	{
+		switch(name.toUpperCase())
+		{
+			case "HUGEEXPLOSION":
+				return EnumParticle.EXPLOSION_HUGE;
+			case "BUBBLE":
+				return EnumParticle.WATER_BUBBLE;
+			case "SUSPEND":
+				return EnumParticle.SUSPENDED;
+			case "DEPTHSUSPEND":
+				return EnumParticle.SUSPENDED_DEPTH;
+			case "MAGICCRIT":
+				return EnumParticle.CRIT_MAGIC;
+			case "SMOKE":
+				return EnumParticle.SMOKE_NORMAL;
+			case "MOBSPELL":
+				return EnumParticle.SPELL_MOB;
+			case "MOBSPELLAMBIENT":
+				return EnumParticle.SPELL_MOB_AMBIENT;
+			case "INSTANTSPELL":
+				return EnumParticle.SPELL_INSTANT;
+			case "WITCHMAGIC":
+				return EnumParticle.SPELL_WITCH;
+			case "EXPLODE":
+				return EnumParticle.EXPLOSION_NORMAL;
+			case "SPLASH":
+				return EnumParticle.WATER_SPLASH;
+			case "WAKE":
+				return EnumParticle.WATER_WAKE;
+			case "LARGESMOKE":
+				return EnumParticle.SMOKE_LARGE;
+			case "REDDUST":
+				return EnumParticle.REDSTONE;
+			case "SNOWBALLPOOF":
+				return EnumParticle.SNOWBALL;
+			case "ANGRYVILLAGER":
+				return EnumParticle.VILLAGER_ANGRY;
+			case "HAPPYVILLAGER":
+				return EnumParticle.VILLAGER_HAPPY;
+			case "DRIPWATER":
+				return EnumParticle.DRIP_WATER;
+			case "DRIPLAVA":
+				return EnumParticle.DRIP_LAVA;
+			case "SNOWSHOVEL":
+				return EnumParticle.SNOW_SHOVEL;
+			case "ENCHANTMENTTABLE":
+				return EnumParticle.ENCHANTMENT_TABLE;
+			case "TOWNAURA":
+				return EnumParticle.TOWN_AURA;
+			case "FIREWORKSSPARK":
+				return EnumParticle.FIREWORKS_SPARK;
+			default:
+				return EnumParticle.valueOf(name.toUpperCase());
+		}
+	}
+
 
 	/**
 	 * Instantiates a new @PacketPlayOutWorldParticles object through reflection especially for the "iconcrack" effect


### PR DESCRIPTION
1.8 broke particles, so here's a fix.
You'll also notice other broken files, with easy fixes.

Notice how craftbukkit.jar (yes, Craftbukkit) was added as a dependency. This has to do with the necessity of EnumParticle enumerators (from net.minecraft.server) Be sure to get craftbukkit 1.8 and add it to the classpath.
