### PR TITLE
Performance Block Cache, AirBlast bug fix, Lightning Water Arc Fix

### DIFF
--- a/src/com/projectkorra/ProjectKorra/ConfigManager.java
+++ b/src/com/projectkorra/ProjectKorra/ConfigManager.java
@@ -77,6 +77,7 @@ public class ConfigManager {
 		config.addDefault("Properties.RegionProtection.RespectTowny", true);
 		config.addDefault("Properties.RegionProtection.RespectPreciousStones", true);
 		config.addDefault("Properties.RegionProtection.RespectLWC", true);
+		config.addDefault("Properties.RegionProtection.CacheBlockTime", 5000);
 
 		config.addDefault("Properties.TagAPI.Enabled", true);
 

--- a/src/com/projectkorra/ProjectKorra/ConfigManager.java
+++ b/src/com/projectkorra/ProjectKorra/ConfigManager.java
@@ -307,6 +307,7 @@ public class ConfigManager {
 				+ "Additionally, you can click while channeling to attack things near you, dealing damage and knocking them back. "
 				+ "Releasing shift at any time will dissipate the form.");
 		config.addDefault("Abilities.Water.OctopusForm.Range", 10);
+		config.addDefault("Abilities.Water.OctopusForm.AttackRange", 2.5);
 		config.addDefault("Abilities.Water.OctopusForm.Radius", 3);
 		config.addDefault("Abilities.Water.OctopusForm.Damage", 3);
 		config.addDefault("Abilities.Water.OctopusForm.Knockback", 1.75);

--- a/src/com/projectkorra/ProjectKorra/ProjectKorra.java
+++ b/src/com/projectkorra/ProjectKorra/ProjectKorra.java
@@ -76,7 +76,7 @@ public class ProjectKorra extends JavaPlugin {
 		}
 
 		Methods.deserializeFile();
-
+		Methods.startCacheCleaner(Methods.CACHE_TIME);
 		new CraftingRecipes(this);
 	}
 

--- a/src/com/projectkorra/ProjectKorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/ProjectKorra/airbending/AirBlast.java
@@ -1,8 +1,10 @@
 package com.projectkorra.ProjectKorra.airbending;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -190,12 +192,19 @@ public class AirBlast {
 			instances.remove(id);
 			return false;
 		}
-
-		if (location.distance(origin) > range) {
+		
+		/*
+		 *	If a player presses shift and AirBlasts straight down then
+		 *	the AirBlast's location gets messed up and reading the distance
+		 *	returns Double.NaN. If we don't remove this instance then
+		 *	the AirBlast will never be removed. 
+		 */
+		double dist = location.distance(origin);
+		if (Double.isNaN(dist) || dist > range) {
 			instances.remove(id);
 			return false;
 		}
-
+		
 		for (Entity entity : Methods.getEntitiesAroundPoint(location, affectingradius)) {
 			affect(entity);
 		}
@@ -254,7 +263,10 @@ public class AirBlast {
 			if (entity instanceof Player) {
 				if (Commands.invincible.contains(((Player) entity).getName())) return;
 			}
-
+			
+			if(Double.isNaN(velocity.length()))
+				return;
+			
 			Methods.setVelocity(entity, velocity);
 			entity.setFallDistance(0);
 			if (!isUser && entity instanceof Player) {

--- a/src/com/projectkorra/ProjectKorra/firebending/Lightning.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/Lightning.java
@@ -2,12 +2,14 @@ package com.projectkorra.ProjectKorra.firebending;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -57,6 +59,7 @@ public class Lightning {
 	private ArrayList<Entity> affectedEntities = new ArrayList<Entity>();
 	private ArrayList<Arc> arcs = new ArrayList<Arc>();
 	private ArrayList<BukkitRunnable> tasks = new ArrayList<BukkitRunnable>();
+	private HashMap<Block, Boolean> isTransparentCache = new HashMap<Block, Boolean>();
 
 	public Lightning(Player player) {
 		this.player = player;
@@ -160,17 +163,13 @@ public class Lightning {
 				for(int j = 0; j < arc.getAnimLocs().size() - 1; j++) {
 					final Location iterLoc = arc.getAnimLocs().get(j).getLoc().clone();
 					final Location dest = arc.getAnimLocs().get(j + 1).getLoc().clone();
-					
-					if(!isTransparent(player, iterLoc.getBlock())) {
-						if(SELF_HIT_CLOSE && player.getLocation().distance(iterLoc) < 3) {
-							if(!affectedEntities.contains(player)) {
+					if(SELF_HIT_CLOSE 
+							&& player.getLocation().distance(iterLoc) < 3  
+							&& !isTransparent(player, iterLoc.getBlock())
+							&& !affectedEntities.contains(player)) {
 								affectedEntities.add(player);
 								electrocute(player);
-							}
 						}
-						remove();
-						return;
-					}
 					
 					while(iterLoc.distance(dest) > 0.15) {
 						BukkitRunnable task = new LightningParticle(arc, iterLoc.clone());
@@ -190,15 +189,23 @@ public class Lightning {
 		}
 	}
 	
-	public static boolean isTransparent(Player player, Block block) {
+	public boolean isTransparent(Player player, Block block) {
+		if(isTransparentCache.containsKey(block))
+			return isTransparentCache.get(block);
+		
+		boolean value = false;
 		if (Arrays.asList(Methods.transparentToEarthbending).contains(block.getTypeId())) {
 			if(Methods.isRegionProtectedFromBuild(player, "Lightning", block.getLocation()))
-				return false;
+				value = false;
 			else if(isIce(block.getLocation()))
-				return ARC_ON_ICE;
-			return true;
-		}	
-		return false;
+				value = ARC_ON_ICE;
+			else
+				value = true;
+		}
+		else 
+			value = false;
+		isTransparentCache.put(block, new Boolean(value));
+		return value;		
 	}
 	
 	public void electrocute(LivingEntity lent) {
@@ -283,6 +290,8 @@ public class Lightning {
 	public class Arc {
 		private ArrayList<Location> points;
 		private ArrayList<AnimLocation> animLocs;
+		private ArrayList<LightningParticle> particles;
+		private ArrayList<Arc> subArcs;
 		private Vector direction;
 		private int animCounter;
 		
@@ -291,6 +300,8 @@ public class Lightning {
 			points.add(startPoint.clone());
 			points.add(endPoint.clone());
 			direction = Methods.getDirection(startPoint, endPoint);
+			particles = new ArrayList<LightningParticle>();
+			subArcs = new ArrayList<Arc>();
 			animLocs = new ArrayList<AnimLocation>();
 			animCounter = 0;
 		}
@@ -327,6 +338,7 @@ public class Lightning {
 					double randRange = (Math.random() * range) + (range / 3.0);
 					Location loc2 = loc.clone().add(dir.normalize().multiply(randRange));
 					Arc arc = new Arc(loc, loc2);
+					subArcs.add(arc);
 					arc.setAnimCounter(animLocs.get(i).getAnimCounter());
 					arc.generatePoints(POINT_GENERATION);
 					arcs.add(arc);
@@ -334,6 +346,16 @@ public class Lightning {
 				}
 			}
 			return arcs;
+		}
+		
+		public void cancel() {
+			for(int i = 0; i < particles.size(); i++) {
+				particles.get(i).cancel();
+			}
+			
+			for(Arc subArc : subArcs) {
+				subArc.cancel();
+			}
 		}
 
 		public ArrayList<Location> getPoints() {
@@ -367,6 +389,15 @@ public class Lightning {
 		public void setAnimLocs(ArrayList<AnimLocation> animLocs) {
 			this.animLocs = animLocs;
 		}
+
+		public ArrayList<LightningParticle> getParticles() {
+			return particles;
+		}
+
+		public void setParticles(ArrayList<LightningParticle> particles) {
+			this.particles = particles;
+		}
+		
 	}
 	
 	public class AnimLocation {
@@ -403,6 +434,7 @@ public class Lightning {
 		public LightningParticle(Arc arc, Location loc) {
 			this.arc = arc;
 			this.loc = loc;
+			arc.particles.add(this);
 		}
 		
 		public void cancel() {
@@ -416,7 +448,11 @@ public class Lightning {
 			if(count > 5)
 				this.cancel();
 			else if(count == 1) {
-				
+				if(!isTransparent(player, loc.getBlock())) {
+					arc.cancel();
+					return;
+				}
+					
 				// Handle Water electrocution
 				if(!hitWater && (isWater(loc) || (ARC_ON_ICE && isIce(loc)))) {
 					hitWater = true;

--- a/src/com/projectkorra/ProjectKorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/OctopusForm.java
@@ -22,6 +22,7 @@ public class OctopusForm {
 	public static ConcurrentHashMap<Player, OctopusForm> instances = new ConcurrentHashMap<Player, OctopusForm>();
 
 	private static int RANGE = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.OctopusForm.Range");
+	private static double ATTACK_RANGE = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.OctopusForm.AttackRange");
 	private static int DAMAGE = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.OctopusForm.Damage");
 	private static long INTERVAL = ProjectKorra.plugin.getConfig().getLong("Abilities.Water.OctopusForm.FormDelay");
 	private static double KNOCKBACK = ProjectKorra.plugin.getConfig().getDouble("Abilities.Water.OctopusForm.Knockback");
@@ -46,6 +47,7 @@ public class OctopusForm {
 	private boolean forming = false;
 	private boolean formed = false;
 	private int range = RANGE;
+	private double attackRange = ATTACK_RANGE;
 	private int damage = DAMAGE;
 	private long interval = INTERVAL;
 	private double knockback = KNOCKBACK;
@@ -128,7 +130,7 @@ public class OctopusForm {
 	}
 
 	private void affect(Location location) {
-		for (Entity entity : Methods.getEntitiesAroundPoint(location, range)) {
+		for (Entity entity : Methods.getEntitiesAroundPoint(location, attackRange)) {
 			if (entity.getEntityId() == player.getEntityId())
 				continue;
 			if (Methods.isRegionProtectedFromBuild(player, "OctopusForm", entity.getLocation()))
@@ -499,5 +501,15 @@ public class OctopusForm {
 	public void setRadius(double radius) {
 		this.radius = radius;
 	}
+
+	public double getAttackRange() {
+		return attackRange;
+	}
+
+	public void setAttackRange(double attackRange) {
+		this.attackRange = attackRange;
+	}
+	
+	
 
 }

--- a/src/config.yml
+++ b/src/config.yml
@@ -233,6 +233,7 @@ Abilities:
       Enabled: true
       Description: "This ability allows the waterbender to manipulate a large quantity of water into a form resembling that of an octopus. To use, click to select a water source. Then, hold sneak to channel this ability. While channleing, the water will form itself around you and has a chance to block incoming attacks. Additionally, you can click while channeling to attack things near you, dealing damage and knocking the target back. Releasing shift at any time will dissipate the form."
       Range: 10
+      AttackRange: 2.5
       Damage: 3
       Radius: 3
       FormDelay: 50

--- a/src/config.yml
+++ b/src/config.yml
@@ -33,6 +33,7 @@ Properties:
     RespectTowny: true
     RespectPreciousStones: true
     RespectLWC: true
+    CacheBlockTime: 5000
   Air:
     CanBendWithWeapons: false
     Particles: smoke


### PR DESCRIPTION
Major Performance Improvement:
    *IMPORTANT If you are a server owner please read*
- A new config option has been added called CacheBlockTime (default 5 seconds). If your server has specific regions that toggle bending off and on multiple times within the span of a few minutes, such as a custom ProBendingArena or Agni Kai Arena, you will probably want to keep the CacheBlockTime less than 3 seconds. If you disable bending in an area it will take up to CacheBlockTime to update.
    
- If your server does not have any of these areas that constantly deny or allow bending then you should increase the CacheBlockTime to 30 seconds or so.
    
- The Block Cache makes it so the server does not have to keep processing the same block multiple times in a row. For example, imagine you used PhaseChange, the block cache will log all of the ice blocks so that it does not have to keep checking if they are bendable blocks. Rather than processing the blocks 20 times a second, if you set the block cache to 30 seconds then each block will only be checked once every 30 seconds (600x less processing in this case).

Removed a leftover broadcast message:
- The plugin no longer broadcasts "RPG NOT DETECTED"
    
Fixed Lightning not arcing in water:
- After fixing the issue with Lightning passing through walls, a new bug arose causing it to not sub arc in water. Basically, the Lightning was hitting dirt in the water which was causing the entire ability to remove itself.
    
- Added a simple process cache to speed up performance while checking each individual particle. Previously, the ability was only checking a small portion of the lightning particles. Now it checks every particle to increase precision, consequently, it uses a cache to make sure we aren't wasting processing power.
    
OctopusForm - Added an AttackRange variable:
- OctopusForm range was only controlling the distance that a player could stream water from. The AttackRange configuration option changes the punch distance of OctopusForm.
    
AirBlast - Fixed a severe bug that was causing the plugin to crash:
    * Don't be this specific in the release notes, wouldn't want people to use this against unupdated plugins *
- If a player looked straight down and spammed shift/click then the AirBlast was continuing into the void and not deleting itself. It was then attempting to affect every entity that was currently spawned in the game, causing a huge amount of processing. When the plugin attempted to do a distance call on the AirBlast location and an entity location the result was Double.NaN (not a number). The plugin was then trying to set a velocity using NaN which was causing an instant crash. This bug was fixed by adding NaN checks at both the Location and Velocity.
    