### PR TITLE
Stops ProjectKorra from not working due to broken custom abilities

### DIFF
--- a/src/com/projectkorra/ProjectKorra/Ability/AbilityModuleManager.java
+++ b/src/com/projectkorra/ProjectKorra/Ability/AbilityModuleManager.java
@@ -207,74 +207,89 @@ public class AbilityModuleManager {
 			}
 		}
 		for (AbilityModule ab: ability) {
-			//To check if EarthBlast == Earthblast or for example, EarthBlast == EARTHBLAST
-                        boolean succes = true;
-                        for(String enabledAbility : abilities){
-                            if(enabledAbility.equalsIgnoreCase(ab.getName())){
-                                succes = false;
-                            }
-                        }
-                        if (!succes)
-                            continue;
- 			ab.onThisLoad();
- 			abilities.add(ab.getName());
-                        for (StockAbilities a: StockAbilities.values()) {
-                            if (a.name().equalsIgnoreCase(ab.getName())){
-                                disabledStockAbilities.add(a.name());
-                            }
-                        }
-			if (ab.getElement() == Element.Air.toString()) airbendingabilities.add(ab.getName()); 
-			if (ab.getElement() == Element.Water.toString()) waterbendingabilities.add(ab.getName());
-			if (ab.getElement() == Element.Earth.toString()) earthbendingabilities.add(ab.getName());
-			if (ab.getElement() == Element.Fire.toString()) firebendingabilities.add(ab.getName());
-			if (ab.getElement() == Element.Chi.toString()) chiabilities.add(ab.getName());
-			if (ab.isShiftAbility()) shiftabilities.add(ab.getName());
-			if (ab.isHarmlessAbility()) harmlessabilities.add(ab.getName());
-			
-			if (ab.getSubElement() != null)
-			{
-				subabilities.add(ab.getName());
-				switch(ab.getSubElement())
-				{
-					case Bloodbending:
-						bloodabilities.add(ab.getName());
-						break;
-					case Combustion:
-						combustionabilities.add(ab.getName());
-						break;
-					case Flight:
-						flightabilities.add(ab.getName());
-						break;
-					case Healing:
-						healingabilities.add(ab.getName());
-						break;
-					case Icebending:
-						iceabilities.add(ab.getName());
-						break;
-					case Lavabending:
-						lavaabilities.add(ab.getName());
-						break;
-					case Lightning:
-						lightningabilities.add(ab.getName());
-						break;
-					case Metalbending:
-						metalabilities.add(ab.getName());
-						break;
-					case Plantbending:
-						plantabilities.add(ab.getName());
-						break;
-					case Sandbending:
-						sandabilities.add(ab.getName());
-						break;
-					case SpiritualProjection:
-						spiritualprojectionabilities.add(ab.getName());
-						break;
+			try {
+				//To check if EarthBlast == Earthblast or for example, EarthBlast == EARTHBLAST
+				boolean succes = true;
+				for(String enabledAbility : abilities){
+					if(enabledAbility.equalsIgnoreCase(ab.getName())){
+						succes = false;
+					}
 				}
+				if (!succes)
+					continue;
+				ab.onThisLoad();
+				abilities.add(ab.getName());
+				for (StockAbilities a: StockAbilities.values()) {
+					if (a.name().equalsIgnoreCase(ab.getName())){
+						disabledStockAbilities.add(a.name());
+					}
+				}
+				if (ab.getElement() == Element.Air.toString()) airbendingabilities.add(ab.getName()); 
+				if (ab.getElement() == Element.Water.toString()) waterbendingabilities.add(ab.getName());
+				if (ab.getElement() == Element.Earth.toString()) earthbendingabilities.add(ab.getName());
+				if (ab.getElement() == Element.Fire.toString()) firebendingabilities.add(ab.getName());
+				if (ab.getElement() == Element.Chi.toString()) chiabilities.add(ab.getName());
+				if (ab.isShiftAbility()) shiftabilities.add(ab.getName());
+				if (ab.isHarmlessAbility()) harmlessabilities.add(ab.getName());
+				
+				if (ab.getSubElement() != null)
+				{
+					subabilities.add(ab.getName());
+					switch(ab.getSubElement())
+					{
+						case Bloodbending:
+							bloodabilities.add(ab.getName());
+							break;
+						case Combustion:
+							combustionabilities.add(ab.getName());
+							break;
+						case Flight:
+							flightabilities.add(ab.getName());
+							break;
+						case Healing:
+							healingabilities.add(ab.getName());
+							break;
+						case Icebending:
+							iceabilities.add(ab.getName());
+							break;
+						case Lavabending:
+							lavaabilities.add(ab.getName());
+							break;
+						case Lightning:
+							lightningabilities.add(ab.getName());
+							break;
+						case Metalbending:
+							metalabilities.add(ab.getName());
+							break;
+						case Plantbending:
+							plantabilities.add(ab.getName());
+							break;
+						case Sandbending:
+							sandabilities.add(ab.getName());
+							break;
+						case SpiritualProjection:
+							spiritualprojectionabilities.add(ab.getName());
+							break;
+					}
+				}
+				
+				// if (ab.isMetalbendingAbility()) metalbendingabilities.add(ab.getName());
+				descriptions.put(ab.getName(), ab.getDescription());
+				authors.put(ab.getName(), ab.getAuthor());
+			} catch (AbstractMethodError e) { //If triggered means ability was made pre 1.6 BETA 8
+				ProjectKorra.log.warning("The ability " + ab.getName() + " is either broken or outdated. Please remove it!");
+				e.printStackTrace();
+				ab.stop();
+				abilities.remove(ab.getName());
+				final AbilityModule skill = ab;
+				//Bellow to avoid ConcurrentModificationException
+				plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
+					public void run() {
+						ability.remove(skill);
+					}
+				}, 10);
+				continue;
 			}
-			
-			// if (ab.isMetalbendingAbility()) metalbendingabilities.add(ab.getName());
-			descriptions.put(ab.getName(), ab.getDescription());
-			authors.put(ab.getName(), ab.getAuthor());
 		}
 		
 		Collections.sort(airbendingabilities);

--- a/src/com/projectkorra/ProjectKorra/Ability/AbilityModuleManager.java
+++ b/src/com/projectkorra/ProjectKorra/Ability/AbilityModuleManager.java
@@ -278,7 +278,7 @@ public class AbilityModuleManager {
 				authors.put(ab.getName(), ab.getAuthor());
 			} catch (AbstractMethodError e) { //If triggered means ability was made pre 1.6 BETA 8
 				ProjectKorra.log.warning("The ability " + ab.getName() + " is either broken or outdated. Please remove it!");
-				e.printStackTrace();
+				//e.printStackTrace();
 				ab.stop();
 				abilities.remove(ab.getName());
 				final AbilityModule skill = ab;


### PR DESCRIPTION
* Surrounded AbilityModule loading with a try catch of AbstractMethodError
* This error is caused by the update on AbilityModule 7684931 . All Custom Abilities are forced to update, if not they will cause AbstractMethodError
* This PR address's that issue and instead disables the Custom Ability providing an error message of
"The ability " + ab.getName() + " is either broken or outdated. Please remove it!"
* A delayed task is used to prevent ConcurrentModificationException while removing ability from maps and lists
* Plugin will continue to work while totally ignoring broken plugins

* UPDATE - removed printstacktrace to prevent spam