### PR TITLE
Fixed WaterArms flooding and WaterManipulation bugs.

### DIFF
--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterArms.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterArms.java
@@ -249,7 +249,7 @@ public class WaterArms {
 		if (!canPlaceBlock(r2.getBlock()))
 			return false;
 
-		new TempBlock(r2.getBlock(), Material.STATIONARY_WATER, (byte) 0);
+		new TempBlock(r2.getBlock(), Material.STATIONARY_WATER, (byte) 8);
 		revert.put(r2.getBlock(), 0L);
 
 		for (int j = 0; j <= initLength; j++) {
@@ -271,7 +271,7 @@ public class WaterArms {
 				revert.put(r3.getBlock(), 0L);
 			} else {
 				new TempBlock(r3.getBlock(), Material.STATIONARY_WATER,
-						(byte) 0);
+						(byte) 8);
 				revert.put(r3.getBlock(), 0L);
 			}
 		}
@@ -305,7 +305,7 @@ public class WaterArms {
 		if (!canPlaceBlock(l2.getBlock()))
 			return false;
 
-		new TempBlock(l2.getBlock(), Material.STATIONARY_WATER, (byte) 0);
+		new TempBlock(l2.getBlock(), Material.STATIONARY_WATER, (byte) 8);
 		revert.put(l2.getBlock(), 0L);
 
 		for (int j = 0; j <= initLength; j++) {
@@ -327,7 +327,7 @@ public class WaterArms {
 				revert.put(l3.getBlock(), 0L);
 			} else {
 				new TempBlock(l3.getBlock(), Material.STATIONARY_WATER,
-						(byte) 0);
+						(byte) 8);
 				revert.put(l3.getBlock(), 0L);
 			}
 		}

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterArmsSpear.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterArmsSpear.java
@@ -213,7 +213,7 @@ public class WaterArmsSpear {
 				}
 			}
 			new TempBlock(location.getBlock(), Material.STATIONARY_WATER,
-					(byte) 0);
+					(byte) 8);
 			WaterArms.revert.put(location.getBlock(),
 					System.currentTimeMillis() + 600L);
 			Vector direction = GeneralMethods.getDirection(

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterArmsWhip.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterArmsWhip.java
@@ -277,7 +277,7 @@ public class WaterArmsWhip {
 				}
 
 				new TempBlock(l2.getBlock(), Material.STATIONARY_WATER,
-						(byte) 0);
+						(byte) 8);
 				WaterArms.revert.put(l2.getBlock(), 0L);
 
 				if (i == activeLength) {

--- a/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/WaterManipulation.java
@@ -45,7 +45,7 @@ public class WaterManipulation {
 	// private static double speed = 1.5;
 	private static int ID = Integer.MIN_VALUE;
 
-	private static final byte full = 0x0;
+	private static final byte full = 0x8;
 	private static HashSet<Byte> water = new HashSet<Byte>();
 	// private static final byte half = 0x4;
 
@@ -419,9 +419,9 @@ public class WaterManipulation {
 				}
 				if (trail != null) {
 					trail2 = trail;
-					trail2.setType(Material.WATER, (byte) 2);
+					trail2.setType(Material.STATIONARY_WATER, (byte) 2);
 				}
-				trail = new TempBlock(sourceblock, Material.WATER, (byte) 1);
+				trail = new TempBlock(sourceblock, Material.STATIONARY_WATER, (byte) 1);
 				sourceblock = block;
 
 				if (location.distance(targetdestination) <= 1 || location.distance(firstdestination) > range) {
@@ -504,7 +504,7 @@ public class WaterManipulation {
 		}
 		if (FreezeMelt.frozenblocks.containsKey(block))
 			FreezeMelt.frozenblocks.remove(block);
-		block.setType(Material.WATER);
+		block.setType(Material.STATIONARY_WATER);
 		block.setData(full);
 	}
 
@@ -526,7 +526,7 @@ public class WaterManipulation {
 					&& EarthMethods.isTransparentToEarthbending(player, eyeloc.getBlock())) {
 
 				if (getTargetLocation(player).distance(block.getLocation()) > 1) {
-					block.setType(Material.WATER);
+					block.setType(Material.STATIONARY_WATER);
 					block.setData(full);
 					WaterManipulation watermanip = new WaterManipulation(player);
 					watermanip.moveWater();


### PR DESCRIPTION
Fixed WaterArms causing flooding, a more thorough version of Runefist's fix.
Attempted to fix the WaterManipulation water being left on occasion, some blocks may be left but it's far less than it used to be.