### PR TITLE
Dynamic Source Selection

### DIFF
--- a/src/com/projectkorra/ProjectKorra/ComboManager.java
+++ b/src/com/projectkorra/ProjectKorra/ComboManager.java
@@ -1,9 +1,11 @@
 package com.projectkorra.ProjectKorra;
 
 import com.projectkorra.ProjectKorra.Ability.Combo.ComboAbilityModule;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.airbending.AirCombo;
 import com.projectkorra.ProjectKorra.firebending.FireCombo;
 import com.projectkorra.ProjectKorra.waterbending.WaterCombo;
+
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -13,10 +15,6 @@ import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ComboManager {
-	public static enum ClickType {
-		SHIFTDOWN, SHIFTUP, LEFTCLICK, RIGHTCLICK
-	}
-
 	private static final long CLEANUP_DELAY = 10000;
 	public static ConcurrentHashMap<String, ArrayList<AbilityInformation>> recentlyUsedAbilities = new ConcurrentHashMap<String, ArrayList<AbilityInformation>>();
 	public static ArrayList<ComboAbility> comboAbilityList = new ArrayList<ComboAbility>();

--- a/src/com/projectkorra/ProjectKorra/ComboManager.java
+++ b/src/com/projectkorra/ProjectKorra/ComboManager.java
@@ -24,58 +24,58 @@ public class ComboManager {
 
 	public ComboManager() {
 		ArrayList<AbilityInformation> fireKick = new ArrayList<AbilityInformation>();
-		fireKick.add(new AbilityInformation("FireBlast", ClickType.LEFTCLICK));
-		fireKick.add(new AbilityInformation("FireBlast", ClickType.LEFTCLICK));
-		fireKick.add(new AbilityInformation("FireBlast", ClickType.SHIFTDOWN));
-		fireKick.add(new AbilityInformation("FireBlast", ClickType.LEFTCLICK));
+		fireKick.add(new AbilityInformation("FireBlast", ClickType.LEFT_CLICK));
+		fireKick.add(new AbilityInformation("FireBlast", ClickType.LEFT_CLICK));
+		fireKick.add(new AbilityInformation("FireBlast", ClickType.SHIFT_DOWN));
+		fireKick.add(new AbilityInformation("FireBlast", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("FireKick", fireKick, FireCombo.class));
 
 		ArrayList<AbilityInformation> fireSpin = new ArrayList<AbilityInformation>();
-		fireSpin.add(new AbilityInformation("FireBlast", ClickType.LEFTCLICK));
-		fireSpin.add(new AbilityInformation("FireBlast", ClickType.LEFTCLICK));
-		fireSpin.add(new AbilityInformation("FireShield", ClickType.LEFTCLICK));
-		fireSpin.add(new AbilityInformation("FireShield", ClickType.SHIFTDOWN));
-		fireSpin.add(new AbilityInformation("FireShield", ClickType.SHIFTUP));
+		fireSpin.add(new AbilityInformation("FireBlast", ClickType.LEFT_CLICK));
+		fireSpin.add(new AbilityInformation("FireBlast", ClickType.LEFT_CLICK));
+		fireSpin.add(new AbilityInformation("FireShield", ClickType.LEFT_CLICK));
+		fireSpin.add(new AbilityInformation("FireShield", ClickType.SHIFT_DOWN));
+		fireSpin.add(new AbilityInformation("FireShield", ClickType.SHIFT_UP));
 		comboAbilityList.add(new ComboAbility("FireSpin", fireSpin, FireCombo.class));
 
 		ArrayList<AbilityInformation> jetBlast = new ArrayList<AbilityInformation>();
-		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFTDOWN));
-		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFTUP));
-		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFTDOWN));
-		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFTUP));
-		jetBlast.add(new AbilityInformation("FireShield", ClickType.SHIFTDOWN));
-		jetBlast.add(new AbilityInformation("FireShield", ClickType.SHIFTUP));
-		jetBlast.add(new AbilityInformation("FireJet", ClickType.LEFTCLICK));
+		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFT_DOWN));
+		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFT_UP));
+		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFT_DOWN));
+		jetBlast.add(new AbilityInformation("FireJet", ClickType.SHIFT_UP));
+		jetBlast.add(new AbilityInformation("FireShield", ClickType.SHIFT_DOWN));
+		jetBlast.add(new AbilityInformation("FireShield", ClickType.SHIFT_UP));
+		jetBlast.add(new AbilityInformation("FireJet", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("JetBlast", jetBlast, FireCombo.class));
 
 		ArrayList<AbilityInformation> jetBlaze = new ArrayList<AbilityInformation>();
-		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFTDOWN));
-		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFTUP));
-		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFTDOWN));
-		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFTUP));
-		jetBlaze.add(new AbilityInformation("Blaze", ClickType.SHIFTDOWN));
-		jetBlaze.add(new AbilityInformation("Blaze", ClickType.SHIFTUP));
-		jetBlaze.add(new AbilityInformation("FireJet", ClickType.LEFTCLICK));
+		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFT_DOWN));
+		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFT_UP));
+		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFT_DOWN));
+		jetBlaze.add(new AbilityInformation("FireJet", ClickType.SHIFT_UP));
+		jetBlaze.add(new AbilityInformation("Blaze", ClickType.SHIFT_DOWN));
+		jetBlaze.add(new AbilityInformation("Blaze", ClickType.SHIFT_UP));
+		jetBlaze.add(new AbilityInformation("FireJet", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("JetBlaze", jetBlaze, FireCombo.class));
 
 		ArrayList<AbilityInformation> fireWheel = new ArrayList<AbilityInformation>();
-		fireWheel.add(new AbilityInformation("FireShield", ClickType.SHIFTDOWN));
-		fireWheel.add(new AbilityInformation("FireShield", ClickType.RIGHTCLICK));
-		fireWheel.add(new AbilityInformation("FireShield", ClickType.RIGHTCLICK));
-		fireWheel.add(new AbilityInformation("Blaze", ClickType.SHIFTUP));
+		fireWheel.add(new AbilityInformation("FireShield", ClickType.SHIFT_DOWN));
+		fireWheel.add(new AbilityInformation("FireShield", ClickType.RIGHT_CLICK));
+		fireWheel.add(new AbilityInformation("FireShield", ClickType.RIGHT_CLICK));
+		fireWheel.add(new AbilityInformation("Blaze", ClickType.SHIFT_UP));
 		comboAbilityList.add(new ComboAbility("FireWheel", fireWheel, FireCombo.class));
 
 		ArrayList<AbilityInformation> twister = new ArrayList<AbilityInformation>();
-		twister.add(new AbilityInformation("AirShield", ClickType.SHIFTDOWN));
-		twister.add(new AbilityInformation("AirShield", ClickType.SHIFTUP));
-		twister.add(new AbilityInformation("Tornado", ClickType.SHIFTDOWN));
-		twister.add(new AbilityInformation("AirBlast", ClickType.LEFTCLICK));
+		twister.add(new AbilityInformation("AirShield", ClickType.SHIFT_DOWN));
+		twister.add(new AbilityInformation("AirShield", ClickType.SHIFT_UP));
+		twister.add(new AbilityInformation("Tornado", ClickType.SHIFT_DOWN));
+		twister.add(new AbilityInformation("AirBlast", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("Twister", twister, AirCombo.class));
 
 		ArrayList<AbilityInformation> airStream = new ArrayList<AbilityInformation>();
-		airStream.add(new AbilityInformation("AirShield", ClickType.SHIFTDOWN));
-		airStream.add(new AbilityInformation("AirSuction", ClickType.LEFTCLICK));
-		airStream.add(new AbilityInformation("AirBlast", ClickType.LEFTCLICK));
+		airStream.add(new AbilityInformation("AirShield", ClickType.SHIFT_DOWN));
+		airStream.add(new AbilityInformation("AirSuction", ClickType.LEFT_CLICK));
+		airStream.add(new AbilityInformation("AirBlast", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("AirStream", airStream, AirCombo.class));
 
 		/*
@@ -87,35 +87,35 @@ public class ComboManager {
 		 */
 
 		ArrayList<AbilityInformation> airSweep = new ArrayList<AbilityInformation>();
-		airSweep.add(new AbilityInformation("AirSwipe", ClickType.LEFTCLICK));
-		airSweep.add(new AbilityInformation("AirSwipe", ClickType.LEFTCLICK));
-		airSweep.add(new AbilityInformation("AirBurst", ClickType.SHIFTDOWN));
-		airSweep.add(new AbilityInformation("AirBurst", ClickType.LEFTCLICK));
+		airSweep.add(new AbilityInformation("AirSwipe", ClickType.LEFT_CLICK));
+		airSweep.add(new AbilityInformation("AirSwipe", ClickType.LEFT_CLICK));
+		airSweep.add(new AbilityInformation("AirBurst", ClickType.SHIFT_DOWN));
+		airSweep.add(new AbilityInformation("AirBurst", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("AirSweep", airSweep, AirCombo.class));
 
 		ArrayList<AbilityInformation> iceWave = new ArrayList<AbilityInformation>();
-		iceWave.add(new AbilityInformation("WaterSpout", ClickType.SHIFTUP));
-		iceWave.add(new AbilityInformation("PhaseChange", ClickType.LEFTCLICK));
+		iceWave.add(new AbilityInformation("WaterSpout", ClickType.SHIFT_UP));
+		iceWave.add(new AbilityInformation("PhaseChange", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("IceWave", iceWave, WaterCombo.class));
 
 		ArrayList<AbilityInformation> icePillar = new ArrayList<AbilityInformation>();
-		icePillar.add(new AbilityInformation("IceSpike", ClickType.LEFTCLICK));
-		icePillar.add(new AbilityInformation("IceSpike", ClickType.LEFTCLICK));
-		icePillar.add(new AbilityInformation("WaterSpout", ClickType.LEFTCLICK));
+		icePillar.add(new AbilityInformation("IceSpike", ClickType.LEFT_CLICK));
+		icePillar.add(new AbilityInformation("IceSpike", ClickType.LEFT_CLICK));
+		icePillar.add(new AbilityInformation("WaterSpout", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("IcePillar", icePillar, WaterCombo.class));
 
 		ArrayList<AbilityInformation> iceBullet = new ArrayList<AbilityInformation>();
-		iceBullet.add(new AbilityInformation("WaterBubble", ClickType.SHIFTDOWN));
-		iceBullet.add(new AbilityInformation("WaterBubble", ClickType.SHIFTUP));
-		iceBullet.add(new AbilityInformation("IceBlast", ClickType.SHIFTDOWN));
-		iceBullet.add(new AbilityInformation("IceBlast", ClickType.LEFTCLICK));
+		iceBullet.add(new AbilityInformation("WaterBubble", ClickType.SHIFT_DOWN));
+		iceBullet.add(new AbilityInformation("WaterBubble", ClickType.SHIFT_UP));
+		iceBullet.add(new AbilityInformation("IceBlast", ClickType.SHIFT_DOWN));
+		iceBullet.add(new AbilityInformation("IceBlast", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("IceBullet", iceBullet, WaterCombo.class));
 
 		ArrayList<AbilityInformation> iceBulletLeft = new ArrayList<AbilityInformation>();
-		iceBulletLeft.add(new AbilityInformation("IceBlast", ClickType.LEFTCLICK));
+		iceBulletLeft.add(new AbilityInformation("IceBlast", ClickType.LEFT_CLICK));
 		comboAbilityList.add(new ComboAbility("IceBulletLeftClick", iceBulletLeft, WaterCombo.class));
 		ArrayList<AbilityInformation> iceBulletRight = new ArrayList<AbilityInformation>();
-		iceBulletRight.add(new AbilityInformation("IceBlast", ClickType.RIGHTCLICK));
+		iceBulletRight.add(new AbilityInformation("IceBlast", ClickType.RIGHT_CLICK));
 		comboAbilityList.add(new ComboAbility("IceBulletRightClick", iceBulletRight, WaterCombo.class));
 
 		startCleanupTask();

--- a/src/com/projectkorra/ProjectKorra/PKListener.java
+++ b/src/com/projectkorra/ProjectKorra/PKListener.java
@@ -62,6 +62,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
 import com.projectkorra.ProjectKorra.CustomEvents.PlayerGrappleEvent;
 import com.projectkorra.ProjectKorra.Objects.Preset;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
 import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.GrapplingHookAPI;
 import com.projectkorra.ProjectKorra.Utilities.HorizontalVelocityChangeEvent;
@@ -278,10 +279,10 @@ public class PKListener implements Listener {
 
 		if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
 			GeneralMethods.cooldowns.put(player.getName(), System.currentTimeMillis());
-			ComboManager.addComboAbility(player, ClickType.RIGHTCLICK);
+			ComboManager.addComboAbility(player, ClickType.RIGHT_CLICK);
 			String ability = GeneralMethods.getBoundAbility(player);
 			if(ability != null && ability.equalsIgnoreCase("EarthSmash"))
-				new EarthSmash(player, ClickType.RIGHTCLICK);
+				new EarthSmash(player, ClickType.RIGHT_CLICK);
 		}
 		if (Paralyze.isParalyzed(player) || ChiComboManager.isParalyzed(player) || Bloodbending.isBloodbended(player) || Suffocate.isBreathbent(player)) {
 			event.setCancelled(true);
@@ -426,9 +427,9 @@ public class PKListener implements Listener {
 		if (event.isCancelled()) return;
 		
 		if(player.isSneaking())
-			ComboManager.addComboAbility(player, ClickType.SHIFTUP);
+			ComboManager.addComboAbility(player, ClickType.SHIFT_UP);
 		else
-			ComboManager.addComboAbility(player, ClickType.SHIFTDOWN);
+			ComboManager.addComboAbility(player, ClickType.SHIFT_DOWN);
 		
 		if(Suffocate.isBreathbent(player)) {
 			if(!GeneralMethods.getBoundAbility(player).equalsIgnoreCase("AirSwipe") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("FireBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("EarthBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("WaterManipulation")) {
@@ -441,6 +442,10 @@ public class PKListener implements Listener {
 			return;
 		}
 
+		if (!player.isSneaking()) {
+			BlockSource.update(player, ClickType.SHIFT_DOWN);
+		}
+		
 		AirScooter.check(player);
 
 		String abil = GeneralMethods.getBoundAbility(player);
@@ -570,7 +575,7 @@ public class PKListener implements Listener {
 					new LavaFlow(player,LavaFlow.AbilityType.SHIFT);
 				}
 				if (abil.equalsIgnoreCase("EarthSmash")) {
-					new EarthSmash(player, ClickType.SHIFTDOWN);
+					new EarthSmash(player, ClickType.SHIFT_DOWN);
 				}
 
 			}
@@ -804,7 +809,7 @@ public class PKListener implements Listener {
 		if (event.isCancelled()) return;
 
 		Player player = event.getPlayer();
-		ComboManager.addComboAbility(player, ClickType.LEFTCLICK);
+		ComboManager.addComboAbility(player, ClickType.LEFT_CLICK);
 		
 		if(Suffocate.isBreathbent(player)) {
 			if(!GeneralMethods.getBoundAbility(player).equalsIgnoreCase("AirSwipe") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("FireBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("EarthBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("WaterManipulation")) {
@@ -821,6 +826,8 @@ public class PKListener implements Listener {
 			event.setCancelled(true);
 			return;
 		}
+		
+		BlockSource.update(player, ClickType.LEFT_CLICK);
 
 		AirScooter.check(player);
 
@@ -953,7 +960,7 @@ public class PKListener implements Listener {
 				}
 				
 				if (abil.equalsIgnoreCase("EarthSmash")) {
-					new EarthSmash(player, ClickType.LEFTCLICK);
+					new EarthSmash(player, ClickType.LEFT_CLICK);
 				}
 			}
 			if (FireMethods.isFireAbility(abil)) {

--- a/src/com/projectkorra/ProjectKorra/PKListener.java
+++ b/src/com/projectkorra/ProjectKorra/PKListener.java
@@ -59,10 +59,10 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import com.projectkorra.ProjectKorra.ComboManager.ClickType;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
 import com.projectkorra.ProjectKorra.CustomEvents.PlayerGrappleEvent;
 import com.projectkorra.ProjectKorra.Objects.Preset;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.GrapplingHookAPI;
 import com.projectkorra.ProjectKorra.Utilities.HorizontalVelocityChangeEvent;
 import com.projectkorra.ProjectKorra.airbending.AirBlast;
@@ -281,7 +281,7 @@ public class PKListener implements Listener {
 			ComboManager.addComboAbility(player, ClickType.RIGHTCLICK);
 			String ability = GeneralMethods.getBoundAbility(player);
 			if(ability != null && ability.equalsIgnoreCase("EarthSmash"))
-				new EarthSmash(player, EarthSmash.ClickType.RIGHTCLICK);
+				new EarthSmash(player, ClickType.RIGHTCLICK);
 		}
 		if (Paralyze.isParalyzed(player) || ChiComboManager.isParalyzed(player) || Bloodbending.isBloodbended(player) || Suffocate.isBreathbent(player)) {
 			event.setCancelled(true);
@@ -426,9 +426,9 @@ public class PKListener implements Listener {
 		if (event.isCancelled()) return;
 		
 		if(player.isSneaking())
-			ComboManager.addComboAbility(player, ComboManager.ClickType.SHIFTUP);
+			ComboManager.addComboAbility(player, ClickType.SHIFTUP);
 		else
-			ComboManager.addComboAbility(player, ComboManager.ClickType.SHIFTDOWN);
+			ComboManager.addComboAbility(player, ClickType.SHIFTDOWN);
 		
 		if(Suffocate.isBreathbent(player)) {
 			if(!GeneralMethods.getBoundAbility(player).equalsIgnoreCase("AirSwipe") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("FireBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("EarthBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("WaterManipulation")) {
@@ -570,7 +570,7 @@ public class PKListener implements Listener {
 					new LavaFlow(player,LavaFlow.AbilityType.SHIFT);
 				}
 				if (abil.equalsIgnoreCase("EarthSmash")) {
-					new EarthSmash(player, EarthSmash.ClickType.SHIFT);
+					new EarthSmash(player, ClickType.SHIFTDOWN);
 				}
 
 			}
@@ -804,7 +804,7 @@ public class PKListener implements Listener {
 		if (event.isCancelled()) return;
 
 		Player player = event.getPlayer();
-		ComboManager.addComboAbility(player, ComboManager.ClickType.LEFTCLICK);
+		ComboManager.addComboAbility(player, ClickType.LEFTCLICK);
 		
 		if(Suffocate.isBreathbent(player)) {
 			if(!GeneralMethods.getBoundAbility(player).equalsIgnoreCase("AirSwipe") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("FireBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("EarthBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("WaterManipulation")) {
@@ -953,7 +953,7 @@ public class PKListener implements Listener {
 				}
 				
 				if (abil.equalsIgnoreCase("EarthSmash")) {
-					new EarthSmash(player, EarthSmash.ClickType.LEFTCLICK);
+					new EarthSmash(player, ClickType.LEFTCLICK);
 				}
 			}
 			if (FireMethods.isFireAbility(abil)) {

--- a/src/com/projectkorra/ProjectKorra/Utilities/BlockSource.java
+++ b/src/com/projectkorra/ProjectKorra/Utilities/BlockSource.java
@@ -1,0 +1,292 @@
+package com.projectkorra.ProjectKorra.Utilities;
+
+import java.util.HashMap;
+
+import org.bukkit.block.Block;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+import com.projectkorra.ProjectKorra.GeneralMethods;
+import com.projectkorra.ProjectKorra.ProjectKorra;
+import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
+import com.projectkorra.ProjectKorra.waterbending.WaterMethods;
+
+/**
+ * BlockSource is a class that handles water and earth bending sources.
+ * When a Player left clicks or presses shift the update method is called
+ * which attempts to update the player's sources.
+ * 
+ * In this class ClickType refers to the way in which the source was selected.
+ * For example, Surge has two different ways to select a source, one involving shift and
+ * another involving left clicks.
+ */
+public class BlockSource {
+	public static enum BlockSourceType {
+		WATER, ICE, PLANT, EARTH, METAL, LAVA
+	}
+
+	private static HashMap<Player, HashMap<BlockSourceType, HashMap<ClickType, BlockSourceInformation>>> playerSources = 
+			new HashMap<Player, HashMap<BlockSourceType, HashMap<ClickType, BlockSourceInformation>>>();
+	private static FileConfiguration config = ProjectKorra.plugin.getConfig();
+	// The player should never need to grab source blocks from farther than this.
+	private static double MAX_RANGE = config.getDouble("Abilities.Water.WaterManipulation.Range");
+
+	/**
+	 * Updates all of the player's sources.
+	 * 
+	 * @param player the player performing the bending.
+	 * @param clickType either ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK
+	 */
+	public static void update(Player player, ClickType clickType) {
+		String boundAbil = GeneralMethods.getBoundAbility(player);
+		if (boundAbil == null) {
+			return;
+		}
+		if (WaterMethods.isWaterAbility(boundAbil)) {
+			Block waterBlock = WaterMethods.getWaterSourceBlock(player, MAX_RANGE, true);
+			if (waterBlock != null) {
+				putSource(player, waterBlock, BlockSourceType.WATER, clickType);
+				if (WaterMethods.isPlant(waterBlock)) {
+					putSource(player, waterBlock, BlockSourceType.PLANT, clickType);
+				}
+				if (WaterMethods.isIcebendable(waterBlock)) {
+					putSource(player, waterBlock, BlockSourceType.ICE, clickType);
+				}
+			}
+		} else if (EarthMethods.isEarthAbility(boundAbil)) {
+			Block earthBlock = EarthMethods.getEarthSourceBlock(player, MAX_RANGE);
+			if (earthBlock != null) {
+				putSource(player, earthBlock, BlockSourceType.EARTH, clickType);
+				if (EarthMethods.isMetal(earthBlock)) {
+					putSource(player, earthBlock, BlockSourceType.METAL, clickType);
+				}
+			}
+			
+			// We need to handle lava differently, since getEarthSourceBlock doesn't account for
+			// lava. We should only select the lava source if it is closer than the earth.
+			Block lavaBlock = EarthMethods.getLavaSourceBlock(player, MAX_RANGE);
+			double earthDist = earthBlock != null ? 
+					earthBlock.getLocation().distanceSquared(player.getLocation()) : Double.MAX_VALUE;
+			double lavaDist = lavaBlock != null ? 
+					lavaBlock.getLocation().distanceSquared(player.getLocation()) : Double.MAX_VALUE;
+			if (lavaBlock != null && lavaDist <= earthDist) {
+				putSource(player, null, BlockSourceType.EARTH, clickType);
+				putSource(player, lavaBlock, BlockSourceType.LAVA, clickType);
+			}
+		}
+	}
+
+	/**
+	 * Helper method to create and update a specific source
+	 * 
+	 * @param player a player.
+	 * @param block the block that is considered a source.
+	 * @param sourceType the elemental type of the block.
+	 * @param clickType the type of click, either SHIFT_DOWN or LEFT_CLICK.
+	 */
+	private static void putSource(Player player, Block block, BlockSourceType sourceType, ClickType clickType) {
+		if (!playerSources.containsKey(player)) {
+			playerSources.put(player, new HashMap<BlockSourceType, HashMap<ClickType, BlockSourceInformation>>());
+		}
+		if (!playerSources.get(player).containsKey(sourceType)) {
+			playerSources.get(player).put(sourceType, new HashMap<ClickType, BlockSourceInformation>());
+		}
+		BlockSourceInformation info = new BlockSourceInformation(player, block, sourceType, clickType);
+		playerSources.get(player).get(sourceType).put(clickType, info);
+	}
+	
+	/**
+	 * Access a block source information depending on a range and click type.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param clickType the action that was performed to access the source, either
+	 *            ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK.
+	 * @return a valid bendable block, or null if none was found.
+	 */
+	public static BlockSourceInformation getBlockSourceInformation(Player player, double range, 
+			BlockSourceType sourceType, ClickType clickType) {
+		if (!playerSources.containsKey(player)) {
+			return null;
+		} else if (!playerSources.get(player).containsKey(sourceType)) {
+			return null;
+		} else if (!playerSources.get(player).get(sourceType).containsKey(clickType)) {
+			return null;
+		}
+		BlockSourceInformation blockInfo = playerSources.get(player).get(sourceType).get(clickType);
+		return isStillAValidSource(blockInfo, range, clickType) ? blockInfo : null;
+	}
+	
+	/**
+	 * Access a specific type of source block depending on a range and click type.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param clickType the action that was performed to access the source, either
+	 *            ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK.
+	 * @return a valid bendable block, or null if none was found.
+	 */
+	public static Block getSourceBlock(Player player, double range, BlockSourceType sourceType, ClickType clickType) {
+		BlockSourceInformation info = getBlockSourceInformation(player, range, sourceType, clickType);
+		return info != null ? info.getBlock() : null;
+	}
+
+	/**
+	 * Attempts to access a Water bendable block that was recently shifted or clicked on by the
+	 * player.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @return a valid Water bendable block, or null if none was found.
+	 */
+	public static Block getWaterSourceBlock(Player player, double range) {
+		return getWaterSourceBlock(player, range, ClickType.LEFT_CLICK);
+	}
+
+	/**
+	 * Attempts to access a Water bendable block that was recently shifted or clicked on by the
+	 * player.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param clickType the action that was performed to access the source, either
+	 *            ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK.
+	 * @return a valid Water bendable block, or null if none was found.
+	 */
+	public static Block getWaterSourceBlock(Player player, double range, ClickType clickType) {
+		return getWaterSourceBlock(player, range, clickType, true, true, true);
+	}
+
+	/**
+	 * Attempts to access a Water bendable block that was recently shifted or clicked on by the
+	 * player.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param allowWater true if water blocks are allowed.
+	 * @param allowIce true if ice blocks are allowed.
+	 * @param allowPlant true if plant blocks are allowed.
+	 * @return a valid Water bendable block, or null if none was found.
+	 */
+	public static Block getWaterSourceBlock(Player player, double range, boolean allowWater, boolean allowIce, boolean allowPlant) {
+		return getWaterSourceBlock(player, range, ClickType.LEFT_CLICK, allowWater, allowIce, allowPlant);
+	}
+
+	/**
+	 * Attempts to access a Water bendable block that was recently shifted or clicked on by the
+	 * player.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param clickType the action that was performed to access the source, either
+	 *            ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK.
+	 * @param allowWater true if water blocks are allowed.
+	 * @param allowIce true if ice blocks are allowed.
+	 * @param allowPlant true if plant blocks are allowed.
+	 * @return a valid Water bendable block, or null if none was found.
+	 */
+	public static Block getWaterSourceBlock(Player player, double range, ClickType clickType, boolean allowWater,
+			boolean allowIce, boolean allowPlant) {
+		Block sourceBlock = null;
+		if (allowWater) {
+			sourceBlock = getSourceBlock(player, range, BlockSourceType.WATER, clickType);
+		}
+		if (allowIce && sourceBlock == null) {
+			sourceBlock = getSourceBlock(player, range, BlockSourceType.ICE, clickType);
+		}
+		if (allowPlant && sourceBlock == null) {
+			sourceBlock = getSourceBlock(player, range, BlockSourceType.PLANT, clickType);
+		}
+		return sourceBlock;
+	}
+
+	/**
+	 * Attempts to access a Earth bendable block that was recently shifted or clicked on by the
+	 * player.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param clickType the action that was performed to access the source, either
+	 *            ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK.
+	 * @return a valid Earth bendable block, or null if none was found.
+	 */
+	public static Block getEarthSourceBlock(Player player, double range, ClickType clickType) {
+		return getSourceBlock(player, range, BlockSourceType.EARTH, clickType);
+	}
+	
+	/**
+	 * Attempts to access a Lava bendable block that was recently shifted or clicked on by the
+	 * player.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param clickType the action that was performed to access the source, either
+	 *            ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK.
+	 * @return a valid Lava bendable block, or null if none was found.
+	 */
+	public static Block getLavaSourceBlock(Player player, double range, ClickType clickType) {
+		return getSourceBlock(player, range, BlockSourceType.LAVA, clickType);
+	}
+	
+	/**
+	 * Attempts to access a Lava bendable block or an Earth block that was recently shifted or clicked on by the
+	 * player.
+	 * 
+	 * @param player the player that is trying to bend.
+	 * @param range the maximum range to access the block.
+	 * @param clickType the action that was performed to access the source, either
+	 *            ClickType.SHIFT_DOWN or ClickType.LEFT_CLICK.
+	 * @return a valid Earth or Lava bendable block, or null if none was found.
+	 */
+	public static Block getEarthOrLavaSourceBlock(Player player, double range, ClickType clickType) {
+		BlockSourceInformation earthBlockInfo = getBlockSourceInformation(player, range, BlockSourceType.EARTH, clickType);
+		BlockSourceInformation lavaBlockInfo = getBlockSourceInformation(player, range, BlockSourceType.LAVA, clickType);
+		if (earthBlockInfo == null && lavaBlockInfo == null) {
+			return null;
+		} else if (earthBlockInfo == null && lavaBlockInfo != null) {
+			return lavaBlockInfo.getBlock();
+		} else if (earthBlockInfo != null && lavaBlockInfo == null) {
+			return earthBlockInfo.getBlock();
+		} else if (earthBlockInfo.getCreationTime() <= lavaBlockInfo.getCreationTime()) {
+			return earthBlockInfo.getBlock();
+		} else {
+			return lavaBlockInfo.getBlock();
+		}
+	}
+	
+	/**
+	 * Determines if a BlockSourceInformation is valid, depending on the players range from the
+	 * source, and if the source has not been modified since the time that it was first created.
+	 * 
+	 * @param info the source information.
+	 * @param range the maximum bending range.
+	 * @return true if it is valid.
+	 */
+	private static boolean isStillAValidSource(BlockSourceInformation info, double range, ClickType clickType) {
+		if (info == null || info.getBlock() == null) {
+			return false;
+		} else if (info.getClickType() != clickType) {
+			return false;
+		} else if (Math.abs(info.getPlayer().getLocation().distance(info.getBlock().getLocation())) > range) {
+			return false;
+		} else if (info.getSourceType() == BlockSourceType.WATER
+				&& !WaterMethods.isWaterbendable(info.getBlock(), info.getPlayer())) {
+			return false;
+		} else if (info.getSourceType() == BlockSourceType.ICE && !WaterMethods.isIcebendable(info.getBlock())) {
+			return false;
+		} else if (info.getSourceType() == BlockSourceType.PLANT
+				&& (!WaterMethods.isPlant(info.getBlock()) || !WaterMethods.isWaterbendable(info.getBlock(), info.getPlayer()))) {
+			return false;
+		} else if (info.getSourceType() == BlockSourceType.EARTH
+				&& !EarthMethods.isEarthbendable(info.getPlayer(), info.getBlock())) {
+			return false;
+		} else if (info.getSourceType() == BlockSourceType.METAL
+				&& (!EarthMethods.isMetal(info.getBlock()) || !EarthMethods.isEarthbendable(info.getPlayer(), info.getBlock()))) {
+			return false;
+		} else if (info.getSourceType() == BlockSourceType.LAVA
+				&& (!EarthMethods.isLava(info.getBlock()) || !EarthMethods.isLavabendable(info.getBlock(), info.getPlayer()))) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/com/projectkorra/ProjectKorra/Utilities/BlockSourceInformation.java
+++ b/src/com/projectkorra/ProjectKorra/Utilities/BlockSourceInformation.java
@@ -1,0 +1,62 @@
+package com.projectkorra.ProjectKorra.Utilities;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+import com.projectkorra.ProjectKorra.Utilities.BlockSource.BlockSourceType;
+
+public class BlockSourceInformation {
+	private Player player;
+	private Block block;
+	private BlockSourceType sourceType;
+	private ClickType clickType;
+	private long creationTime;
+	
+	public BlockSourceInformation(Player player, Block block, BlockSourceType sourceType, ClickType clickType) {
+		this.player = player;
+		this.block = block;
+		this.sourceType = sourceType;
+		this.creationTime = System.currentTimeMillis();
+		this.clickType = clickType;
+	}
+
+	public Block getBlock() {
+		return block;
+	}
+
+	public void setBlock(Block block) {
+		this.block = block;
+	}
+
+	public BlockSourceType getSourceType() {
+		return sourceType;
+	}
+
+	public void setSourceType(BlockSourceType sourceType) {
+		this.sourceType = sourceType;
+	}
+
+	public long getCreationTime() {
+		return creationTime;
+	}
+
+	public void setCreationTime(long creationTime) {
+		this.creationTime = creationTime;
+	}
+
+	public Player getPlayer() {
+		return player;
+	}
+
+	public void setPlayer(Player player) {
+		this.player = player;
+	}
+
+	public ClickType getClickType() {
+		return clickType;
+	}
+
+	public void setClickType(ClickType clickType) {
+		this.clickType = clickType;
+	}
+}

--- a/src/com/projectkorra/ProjectKorra/Utilities/ClickType.java
+++ b/src/com/projectkorra/ProjectKorra/Utilities/ClickType.java
@@ -1,5 +1,5 @@
 package com.projectkorra.ProjectKorra.Utilities;
 
 public enum ClickType {
-	SHIFTDOWN, SHIFTUP, LEFTCLICK, RIGHTCLICK
+	SHIFT, SHIFT_DOWN, SHIFT_UP, CLICK, LEFT_CLICK, RIGHT_CLICK
 }

--- a/src/com/projectkorra/ProjectKorra/Utilities/ClickType.java
+++ b/src/com/projectkorra/ProjectKorra/Utilities/ClickType.java
@@ -1,0 +1,5 @@
+package com.projectkorra.ProjectKorra.Utilities;
+
+public enum ClickType {
+	SHIFTDOWN, SHIFTUP, LEFTCLICK, RIGHTCLICK
+}

--- a/src/com/projectkorra/ProjectKorra/airbending/AirCombo.java
+++ b/src/com/projectkorra/ProjectKorra/airbending/AirCombo.java
@@ -11,7 +11,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.ProjectKorra.BendingPlayer;
-import com.projectkorra.ProjectKorra.ComboManager.ClickType;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Commands;
 import com.projectkorra.ProjectKorra.Element;
 import com.projectkorra.ProjectKorra.Flight;

--- a/src/com/projectkorra/ProjectKorra/earthbending/Collapse.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/Collapse.java
@@ -11,6 +11,8 @@ import org.bukkit.entity.Player;
 import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 
 public class Collapse {
 	
@@ -29,7 +31,7 @@ public class Collapse {
 		if (bPlayer.isOnCooldown("Collapse")) return;
 
 		this.player = player;
-		Block sblock = EarthMethods.getEarthSourceBlock(player, range);
+		Block sblock = BlockSource.getEarthSourceBlock(player, range, ClickType.SHIFT_DOWN);
 		Location location;
 		if (sblock == null) {
 			location = player.getTargetBlock(

--- a/src/com/projectkorra/ProjectKorra/earthbending/CompactColumn.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/CompactColumn.java
@@ -10,6 +10,8 @@ import org.bukkit.util.Vector;
 import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 
 public class CompactColumn {
 
@@ -36,7 +38,7 @@ public class CompactColumn {
 		BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
 		if (bPlayer.isOnCooldown("Collapse")) return;
 
-		block = EarthMethods.getEarthSourceBlock(player, range);
+		block = BlockSource.getEarthSourceBlock(player, range, ClickType.LEFT_CLICK);
 		if (block == null)
 			return;
 		origin = block.getLocation();

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthBlast.java
@@ -14,6 +14,8 @@ import org.bukkit.util.Vector;
 import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.firebending.Combustion;
 import com.projectkorra.ProjectKorra.firebending.FireBlast;
@@ -69,7 +71,7 @@ public class EarthBlast {
 
 	public boolean prepare() {
 		cancelPrevious();
-		Block block = EarthMethods.getEarthSourceBlock(player, preparerange);
+		Block block = BlockSource.getEarthSourceBlock(player, range, ClickType.SHIFT_DOWN);
 		block(player);
 		if (block != null) {
 			sourceblock = block;

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthColumn.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthColumn.java
@@ -10,6 +10,8 @@ import org.bukkit.util.Vector;
 import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 
 public class EarthColumn {
 
@@ -41,7 +43,7 @@ public class EarthColumn {
 		if (bPlayer.isOnCooldown("RaiseEarth")) return;
 
 		try {
-			block = EarthMethods.getEarthSourceBlock(player, range);
+			block = BlockSource.getEarthSourceBlock(player, range, ClickType.LEFT_CLICK);
 			if (block == null)
 				return;
 			origin = block.getLocation();

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthMethods.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthMethods.java
@@ -25,6 +25,7 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AbilityModuleManager;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
 
 public class EarthMethods {
 	
@@ -114,6 +115,15 @@ public class EarthMethods {
 		return maxlength;
 	}
 	
+	/**
+	 * Finds a valid Earth source for a Player. To use dynamic source selection, use
+	 * BlockSource.getEarthSourceBlock() instead of this method. Dynamic source selection
+	 * saves the user's previous source for future use.
+	 * {@link BlockSource#getEarthSourceBlock(Player, double, com.projectkorra.ProjectKorra.Utilities.ClickType)}
+	 * @param player the player that is attempting to Earthbend.
+	 * @param range the maximum block selection range.
+	 * @return a valid Earth source block, or null if one could not be found.
+	 */
 	@SuppressWarnings("deprecation")
 	public static Block getEarthSourceBlock(Player player, double range) {
 		Block testblock = player.getTargetBlock(getTransparentEarthbending(), (int) range);
@@ -149,6 +159,15 @@ public class EarthMethods {
 		return set;
 	}
 	
+	/**
+	 * Finds a valid Lava source for a Player. To use dynamic source selection, use
+	 * BlockSource.getLavaSourceBlock() instead of this method. Dynamic source selection
+	 * saves the user's previous source for future use.
+	 * {@link BlockSource#getLavaSourceBlock(Player, double, com.projectkorra.ProjectKorra.Utilities.ClickType)}
+	 * @param player the player that is attempting to Earthbend.
+	 * @param range the maximum block selection range.
+	 * @return a valid Lava source block, or null if one could not be found.
+	 */
 	@SuppressWarnings("deprecation")
 	public static Block getLavaSourceBlock(Player player, double range) {
 		Location location = player.getEyeLocation();

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthSmash.java
@@ -18,6 +18,7 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
 import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
@@ -72,7 +73,7 @@ public class EarthSmash {
 		bplayer = GeneralMethods.getBendingPlayer(player.getName());
 		this.time = System.currentTimeMillis();
 		
-		if(type == ClickType.SHIFTDOWN || type == ClickType.SHIFTUP && !player.isSneaking()) {		
+		if(type == ClickType.SHIFT_DOWN || type == ClickType.SHIFT_UP && !player.isSneaking()) {		
 			grabRange = GRAB_RANGE;
 			chargeTime = CHARGE_TIME;
 			cooldown = MAIN_COOLDOWN;
@@ -112,7 +113,7 @@ public class EarthSmash {
 				return;
 			}
 		}
-		else if(type == ClickType.LEFTCLICK && player.isSneaking()) {
+		else if(type == ClickType.LEFT_CLICK && player.isSneaking()) {
 			for(EarthSmash smash : instances) {
 				if(smash.state == State.GRABBED && smash.player == player) {
 					smash.state = State.SHOT;
@@ -123,7 +124,7 @@ public class EarthSmash {
 			}
 			return;
 		}
-		else if(type == ClickType.RIGHTCLICK && player.isSneaking()) {
+		else if(type == ClickType.RIGHT_CLICK && player.isSneaking()) {
 			EarthSmash grabbedSmash = aimingAtSmashCheck(player, State.GRABBED);
 			if(grabbedSmash != null) {
 				player.teleport(grabbedSmash.loc.clone().add(0, 2, 0));
@@ -168,7 +169,7 @@ public class EarthSmash {
 		if(state == State.START && progressCounter > 1) {
 			if(!player.isSneaking()) {
 				if(System.currentTimeMillis() - time > chargeTime) {
-					origin = EarthMethods.getEarthSourceBlock(player, grabRange);
+					origin = BlockSource.getEarthSourceBlock(player, grabRange, ClickType.SHIFT_DOWN);
 					if(origin == null){
 						remove();
 						return;

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthSmash.java
@@ -18,14 +18,12 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.waterbending.WaterMethods;
 
 public class EarthSmash {
-	public static enum ClickType {
-		LEFTCLICK, RIGHTCLICK, SHIFT;
-	}
 	public static enum State {
 		START, LIFTING, LIFTED, GRABBED, SHOT, FLYING, REMOVED
 	}
@@ -74,7 +72,7 @@ public class EarthSmash {
 		bplayer = GeneralMethods.getBendingPlayer(player.getName());
 		this.time = System.currentTimeMillis();
 		
-		if(type == ClickType.SHIFT && !player.isSneaking()) {		
+		if(type == ClickType.SHIFTDOWN || type == ClickType.SHIFTUP && !player.isSneaking()) {		
 			grabRange = GRAB_RANGE;
 			chargeTime = CHARGE_TIME;
 			cooldown = MAIN_COOLDOWN;

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthWall.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthWall.java
@@ -11,6 +11,8 @@ import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 
 public class EarthWall {
 
@@ -42,7 +44,7 @@ public class EarthWall {
 		Vector orth = new Vector(ox, oy, oz);
 		orth = orth.normalize();
 
-		Block sblock = EarthMethods.getEarthSourceBlock(player, range);
+		Block sblock = BlockSource.getEarthSourceBlock(player, range, ClickType.SHIFT_DOWN);
 		Location origin;
 		if (sblock == null) {
 			origin = player.getTargetBlock(EarthMethods.getTransparentEarthbending(),

--- a/src/com/projectkorra/ProjectKorra/earthbending/LavaFlow.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/LavaFlow.java
@@ -15,6 +15,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.waterbending.Plantbending;
 import com.projectkorra.ProjectKorra.waterbending.WaterMethods;
@@ -164,7 +166,7 @@ public class LavaFlow {
 			instances.add(this);
 		}
 		else if(type == AbilityType.CLICK) {
-			Block sourceBlock = getEarthSourceBlock(player, clickRange);
+			Block sourceBlock = BlockSource.getEarthOrLavaSourceBlock(player, clickRange, ClickType.LEFT_CLICK);
 			if(sourceBlock == null) {
 				remove();
 				return;
@@ -541,38 +543,6 @@ public class LavaFlow {
 	
 	public static boolean isLava(Block block) {
 		return block.getType() == Material.LAVA || block.getType() == Material.STATIONARY_LAVA;
-	}
-
-	/**
-	 * A version of Methods.getEarthSourceBlock but this one force
-	 * allows the use of Lava.
-	 * @param player the player that is viewing earth material
-	 * @param range the maximum range to locate a block
-	 * @return a block if one was found, else null
-	 */
-	public static Block getEarthSourceBlock(Player player, double range) {
-		HashSet<Byte> bendables = EarthMethods.getTransparentEarthbending();
-		bendables.remove((byte) 10);
-		bendables.remove((byte) 11);
-		
-		@SuppressWarnings("deprecation")
-		Block testblock = player.getTargetBlock(bendables, (int) range);
-		if ((!GeneralMethods.isRegionProtectedFromBuild(player, "LavaFlow", testblock.getLocation()))
-				&& (isEarthbendableMaterial(testblock.getType(), player) || isLava(testblock)))
-			return testblock;
-
-		Location location = player.getEyeLocation();
-		Vector vector = location.getDirection().clone().normalize();
-		for (double i = 0; i <= range; i++) {
-			Block block = location.clone().add(vector.clone().multiply(i))
-					.getBlock();
-			if (GeneralMethods.isRegionProtectedFromBuild(player, "RaiseEarth", location))
-				continue;
-			if (isEarthbendableMaterial(testblock.getType(), player) || isLava(testblock)) {
-				return block;
-			}
-		}
-		return null;
 	}
 	
 	/**

--- a/src/com/projectkorra/ProjectKorra/earthbending/LavaSurge.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/LavaSurge.java
@@ -20,6 +20,8 @@ import com.projectkorra.ProjectKorra.BendingPlayer;
 import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 
 public class LavaSurge 
@@ -99,7 +101,7 @@ public class LavaSurge
 	
 	public boolean prepare()
 	{
-		Block targetBlock = EarthMethods.getEarthSourceBlock(player, prepareRange);
+		Block targetBlock = BlockSource.getEarthSourceBlock(player, prepareRange, ClickType.SHIFT_DOWN);
 		
 		if(targetBlock == null || 
 				!(targetBlock.getRelative(BlockFace.UP).getType() == Material.AIR) &&

--- a/src/com/projectkorra/ProjectKorra/earthbending/LavaWall.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/LavaWall.java
@@ -16,6 +16,9 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource.BlockSourceType;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.firebending.FireBlast;
 
 public class LavaWall {
@@ -62,7 +65,7 @@ public class LavaWall {
 
 	public boolean prepare() {
 		cancelPrevious();
-		Block block = EarthMethods.getLavaSourceBlock(player, range);
+		Block block = BlockSource.getSourceBlock(player, range, BlockSourceType.LAVA, ClickType.LEFT_CLICK);
 		if (block != null) {
 			sourceblock = block;
 			focusBlock();

--- a/src/com/projectkorra/ProjectKorra/earthbending/LavaWave.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/LavaWave.java
@@ -17,6 +17,9 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource.BlockSourceType;
 import com.projectkorra.ProjectKorra.firebending.FireBlast;
 import com.projectkorra.ProjectKorra.waterbending.WaterMethods;
 
@@ -62,7 +65,7 @@ public class LavaWave {
 	public boolean prepare() {
 		cancelPrevious();
 		// Block block = player.getTargetBlock(null, (int) range);
-		Block block = EarthMethods.getLavaSourceBlock(player, range);
+		Block block = BlockSource.getSourceBlock(player, range, BlockSourceType.LAVA, ClickType.SHIFT_DOWN);
 		if (block != null) {
 			sourceblock = block;
 			focusBlock();

--- a/src/com/projectkorra/ProjectKorra/firebending/FireCombo.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/FireCombo.java
@@ -16,12 +16,12 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.ProjectKorra.BendingPlayer;
-import com.projectkorra.ProjectKorra.ComboManager.ClickType;
 import com.projectkorra.ProjectKorra.Commands;
 import com.projectkorra.ProjectKorra.Element;
 import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.chiblocking.ChiMethods;

--- a/src/com/projectkorra/ProjectKorra/waterbending/IceBlast.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/IceBlast.java
@@ -18,6 +18,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.TempPotionEffect;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
@@ -55,7 +57,7 @@ public class IceBlast {
 		block(player);
 		range = WaterMethods.waterbendingNightAugment(defaultrange, player.getWorld());
 		this.player = player;
-		Block sourceblock = WaterMethods.getIceSourceBlock(player, range);
+		Block sourceblock = BlockSource.getWaterSourceBlock(player, range, ClickType.SHIFT_DOWN, false, true, false);
 
 		if (sourceblock == null) {
 			return;

--- a/src/com/projectkorra/ProjectKorra/waterbending/IceSpike2.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/IceSpike2.java
@@ -18,6 +18,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.TempPotionEffect;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
 
@@ -61,7 +63,8 @@ public class IceSpike2 {
 			plantbending = true;
 		range = WaterMethods.waterbendingNightAugment(defaultrange, player.getWorld());
 		this.player = player;
-		Block sourceblock = WaterMethods.getWaterSourceBlock(player, range, plantbending);
+		Block sourceblock = BlockSource.getWaterSourceBlock(player, range, ClickType.SHIFT_DOWN, 
+				true, true, plantbending);
 
 		if (sourceblock == null) {
 			new SpikeField(player);

--- a/src/com/projectkorra/ProjectKorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/OctopusForm.java
@@ -16,6 +16,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
 
@@ -66,7 +68,8 @@ public class OctopusForm {
 		}
 		this.player = player;
 		time = System.currentTimeMillis();
-		sourceblock = WaterMethods.getWaterSourceBlock(player, range, true);
+		sourceblock = BlockSource.getWaterSourceBlock(player, range, ClickType.LEFT_CLICK, 
+				true, true, WaterMethods.canPlantbend(player));
 		if (sourceblock != null) {
 			sourcelocation = sourceblock.getLocation();
 			sourceselected = true;

--- a/src/com/projectkorra/ProjectKorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/Torrent.java
@@ -18,6 +18,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
 
@@ -74,7 +76,8 @@ public class Torrent {
 		}
 		this.player = player;
 		time = System.currentTimeMillis();
-		sourceblock = WaterMethods.getWaterSourceBlock(player, selectrange, WaterMethods.canPlantbend(player));
+		sourceblock = BlockSource.getWaterSourceBlock(player, selectrange, ClickType.LEFT_CLICK, 
+				true, true, WaterMethods.canPlantbend(player));
 		if (sourceblock != null) {
 			sourceselected = true;
 			instances.put(player, this);

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterCombo.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterCombo.java
@@ -20,6 +20,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.chiblocking.ChiMethods;
 import com.projectkorra.ProjectKorra.chiblocking.Paralyze;
@@ -269,8 +271,8 @@ public class WaterCombo {
 					remove();
 					return;
 				}
-				Block waterBlock = WaterMethods.getWaterSourceBlock(player, range,
-						true);
+				Block waterBlock = BlockSource.getWaterSourceBlock(player, range, ClickType.LEFT_CLICK, 
+						true, true, WaterMethods.canPlantbend(player));
 				if (waterBlock == null) {
 					remove();
 					return;

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
@@ -19,6 +19,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.earthbending.EarthBlast;
 import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
@@ -88,7 +90,8 @@ public class WaterManipulation {
 
 	public boolean prepare() {
 		// Block block = player.getTargetBlock(null, (int) range);
-		Block block = WaterMethods.getWaterSourceBlock(player, range, WaterMethods.canPlantbend(player));
+		Block block = BlockSource.getWaterSourceBlock(player, range, 
+				ClickType.SHIFT_DOWN, true, true, WaterMethods.canPlantbend(player));
 		// if (prepared.containsKey(player)
 		// && !Methods.isWaterbendable(block, player)) {
 		// instances.get(prepared.get(player)).displacing = true;

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterMethods.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterMethods.java
@@ -22,6 +22,7 @@ import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AbilityModuleManager;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
 import com.projectkorra.ProjectKorra.chiblocking.ChiMethods;
 import com.projectkorra.rpg.RPGMethods;
 import com.projectkorra.rpg.WorldEvents;
@@ -116,6 +117,16 @@ public class WaterMethods {
 		return ChatColor.valueOf(config.getString("Properties.Chat.Colors.Water"));
 	}
 	
+	/**
+	 * Finds a valid Water source for a Player. To use dynamic source selection, use
+	 * BlockSource.getWaterSourceBlock() instead of this method. Dynamic source selection
+	 * saves the user's previous source for future use.
+	 * {@link BlockSource#getWaterSourceBlock(Player, double)}
+	 * @param player the player that is attempting to Waterbend.
+	 * @param range the maximum block selection range.
+	 * @param plantbending true if the player can bend plants.
+	 * @return a valid Water source block, or null if one could not be found.
+	 */
 	@SuppressWarnings("deprecation")
 	public static Block getWaterSourceBlock(Player player, double range,
 			boolean plantbending) {

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterWall.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterWall.java
@@ -16,6 +16,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
 import com.projectkorra.ProjectKorra.firebending.FireBlast;
 
@@ -148,7 +150,8 @@ public class WaterWall {
 	public boolean prepare() {
 		cancelPrevious();
 		// Block block = player.getTargetBlock(null, (int) range);
-		Block block = WaterMethods.getWaterSourceBlock(player, range, WaterMethods.canPlantbend(player));
+		Block block = BlockSource.getWaterSourceBlock(player, range, ClickType.LEFT_CLICK, 
+				true, true, WaterMethods.canPlantbend(player));
 		if (block != null) {
 			sourceblock = block;
 			focusBlock();
@@ -462,7 +465,8 @@ public class WaterWall {
 
 		if (!instances.containsKey(player.getEntityId())) {
 			if (!Wave.instances.containsKey(player.getEntityId())
-					&& WaterMethods.getWaterSourceBlock(player, (int) Wave.defaultrange, WaterMethods.canPlantbend(player)) == null
+					&& BlockSource.getWaterSourceBlock(player, (int) Wave.defaultrange, ClickType.LEFT_CLICK,
+							true, true, WaterMethods.canPlantbend(player)) == null
 					&& WaterReturn.hasWaterBottle(player)) {
 				BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
 

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterWave.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterWave.java
@@ -19,6 +19,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 
 public class WaterWave {
 	public static enum AbilityType {
@@ -104,8 +106,8 @@ public class WaterWave {
 				removeType(player, AbilityType.CLICK);
 				instances.add(this);
 
-				Block block = WaterMethods.getWaterSourceBlock(player, range,
-						WaterMethods.canPlantbend(player));
+				Block block = BlockSource.getWaterSourceBlock(player, range, ClickType.LEFT_CLICK, 
+						true, true, WaterMethods.canPlantbend(player));
 				if (block == null) {
 					remove();
 					return;

--- a/src/com/projectkorra/ProjectKorra/waterbending/Wave.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/Wave.java
@@ -17,6 +17,8 @@ import com.projectkorra.ProjectKorra.GeneralMethods;
 import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AvatarState;
+import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ClickType;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
 import com.projectkorra.ProjectKorra.earthbending.EarthMethods;
 import com.projectkorra.ProjectKorra.firebending.FireBlast;
@@ -82,7 +84,8 @@ public class Wave {
 	public boolean prepare() {
 		cancelPrevious();
 		// Block block = player.getTargetBlock(null, (int) range);
-		Block block = WaterMethods.getWaterSourceBlock(player, range, WaterMethods.canPlantbend(player));
+		Block block = BlockSource.getWaterSourceBlock(player, range, ClickType.SHIFT_DOWN, 
+				true, true, WaterMethods.canPlantbend(player));
 		if (block != null) {
 			sourceblock = block;
 			focusBlock();


### PR DESCRIPTION
Dynamic Water, Earth, and Lava Source Selection:
    - Source selection has been reworked to be more adaptable in certain situations. For example, a Water bender does not need to reselect sources just to use the same ability.
    - Once a block is selected as a source, it will be saved until the player selects a different source for that particular element. If the user has multiple elements then they would be able to have a different source for each element.
    - Sources now transfer between abilities. For example, if a user selects a block with WaterManipulation then switches to Torrent they can still use the same source block.
        * Note: Although the Player does not have to reselect a source, they must perform the same sneak/left click actions that they normally would. For example, if a Player wants to spam WaterManipulation from the same source they cannot just simply spam left click, they must sneak and then left click every time.
    - Due to some abilities requiring both sneak based sources and left click based sources (e.g Surge Wave and Surge Wall) these sources are considered independently from one another. This means that a Waterbender can have a source for sneak based abilities (WaterManipulation, Torrent, etc) and a separate source for left click based abilities (Surge Wall).