### PR TITLE
Updated the ParticleLib to allow for increased render distance

### DIFF
--- a/src/com/projectkorra/ProjectKorra/Utilities/ParticleEffect.java
+++ b/src/com/projectkorra/ProjectKorra/Utilities/ParticleEffect.java
@@ -3,6 +3,7 @@ package com.projectkorra.ProjectKorra.Utilities;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +12,7 @@ import java.util.Map.Entry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
@@ -397,6 +399,8 @@ public enum ParticleEffect {
 
 	private static final Map<String, ParticleEffect> NAME_MAP = new HashMap<String, ParticleEffect>();
 	private static final Map<Integer, ParticleEffect> ID_MAP = new HashMap<Integer, ParticleEffect>();
+	// If range is less than 257 it automatically reverts back to 16 blocks for some reason.
+	private static final int RANGE = 257;
 	private final String name;
 	private final int id;
 	private final int requiredVersion;
@@ -615,17 +619,8 @@ public enum ParticleEffect {
 	 * @see ParticlePacket
 	 * @see ParticlePacket#sendTo(Location, double)
 	 */
-	public void display(Location center, float offsetX, float offsetY, float offsetZ, float speed, int amount) throws ParticleVersionException, ParticleDataException, IllegalArgumentException {
-		if (!isSupported()) {
-			throw new ParticleVersionException("This particle effect is not supported by your server version");
-		}
-		if (requiresData) {
-			throw new ParticleDataException("This particle effect requires additional data");
-		}
-		if (requiresWater && !isWater(center)) {
-			throw new IllegalArgumentException("There is no water at the center location");
-		}
-		new ParticlePacket(this, offsetX, offsetY, offsetZ, speed, amount, 16 > 256, null).sendTo(center, 16);
+	public void display(Location center, float offsetX, float offsetY, float offsetZ, float speed, int amount) {
+		display(offsetX, offsetY, offsetZ, speed, amount, center, RANGE);
 	}
 
 	/**

--- a/src/com/projectkorra/ProjectKorra/firebending/Cook.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/Cook.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import com.projectkorra.ProjectKorra.Methods;
+import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 
 public class Cook {
 
@@ -63,8 +64,8 @@ public class Cook {
 			cook();
 			time = System.currentTimeMillis();
 		}
-
-		player.getWorld().playEffect(player.getEyeLocation(), Effect.MOBSPAWNER_FLAMES, 0, 10);
+		ParticleEffect.FLAME.display(player.getEyeLocation(), 0.6F, 0.6F, 0.6F, 0, 6);
+		ParticleEffect.SMOKE.display(player.getEyeLocation(), 0.6F, 0.6F, 0.6F, 0, 6);
 	}
 
 	private void cancel() {

--- a/src/com/projectkorra/ProjectKorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/FireBlast.java
@@ -19,6 +19,7 @@ import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.Methods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.earthbending.EarthBlast;
 import com.projectkorra.ProjectKorra.waterbending.Plantbending;
 import com.projectkorra.ProjectKorra.waterbending.WaterManipulation;
@@ -172,8 +173,10 @@ public class FireBlast {
 	}
 
 	private void advanceLocation() {
-		if (showParticles)
-			location.getWorld().playEffect(location, Effect.MOBSPAWNER_FLAMES, 0, (int) range);
+		if (showParticles) {
+			ParticleEffect.FLAME.display(location, 0.6F, 0.6F, 0.6F, 0, 20);
+			ParticleEffect.SMOKE.display(location, 0.6F, 0.6F, 0.6F, 0, 20);
+		}
 		location = location.add(direction.clone().multiply(speedfactor));
 		if (rand.nextInt(4) == 0) {
 			Methods.playFirebendingSound(location);

--- a/src/com/projectkorra/ProjectKorra/firebending/FireJet.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/FireJet.java
@@ -14,6 +14,7 @@ import com.projectkorra.ProjectKorra.Flight;
 import com.projectkorra.ProjectKorra.Methods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 
 
 public class FireJet {
@@ -76,7 +77,8 @@ public class FireJet {
 			if (Methods.rand.nextInt(2) == 0) {
 				Methods.playFirebendingSound(player.getLocation());
 			}
-			player.getWorld().playEffect(player.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+			ParticleEffect.FLAME.display(player.getLocation(), 0.6F, 0.6F, 0.6F, 0, 20);
+			ParticleEffect.SMOKE.display(player.getLocation(), 0.6F, 0.6F, 0.6F, 0, 20);
 			double timefactor;
 			if (AvatarState.isAvatarState(player) && isToggle) {
 				timefactor = 1;

--- a/src/com/projectkorra/ProjectKorra/firebending/FireShield.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/FireShield.java
@@ -15,6 +15,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.Methods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
+import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.airbending.AirShield;
 import com.projectkorra.ProjectKorra.earthbending.EarthBlast;
 import com.projectkorra.ProjectKorra.waterbending.WaterManipulation;
@@ -106,7 +107,8 @@ public class FireShield {
 
 				for (Block block : blocks) {
 					if (!Methods.isRegionProtectedFromBuild(player,	"FireShield", block.getLocation())) {
-						block.getWorld().playEffect(block.getLocation(), Effect.MOBSPAWNER_FLAMES, 0, 20);
+						ParticleEffect.FLAME.display(block.getLocation(), 0.6F, 0.6F, 0.6F, 0, 10);
+						ParticleEffect.SMOKE.display(block.getLocation(), 0.6F, 0.6F, 0.6F, 0, 10);
 						if (Methods.rand.nextInt(7) == 0) {
 							Methods.playFirebendingSound(block.getLocation());
 						}
@@ -148,7 +150,7 @@ public class FireShield {
 
 				for (Block block : blocks) {
 					if (!Methods.isRegionProtectedFromBuild(player, "FireShield", block.getLocation())) {
-						block.getWorld().playEffect(block.getLocation(), Effect.MOBSPAWNER_FLAMES, 0, 20);
+						ParticleEffect.FLAME.display(block.getLocation(), 0.6F, 0.6F, 0.6F, 0, 20);
 						if (Methods.rand.nextInt(4) == 0) {
 							Methods.playFirebendingSound(block.getLocation());
 						}

--- a/src/com/projectkorra/ProjectKorra/firebending/Fireball.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/Fireball.java
@@ -15,6 +15,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.ProjectKorra.Methods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 
 public class Fireball {
 
@@ -169,7 +170,8 @@ public class Fireball {
 
 	private void fireball() {
 		for (Block block : Methods.getBlocksAroundPoint(location, radius)) {
-			block.getWorld().playEffect(block.getLocation(), Effect.MOBSPAWNER_FLAMES, 0, 20);
+			ParticleEffect.FLAME.display(block.getLocation(), 0.6F, 0.6F, 0.6F, 0, 17);
+			ParticleEffect.SMOKE.display(block.getLocation(), 0.6F, 0.6F, 0.6F, 0, 17);
 			if (Methods.rand.nextInt(4) == 0) {
 				Methods.playFirebendingSound(location);
 			}

--- a/src/com/projectkorra/ProjectKorra/firebending/WallOfFire.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/WallOfFire.java
@@ -18,6 +18,7 @@ import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.Methods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 
 public class WallOfFire {
 
@@ -154,8 +155,8 @@ public class WallOfFire {
 
 	private void display() {
 		for (Block block : blocks) {
-			block.getWorld().playEffect(block.getLocation(),
-					Effect.MOBSPAWNER_FLAMES, 0, 15);
+			ParticleEffect.FLAME.display(block.getLocation(), 0.6F, 0.6F, 0.6F, 0, 6);
+			ParticleEffect.SMOKE.display(block.getLocation(), 0.6F, 0.6F, 0.6F, 0, 6);
 			
 			if (Methods.rand.nextInt(7) == 0) {
 				Methods.playFirebendingSound(block.getLocation());

--- a/src/com/projectkorra/ProjectKorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/Torrent.java
@@ -557,7 +557,7 @@ public class Torrent {
 				thaw(block);
 				continue;
 			}
-			if (block.getLocation().distance(player.getLocation()) > instances.get(player).range || !Methods.canBend(player.getName(), "Torrent")) {
+			if (block.getLocation().distance(player.getLocation()) > RANGE || !Methods.canBend(player.getName(), "Torrent")) {
 				thaw(block);
 			}
 		}


### PR DESCRIPTION
Updated the ParticleLib to account for high ranges:
- The particle library previously only allowed players within a 16 block radius to see a particle. The new version of the library lets us extend the range beyond that.  
- After some testing, the particle library only seems to have "16 blocks or less", or as far as the player has their render distance set. For now I set the range to be the latter option, but if it seems to cause intense FPS lag then we can lower it back down to the 16 block range.
- As a note: Minecraft has a maximum particle per chunk limit, which is why in the past we noticed weird (non fps, non tps) lag issues with Charged AirBurst. The AirBurst would just seem to freeze up an entire chunk of a server, but players outside of that chunk were completely unaffected. I don't believe these increases to the range will affect this lag issue, since we aren't adding any new particles to a specific chunk, instead we are just increasing the render distance for a player.
    
Updated Fire abilities to use the new ParticleLib:
    The following classes have been updated:
    - Cook
    - FireBlast
    - FireJet
    - FireShield
    - Fireball
    - WallOfFire

Fixed an issue where Torrent was causing errors to spam after it was frozen.