### PR TITLE
BendingPlayer API and Command Improvements

### DIFF
--- a/src/com/projectkorra/ProjectKorra/BendingPlayer.java
+++ b/src/com/projectkorra/ProjectKorra/BendingPlayer.java
@@ -75,6 +75,10 @@ public class BendingPlayer {
 	public boolean isPermaRemoved() {
 		return this.permaRemoved;
 	}
+	
+	public void setPermaRemoved(boolean b) {
+		this.permaRemoved = b;
+	}
 
 	public void addElement(Element e) {
 		this.elements.add(e);

--- a/src/com/projectkorra/ProjectKorra/Commands.java
+++ b/src/com/projectkorra/ProjectKorra/Commands.java
@@ -1218,10 +1218,8 @@ public class Commands {
 						}
 						BendingPlayer bTarget = Methods.getBendingPlayer(target.getName());
 
-						if (bTarget.isPermaRemoved()) {
-							s.sendMessage(ChatColor.RED + "That player's bending was permanently removed.");
-							return true;
-						}
+						if (bTarget.isPermaRemoved()) bTarget.setPermaRemoved(false);
+						
 						Element e = null;
 						if (Arrays.asList(airaliases).contains(args[2])) e = Element.Air;
 						if (Arrays.asList(wateraliases).contains(args[2])) e = Element.Water;


### PR DESCRIPTION
- Allows for developers to set whether a bending player is permaremoved
or not
- Allows admins choosing another player's bending to override
permaremove