### PR TITLE
Fix deprecation from 9f969f1, small clean up

### DIFF
--- a/src/com/projectkorra/ProjectKorra/Methods.java
+++ b/src/com/projectkorra/ProjectKorra/Methods.java
@@ -215,7 +215,6 @@ public class Methods {
 	}
 
 	public static boolean canBind(String player, String ability) {
-		@SuppressWarnings("deprecation")
 		Player p = Bukkit.getPlayer(player);
 		if (p == null) return false;
 		if (!p.hasPermission("bending.ability." + ability)) return false;
@@ -232,7 +231,6 @@ public class Methods {
 	 * @param ability The Ability name to check
 	 * @return true If player can bend specified ability and has the permissions to do so
 	 */
-	@SuppressWarnings("deprecation")
 	public static boolean canBend(String player, String ability) {
 		BendingPlayer bPlayer = getBendingPlayer(player);
 		Player p = Bukkit.getPlayer(player);
@@ -278,7 +276,6 @@ public class Methods {
 		return true;
 	}
 
-	@SuppressWarnings("deprecation")
 	public static boolean canBendPassive(String player, Element element) {
 		BendingPlayer bPlayer = getBendingPlayer(player);
 		Player p = Bukkit.getPlayer(player);

--- a/src/com/projectkorra/ProjectKorra/airbending/Tornado.java
+++ b/src/com/projectkorra/ProjectKorra/airbending/Tornado.java
@@ -45,12 +45,11 @@ public class Tornado {
 	private double radius = height / maxheight * maxradius;
 	// private boolean canfly;
 
-	@SuppressWarnings("deprecation")
 	public Tornado(Player player) {
 		this.player = player;
 		// canfly = player.getAllowFlight();
 		// player.setAllowFlight(true);
-		origin = player.getTargetBlock((HashSet<Byte>) null, (int) range).getLocation();
+		origin = player.getTargetBlock((HashSet<Material>) null, (int) range).getLocation();
 		origin.setY(origin.getY() - 1. / 10. * height);
 
 		int angle = 0;
@@ -100,9 +99,8 @@ public class Tornado {
 		return true;
 	}
 
-	@SuppressWarnings("deprecation")
 	private void rotateTornado() {
-		origin = player.getTargetBlock((HashSet<Byte>) null, (int) range).getLocation();
+		origin = player.getTargetBlock((HashSet<Material>) null, (int) range).getLocation();
 
 		double timefactor = height / maxheight;
 		radius = timefactor * maxradius;

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthPassive.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthPassive.java
@@ -78,7 +78,7 @@ public class EarthPassive {
 		for (Player player: Bukkit.getOnlinePlayers()) {
 			if (Methods.canBendPassive(player.getName(), Element.Earth) && Methods.canMetalbend(player)) {
 				if (player.isSneaking() && !Methods.getBendingPlayer(player.getName()).isOnCooldown("MetalPassive")) {
-					Block block = player.getTargetBlock((HashSet<Byte>) null, 5);
+					Block block = player.getTargetBlock((HashSet<Material>) null, 5);
 					if (block == null) continue;
 					if (block.getType() == Material.IRON_DOOR_BLOCK && !Methods.isRegionProtectedFromBuild(player, null, block.getLocation())) {
 						if (block.getData() >= 8) {

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthTunnel.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthTunnel.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
@@ -33,11 +34,10 @@ public class EarthTunnel {
 	private long interval = INTERVAL;
 	private long time;
 
-	@SuppressWarnings("deprecation")
 	public EarthTunnel(Player player) {
 		this.player = player;
 		location = player.getEyeLocation().clone();
-		origin = player.getTargetBlock((HashSet<Byte>) null, (int) range).getLocation();
+		origin = player.getTargetBlock((HashSet<Material>) null, (int) range).getLocation();
 		block = origin.getBlock();
 		direction = location.getDirection().clone().normalize();
 		depth = origin.distance(location) - 1;

--- a/src/com/projectkorra/ProjectKorra/earthbending/Extraction.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/Extraction.java
@@ -18,12 +18,11 @@ public class Extraction {
 	private static int doublechance = ProjectKorra.plugin.getConfig().getInt("Abilities.Earth.Extraction.DoubleLootChance");
 	private static int triplechance = ProjectKorra.plugin.getConfig().getInt("Abilities.Earth.Extraction.TripleLootChance");
 
-	@SuppressWarnings("deprecation")
 	public Extraction(Player player) {
 		BendingPlayer bPlayer = Methods.getBendingPlayer(player.getName());
 		if (bPlayer.isOnCooldown("Extraction")) return;
 
-		Block block = player.getTargetBlock((HashSet<Byte>) null, 5);
+		Block block = player.getTargetBlock((HashSet<Material>) null, 5);
 		if (block == null) {
 			return;
 		}

--- a/src/com/projectkorra/ProjectKorra/firebending/Extinguish.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/Extinguish.java
@@ -18,22 +18,22 @@ public class Extinguish {
 	private static double defaultrange = ProjectKorra.plugin.getConfig().getDouble("Abilities.Fire.HeatControl.Extinguish.Range");
 	private static double defaultradius = ProjectKorra.plugin.getConfig().getDouble("Abilities.Fire.HeatControl.Extinguish.Radius");
 
+	@SuppressWarnings("unused")
 	private static byte full = AirBlast.full;
 
-	@SuppressWarnings("deprecation")
 	public Extinguish(Player player) {
 		BendingPlayer bPlayer = Methods.getBendingPlayer(player.getName());
 
 		if (bPlayer.isOnCooldown("HeatControl")) return;
 
 		double range = Methods.getFirebendingDayAugment(defaultrange, player.getWorld());
-		if (Methods.isMeltable(player.getTargetBlock((HashSet<Byte>) null, (int) range))) {
+		if (Methods.isMeltable(player.getTargetBlock((HashSet<Material>) null, (int) range))) {
 			new HeatMelt(player);
 			return;
 		}
 		double radius = Methods.getFirebendingDayAugment(defaultradius, player.getWorld());
 		for (Block block : Methods.getBlocksAroundPoint(
-				player.getTargetBlock((HashSet<Byte>) null, (int) range).getLocation(), radius)) {
+				player.getTargetBlock((HashSet<Material>) null, (int) range).getLocation(), radius)) {
 			
 			Material mat = block.getType();
 			if(mat != Material.FIRE 

--- a/src/com/projectkorra/ProjectKorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/HeatControl.java
@@ -4,6 +4,7 @@ import com.projectkorra.ProjectKorra.Methods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -80,6 +81,7 @@ public class HeatControl
 		return true;
 	}
 
+	@SuppressWarnings("deprecation")
 	public void freeze(List<Location> area)
 	{
 		if(System.currentTimeMillis() < lastBlockTime + delay)

--- a/src/com/projectkorra/ProjectKorra/firebending/Lightning.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/Lightning.java
@@ -18,7 +18,6 @@ import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.Methods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
-import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 
 public class Lightning {
 	public static enum State {

--- a/src/com/projectkorra/ProjectKorra/waterbending/IceSpike.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/IceSpike.java
@@ -56,7 +56,6 @@ public class IceSpike {
 	private ConcurrentHashMap<Block, Block> affectedblocks = new ConcurrentHashMap<Block, Block>();
 	private List<LivingEntity> damaged = new ArrayList<LivingEntity>();
 
-	@SuppressWarnings("deprecation")
 	public IceSpike(Player player) {
 		BendingPlayer bPlayer = Methods.getBendingPlayer(player.getName());
 		if (bPlayer.isOnCooldown("IceSpike")) return;
@@ -82,7 +81,7 @@ public class IceSpike {
 				this.block = temptestingblock;
 				// }
 			} else {
-				this.block = player.getTargetBlock((HashSet<Byte>) null, (int) range);
+				this.block = player.getTargetBlock((HashSet<Material>) null, (int) range);
 			}
 			origin = block.getLocation();
 			location = origin.clone();

--- a/src/com/projectkorra/ProjectKorra/waterbending/Melt.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/Melt.java
@@ -23,7 +23,6 @@ public class Melt {
 
 	private static final byte full = 0x0;
 
-	@SuppressWarnings("deprecation")
 	public Melt(Player player) {
 		if(!Methods.canIcebend(player))
 			return;
@@ -37,7 +36,7 @@ public class Melt {
 		}
 		boolean evaporate = false;
 		Location location = Methods.getTargetedLocation(player, range);
-		if (Methods.isWater(player.getTargetBlock((HashSet<Byte>) null, range))	&& !(player.getEyeLocation().getBlockY() <= 62)) {
+		if (Methods.isWater(player.getTargetBlock((HashSet<Material>) null, range))	&& !(player.getEyeLocation().getBlockY() <= 62)) {
 			evaporate = true;
 			radius = (int) Methods.waterbendingNightAugment(defaultevaporateradius, player.getWorld());
 		}

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
@@ -209,7 +209,6 @@ public class WaterManipulation {
 		}
 	}
 
-	@SuppressWarnings("deprecation")
 	private boolean progress() {
 		if (player.isDead() || !player.isOnline()
 				|| !Methods.canBend(player.getName(), "WaterManipulation")) {
@@ -300,7 +299,7 @@ public class WaterManipulation {
 
 				Block block = location.getBlock();
 				if (displacing) {
-					Block targetblock = player.getTargetBlock((HashSet<Byte>) null, displrange);
+					Block targetblock = player.getTargetBlock((HashSet<Material>) null, displrange);
 					direction = Methods.getDirection(location, targetblock.getLocation()).normalize();
 					if (!location.getBlock().equals(targetblock.getLocation())) {
 						location = location.clone().add(direction);

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterSourceGrabber.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterSourceGrabber.java
@@ -45,7 +45,6 @@ public class WaterSourceGrabber {
 		this(player, origin, 1);
 	}
 
-	@SuppressWarnings("deprecation")
 	public void progress() {
 		if (state == AnimationState.FAILED || state == AnimationState.FINISHED)
 			return;
@@ -66,7 +65,7 @@ public class WaterSourceGrabber {
 				state = AnimationState.TOWARD;
 		} else {
 			revertBlocks();
-			Location eyeLoc = player.getTargetBlock((HashSet<Byte>) null, 2).getLocation();
+			Location eyeLoc = player.getTargetBlock((HashSet<Material>) null, 2).getLocation();
 			eyeLoc.setY(player.getEyeLocation().getY());
 			Vector vec = Methods.getDirection(currentLoc, eyeLoc);
 			currentLoc.add(vec.normalize().multiply(animSpeed));

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterWall.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterWall.java
@@ -488,7 +488,7 @@ public class WaterWall {
 			new Wave(player);
 			return;
 		} else {
-			if (Methods.isWaterbendable(player.getTargetBlock((HashSet<Byte>) null, (int) Wave.defaultrange), player)) {
+			if (Methods.isWaterbendable(player.getTargetBlock((HashSet<Material>) null, (int) Wave.defaultrange), player)) {
 				new Wave(player);
 				return;
 			}

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterWave.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterWave.java
@@ -80,7 +80,6 @@ public class WaterWave {
 			this.progress();
 	}
 
-	@SuppressWarnings("deprecation")
 	public void progress() {
 		progressCounter++;
 		if (player.isDead() || !player.isOnline()) {
@@ -190,7 +189,7 @@ public class WaterWave {
 					anim = AnimateState.TOWARDPLAYER;
 			} else if (anim == AnimateState.TOWARDPLAYER) {
 				revertBlocks();
-				Location eyeLoc = player.getTargetBlock((HashSet<Byte>) null, 2).getLocation();
+				Location eyeLoc = player.getTargetBlock((HashSet<Material>) null, 2).getLocation();
 				eyeLoc.setY(player.getEyeLocation().getY());
 				Vector vec = Methods.getDirection(currentLoc, eyeLoc);
 				currentLoc.add(vec.normalize().multiply(animSpeed));


### PR DESCRIPTION
* Change ```HashSet<Byte> null``` to ```HashSet<Material> null``` to remove deprecation caused by 9f969f1
* Remove annotations caused by 9f969f1
* Add unused annotation to ```full``` in Extinguish