### PR TITLE
[BugFix] World compare, Preset, Illumination and minor fixes (Merge ready)

### DIFF
--- a/src/com/projectkorra/ProjectKorra/Commands.java
+++ b/src/com/projectkorra/ProjectKorra/Commands.java
@@ -952,7 +952,7 @@ public class Commands {
 
 						for (int i = 1; i <= 9; i++) {
 							String ability = abilities.get(i);
-							if (ability != null) s.sendMessage(i + " - " + GeneralMethods.getAbilityColor(ability) + ability);
+							if (ability != null && !ability.equalsIgnoreCase("null")) s.sendMessage(i + " - " + GeneralMethods.getAbilityColor(ability) + ability);
 						}
 
 						return true;

--- a/src/com/projectkorra/ProjectKorra/Commands.java
+++ b/src/com/projectkorra/ProjectKorra/Commands.java
@@ -242,7 +242,7 @@ public class Commands {
 
 						Preset preset = Preset.getPreset(player, name);
 						preset.delete();
-						s.sendMessage(ChatColor.GREEN + "You have deleted your preset named: " + name);
+						s.sendMessage(ChatColor.GREEN + "You have deleted your preset named: " + ChatColor.YELLOW + name);
 					}
 
 					if (Arrays.asList(bindaliases).contains(args[1].toLowerCase())) {
@@ -257,7 +257,7 @@ public class Commands {
 						}
 
 						Preset.bindPreset(player, name);
-						s.sendMessage(ChatColor.GREEN + "Your bound slots have been set to match the " + name + " preset.");
+						s.sendMessage(ChatColor.GREEN + "Your bound slots have been set to match the " + ChatColor.YELLOW + name + ChatColor.GREEN + " preset.");
 						return true;
 					}
 
@@ -286,7 +286,7 @@ public class Commands {
 						HashMap<Integer, String> abilities = bPlayer.getAbilities();
 						Preset preset = new Preset(player.getUniqueId(), name, abilities);
 						preset.save();
-						s.sendMessage(ChatColor.GREEN + "Created preset with the name: " + name);
+						s.sendMessage(ChatColor.GREEN + "Created preset with the name: " + ChatColor.YELLOW + name);
 						return true;
 					}
 
@@ -945,7 +945,7 @@ public class Commands {
 						HashMap<Integer, String> abilities = bPlayer.getAbilities();
 
 						if (abilities.isEmpty()) {
-							s.sendMessage("You don't have any bound abilities.");
+							s.sendMessage(ChatColor.RED + "You don't have any bound abilities.");
 							s.sendMessage("If you would like to see a list of available abilities, please use the /bending display [Element] command. Use /bending help for more information.");
 							return true;
 						}

--- a/src/com/projectkorra/ProjectKorra/GeneralMethods.java
+++ b/src/com/projectkorra/ProjectKorra/GeneralMethods.java
@@ -1219,8 +1219,10 @@ public class GeneralMethods {
 	public static Collection<Player> getPlayersAroundPoint(Location location, double distance) {
 		Collection<Player> players = new HashSet<Player>();
 		for (Player player: Bukkit.getOnlinePlayers()) {
-			if (player.getLocation().distance(location) <= distance) {
-				players.add(player);
+			if (player.getLocation().getWorld().equals(location.getWorld())) {
+				if (player.getLocation().distance(location) <= distance) {
+					players.add(player);
+				}
 			}
 		}
 		return players;

--- a/src/com/projectkorra/ProjectKorra/GeneralMethods.java
+++ b/src/com/projectkorra/ProjectKorra/GeneralMethods.java
@@ -1406,7 +1406,7 @@ public class GeneralMethods {
 		String uuid = bPlayer.uuid.toString();
 
 		//Temp code to block modifications of binds, Should be replaced when bind event is added.
-		if(MultiAbilityManager.playerAbilities.containsKey(Bukkit.getPlayer(bPlayer.getPlayerName())))
+		if(MultiAbilityManager.playerAbilities.containsKey(Bukkit.getPlayer(bPlayer.uuid)))
 			return;
 		HashMap<Integer, String> abilities = bPlayer.getAbilities();
 

--- a/src/com/projectkorra/ProjectKorra/Objects/Preset.java
+++ b/src/com/projectkorra/ProjectKorra/Objects/Preset.java
@@ -116,31 +116,15 @@ public class Preset {
     
     public void save() {
         DBConnection.sql.modifyQuery("INSERT INTO pk_presets (uuid, name) VALUES ('" + uuid.toString() + "', '" + name
-                + "') ON DUPLICATE KEY UPDATE uuid=uuid;");
+                + "') ON DUPLICATE KEY UPDATE name=VALUES(name)");
         
         /*
          * Now we know the preset exists in the SQL table, so we can manipulate
          * it normally.
          */
-        
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot1 = '" + abilities.get(1) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot2 = '" + abilities.get(2) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot3 = '" + abilities.get(3) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot4 = '" + abilities.get(4) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot5 = '" + abilities.get(5) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot6 = '" + abilities.get(6) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot7 = '" + abilities.get(7) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot8 = '" + abilities.get(8) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
-        DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot9 = '" + abilities.get(9) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name
-                + "'");
+        for (int i = 1; i <= 9; i++) {
+        	DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot" + i + " = '" + abilities.get(i) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name);
+        }
     }
     
 }

--- a/src/com/projectkorra/ProjectKorra/Objects/Preset.java
+++ b/src/com/projectkorra/ProjectKorra/Objects/Preset.java
@@ -115,15 +115,21 @@ public class Preset {
     }
     
     public void save() {
-        DBConnection.sql.modifyQuery("INSERT INTO pk_presets (uuid, name) VALUES ('" + uuid.toString() + "', '" + name
-                + "') ON DUPLICATE KEY UPDATE name=VALUES(name)");
+    	if (ProjectKorra.plugin.getConfig().getString("Storage.engine").equalsIgnoreCase("mysql")) {
+    		DBConnection.sql.modifyQuery("INSERT INTO pk_presets (uuid, name) VALUES ('" + uuid.toString() + "', '" + name + "') "
+    				+ "ON DUPLICATE KEY UPDATE name=VALUES(name)");
+    	} else {
+//    		DBConnection.sql.modifyQuery("INSERT OR IGNORE INTO pk_presets (uuid, name) VALUES ('" + uuid.toString() + "', '" + name + "')");
+//    		DBConnection.sql.modifyQuery("UPDATE pk_presets SET uuid = '" + uuid.toString() + "', name = '" + name + "'");
+    		DBConnection.sql.modifyQuery("INSERT OR REPLACE INTO pk_presets (uuid, name) VALUES ('" + uuid.toString() + "', '" + name + "')");
+    	}
         
         /*
          * Now we know the preset exists in the SQL table, so we can manipulate
          * it normally.
          */
         for (int i = 1; i <= 9; i++) {
-        	DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot" + i + " = '" + abilities.get(i) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name + "'");
+        	DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot" + i + " = '" + (abilities.get(i) == null ? null: abilities.get(i)) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name + "'");
         }
     }
     

--- a/src/com/projectkorra/ProjectKorra/Objects/Preset.java
+++ b/src/com/projectkorra/ProjectKorra/Objects/Preset.java
@@ -123,7 +123,7 @@ public class Preset {
          * it normally.
          */
         for (int i = 1; i <= 9; i++) {
-        	DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot" + i + " = '" + abilities.get(i) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name);
+        	DBConnection.sql.modifyQuery("UPDATE pk_presets SET slot" + i + " = '" + abilities.get(i) + "' WHERE uuid = '" + uuid.toString() + "' AND name = '" + name + "'");
         }
     }
     

--- a/src/com/projectkorra/ProjectKorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/ProjectKorra/airbending/AirSwipe.java
@@ -303,11 +303,13 @@ public class AirSwipe {
 		for (int ID : instances.keySet()) {
 			AirSwipe aswipe = instances.get(ID);
 			
-			for(Vector vec : aswipe.elements.keySet()) {
+			for (Vector vec : aswipe.elements.keySet()) {
 				Location vectorLoc = aswipe.elements.get(vec);
-				if(vectorLoc != null && !vectorLoc.getWorld().equals(loc.getWorld()) && vectorLoc.distance(loc) <= radius){
-					instances.remove(aswipe.id);
-					removed = true;
+				if (vectorLoc != null && !vectorLoc.getWorld().equals(loc.getWorld())) {
+					if (vectorLoc.distance(loc) <= radius) {
+						instances.remove(aswipe.id);
+						removed = true;
+					}
 				}
 			}
 		}

--- a/src/com/projectkorra/ProjectKorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/ProjectKorra/airbending/AirSwipe.java
@@ -305,7 +305,7 @@ public class AirSwipe {
 			
 			for(Vector vec : aswipe.elements.keySet()) {
 				Location vectorLoc = aswipe.elements.get(vec);
-				if(vectorLoc != null && vectorLoc.getWorld() != loc.getWorld() && vectorLoc.distance(loc) <= radius){
+				if(vectorLoc != null && !vectorLoc.getWorld().equals(loc.getWorld()) && vectorLoc.distance(loc) <= radius){
 					instances.remove(aswipe.id);
 					removed = true;
 				}

--- a/src/com/projectkorra/ProjectKorra/earthbending/Catapult.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/Catapult.java
@@ -126,7 +126,7 @@ public class Catapult {
 		}
 
 		// Methods.verbose(player.getLocation().distance(location));
-		if (player.getWorld() != location.getWorld()) {
+		if (!player.getWorld().equals(location.getWorld())) {
 			remove();
 			return;
 		}

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthArmor.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthArmor.java
@@ -77,7 +77,7 @@ public class EarthArmor {
 	}
 
 	private boolean moveBlocks() {
-		if (player.getWorld() != headblock.getWorld()) {
+		if (!player.getWorld().equals(headblock.getWorld())) {
 			cancel();
 			return false;
 		}

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthBlast.java
@@ -135,7 +135,7 @@ public class EarthBlast {
 	@SuppressWarnings("deprecation")
 	public void throwEarth() {
 		if (sourceblock != null) {
-			if (sourceblock.getWorld() == player.getWorld()) {
+			if (sourceblock.getWorld().equals(player.getWorld())) {
 				if (EarthMethods.movedearth.containsKey(sourceblock)) {
 					if (!revert)
 						EarthMethods.removeRevertIndex(sourceblock);
@@ -223,7 +223,7 @@ public class EarthBlast {
 					instances.remove(id);
 					return false;
 				}
-				if (player.getWorld() != sourceblock.getWorld()) {
+				if (!player.getWorld().equals(sourceblock.getWorld())) {
 					unfocusBlock();
 					return false;
 				}

--- a/src/com/projectkorra/ProjectKorra/earthbending/LavaWave.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/LavaWave.java
@@ -104,7 +104,7 @@ public class LavaWave {
 		
 		bPlayer.addCooldown("LavaSurge", GeneralMethods.getGlobalCooldown());
 		if (sourceblock != null) {
-			if (sourceblock.getWorld() != player.getWorld()) {
+			if (!sourceblock.getWorld().equals(player.getWorld())) {
 				return;
 			}
 			if (AvatarState.isAvatarState(player))

--- a/src/com/projectkorra/ProjectKorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/Tremorsense.java
@@ -110,7 +110,7 @@ public class Tremorsense {
 			instances.put(player, this);
 		} else if (block == null) {
 			return;
-		} else if (player.getWorld() != block.getWorld()) {
+		} else if (!player.getWorld().equals(block.getWorld())) {
 			revert();
 		} else if (!EarthMethods.isEarthbendable(player,
 				standblock)) {

--- a/src/com/projectkorra/ProjectKorra/firebending/FireShield.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/FireShield.java
@@ -186,13 +186,13 @@ public class FireShield {
 			Location playerLoc = fshield.player.getLocation();
 
 			if(fshield.shield) {
-				if (playerLoc.getWorld() != loc.getWorld())
+				if (!playerLoc.getWorld().equals(loc.getWorld()))
 					return false;
 				if(playerLoc.distance(loc) <= fshield.radius)
 					return true;
 			} else {
 				Location tempLoc = playerLoc.clone().add(playerLoc.multiply(fshield.discradius));
-				if (tempLoc.getWorld() != loc.getWorld()) 
+				if (!tempLoc.getWorld().equals(loc.getWorld())) 
 					return false;
 				if(tempLoc.distance(loc) <= fshield.discradius)
 					return true;

--- a/src/com/projectkorra/ProjectKorra/firebending/Illumination.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/Illumination.java
@@ -47,7 +47,7 @@ public class Illumination {
 		if (standblock.getType() == Material.GLOWSTONE) {
 			revert();
 		} else if ((FireStream.isIgnitable(player, standingblock) && standblock
-				.getType() != Material.LEAVES)
+				.getType() != Material.LEAVES && standblock.getType() != Material.LEAVES_2)
 				&& block == null
 				&& !blocks.containsKey(standblock)) {
 			block = standingblock;
@@ -56,7 +56,7 @@ public class Illumination {
 			block.setType(Material.TORCH);
 			blocks.put(block, player);
 		} else if ((FireStream.isIgnitable(player, standingblock) && standblock
-				.getType() != Material.LEAVES)
+				.getType() != Material.LEAVES && standblock.getType() != Material.LEAVES_2)
 				&& !block.equals(standblock)
 				&& !blocks.containsKey(standblock) && GeneralMethods.isSolid(standblock)) {
 			revert();

--- a/src/com/projectkorra/ProjectKorra/firebending/Illumination.java
+++ b/src/com/projectkorra/ProjectKorra/firebending/Illumination.java
@@ -67,7 +67,7 @@ public class Illumination {
 			blocks.put(block, player);
 		} else if (block == null) {
 			return;
-		} else if (player.getWorld() != block.getWorld()) {
+		} else if (!player.getWorld().equals(block.getWorld())) {
 			revert();
 		} else if (player.getLocation().distance(block.getLocation()) > FireMethods
 				.getFirebendingDayAugment(range, player.getWorld())) {

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterArms.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterArms.java
@@ -54,30 +54,19 @@ public class WaterArms {
 
 	private int lengthReduction = 0;
 
-	private int initLength = config
-			.getInt("Abilities.Water.WaterArms.Arms.InitialLength");
-	private int sourceGrabRange = config
-			.getInt("Abilities.Water.WaterArms.Arms.SourceGrabRange");
-	private int maxPunches = config
-			.getInt("Abilities.Water.WaterArms.Arms.MaxAttacks");
-	private int maxIceBlasts = config
-			.getInt("Abilities.Water.WaterArms.Arms.MaxIceShots");
-	private int maxUses = config
-			.getInt("Abilities.Water.WaterArms.Arms.MaxAlternateUsage");
-	private long cooldown = config
-			.getLong("Abilities.Water.WaterArms.Arms.Cooldown");
-	private boolean canUsePlantSource = config
-			.getBoolean("Abilities.Water.WaterArms.Arms.AllowPlantSource");
+	private int initLength = config.getInt("Abilities.Water.WaterArms.Arms.InitialLength");
+	private int sourceGrabRange = config.getInt("Abilities.Water.WaterArms.Arms.SourceGrabRange");
+	private int maxPunches = config.getInt("Abilities.Water.WaterArms.Arms.MaxAttacks");
+	private int maxIceBlasts = config.getInt("Abilities.Water.WaterArms.Arms.MaxIceShots");
+	private int maxUses = config.getInt("Abilities.Water.WaterArms.Arms.MaxAlternateUsage");
+	private long cooldown = config.getLong("Abilities.Water.WaterArms.Arms.Cooldown");
+	private boolean canUsePlantSource = config.getBoolean("Abilities.Water.WaterArms.Arms.AllowPlantSource");
 
-	private boolean lightningEnabled = config
-			.getBoolean("Abilities.Water.WaterArms.Arms.Lightning.Enabled");
-	private double lightningDamage = config
-			.getDouble("Abilities.Water.WaterArms.Arms.Lightning.Damage");
-	private boolean lightningKill = config
-			.getBoolean("Abilities.Water.WaterArms.Arms.Lightning.KillUser");
+	private boolean lightningEnabled = config.getBoolean("Abilities.Water.WaterArms.Arms.Lightning.Enabled");
+	private double lightningDamage = config.getDouble("Abilities.Water.WaterArms.Arms.Lightning.Damage");
+	private boolean lightningKill = config.getBoolean("Abilities.Water.WaterArms.Arms.Lightning.KillUser");
 
-	private static String sneakMsg = config
-			.getString("Abilities.Water.WaterArms.SneakMessage");
+	private static String sneakMsg = config.getString("Abilities.Water.WaterArms.SneakMessage");
 
 	private int selectedSlot = 0;
 	private int freezeSlot = 4;
@@ -112,8 +101,7 @@ public class WaterArms {
 					}
 					break;
 				case 4:
-					if (player
-							.hasPermission("bending.ability.WaterArms.Freeze")
+					if (player.hasPermission("bending.ability.WaterArms.Freeze")
 							&& WaterMethods.canIcebend(player)) {
 						new WaterArmsFreeze(player);
 					}
@@ -152,30 +140,24 @@ public class WaterArms {
 			return false;
 		if (!GeneralMethods.canBend(player.getName(), "WaterArms"))
 			return false;
-		if (GeneralMethods.isRegionProtectedFromBuild(player, "WaterArms",
-				player.getLocation()))
+		if (GeneralMethods.isRegionProtectedFromBuild(player, "WaterArms", player.getLocation()))
 			return false;
-		if (GeneralMethods.getBendingPlayer(player.getName()).isOnCooldown(
-				"WaterArms"))
+		if (GeneralMethods.getBendingPlayer(player.getName()).isOnCooldown("WaterArms"))
 			return false;
-		if (GeneralMethods.getBoundAbility(player)
-				.equalsIgnoreCase("WaterArms"))
+		if (GeneralMethods.getBoundAbility(player).equalsIgnoreCase("WaterArms"))
 			return true;
 		return false;
 	}
 
 	private boolean prepare() {
-		Block sourceblock = WaterMethods.getWaterSourceBlock(player,
-				sourceGrabRange, canUsePlantSource);
+		Block sourceblock = WaterMethods.getWaterSourceBlock(player, sourceGrabRange, canUsePlantSource);
 		if (sourceblock != null) {
 			if (WaterMethods.isPlant(sourceblock)) {
 				fullSource = false;
 			}
 			ParticleEffect.LARGE_SMOKE.display(
-					WaterMethods
-							.getWaterSourceBlock(player, sourceGrabRange,
-									canUsePlantSource).getLocation().clone()
-							.add(0.5, 0.5, 0.5), 0, 0, 0, 0F, 4);
+					WaterMethods.getWaterSourceBlock(player, sourceGrabRange, canUsePlantSource)
+									.getLocation().clone().add(0.5, 0.5, 0.5), 0, 0, 0, 0F, 4);
 			return true;
 		} else if (WaterReturn.hasWaterBottle(player)) {
 			WaterReturn.emptyWaterBottle(player);
@@ -189,7 +171,7 @@ public class WaterArms {
 		if (!instances.containsKey(player)) {
 			return;
 		}
-		if (player.isDead() || !player.isOnline() || world != player.getWorld()) {
+		if (player.isDead() || !player.isOnline() || !world.equals(player.getWorld())) {
 			remove();
 			return;
 		}

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
@@ -132,7 +132,7 @@ public class WaterManipulation {
 
 	public void moveWater() {
 		if (sourceblock != null) {
-			if (sourceblock.getWorld() == player.getWorld()) {
+			if (sourceblock.getWorld().equals(player.getWorld())) {
 				targetdestination = getTargetLocation(player, range);
 
 				if (targetdestination.distance(location) <= 1) {

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterReturn.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterReturn.java
@@ -60,7 +60,7 @@ public class WaterReturn {
 			return;
 		}
 
-		if (player.getWorld() != location.getWorld()) {
+		if (!player.getWorld().equals(location.getWorld())) {
 			remove();
 			return;
 		}

--- a/src/com/projectkorra/ProjectKorra/waterbending/Wave.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/Wave.java
@@ -126,7 +126,7 @@ public class Wave {
 		if (bPlayer.isOnCooldown("Surge")) return;
 		bPlayer.addCooldown("Surge", GeneralMethods.getGlobalCooldown());
 		if (sourceblock != null) {
-			if (sourceblock.getWorld() != player.getWorld()) {
+			if (!sourceblock.getWorld().equals(player.getWorld())) {
 				return;
 			}
 			range = WaterMethods.waterbendingNightAugment(range, player.getWorld());


### PR DESCRIPTION
* After further discussion it was decided that all == that were being used to compare worlds should be changed to .equals
* sqlite does not have the command "ON DUPLICATE KEY UPDATE" which is what presets is currently using to save
  * Add check to see if database is sqlite, if so run different command
* Add some color to some of the messages in commands to emphasize the messages
* Change Bukkit.getPlayer(bPlayer.playerName) to Bukkit.getPlayer(bPlayer.uuid)
* Add missing .equalsIgnoreCase("null") to /bend display

READY TO BE PULLED