### PR TITLE
Re-added Sandspout and IceBlast fixes

### DIFF
--- a/src/com/projectkorra/ProjectKorra/Ability/AbilityModuleManager.java
+++ b/src/com/projectkorra/ProjectKorra/Ability/AbilityModuleManager.java
@@ -156,15 +156,18 @@ public class AbilityModuleManager {
 					if (a == StockAbilities.LavaFlow) shiftabilities.add(a.name());
 					if (a == StockAbilities.MetalClips) shiftabilities.add(a.name());
 					if (a == StockAbilities.EarthSmash) shiftabilities.add(a.name());
+					if (a == StockAbilities.SandSpout) shiftabilities.add(a.name());
 					
 					// Earth Sub Abilities
 					if (a == StockAbilities.MetalClips) subabilities.add(a.name());
 					if (a == StockAbilities.Extraction) subabilities.add(a.name());
 					if (a == StockAbilities.LavaFlow) subabilities.add(a.name());
+					if (a == StockAbilities.SandSpout) subabilities.add(a.name());
 					
 					if (a == StockAbilities.MetalClips) metalabilities.add(a.name());
 					if (a == StockAbilities.Extraction) metalabilities.add(a.name());
 					if (a == StockAbilities.LavaFlow) lavaabilities.add(a.name());
+					if (a == StockAbilities.SandSpout) sandabilities.add(a.name());
 //					if (a == StockAbilities.LavaSurge) earthsubabilities.add(a.name());
 					
 				}

--- a/src/com/projectkorra/ProjectKorra/Ability/StockAbilities.java
+++ b/src/com/projectkorra/ProjectKorra/Ability/StockAbilities.java
@@ -18,7 +18,7 @@ public enum StockAbilities {
 	AvatarState,
 
 	// Project Korra
-	Extraction, MetalClips, Smokescreen, Combustion, LavaFlow, Suffocate, IceBlast, WarriorStance, AcrobatStance, QuickStrike, SwiftKick, EarthSmash, Flight, WaterArms;
+	Extraction, MetalClips, Smokescreen, Combustion, LavaFlow, Suffocate, IceBlast, WarriorStance, AcrobatStance, QuickStrike, SwiftKick, EarthSmash, Flight, WaterArms, SandSpout;
 
 	private enum AirbendingAbilities {
 		AirBlast, AirBubble, AirShield, AirSuction, AirSwipe, Tornado, AirScooter, AirSpout, AirBurst, Suffocate, Flight;
@@ -30,7 +30,7 @@ public enum StockAbilities {
 	}
 
 	private enum EarthbendingAbilities {
-		Catapult, RaiseEarth, EarthGrab, EarthTunnel, EarthBlast, Collapse, Tremorsense, EarthArmor, Shockwave, Extraction, MetalClips, LavaFlow, EarthSmash;
+		Catapult, RaiseEarth, EarthGrab, EarthTunnel, EarthBlast, Collapse, Tremorsense, EarthArmor, Shockwave, Extraction, MetalClips, LavaFlow, EarthSmash, SandSpout;
 	}
 
 	private enum FirebendingAbilities {
@@ -73,7 +73,7 @@ public enum StockAbilities {
 	
 	private enum SandbendingAbilities
 	{
-		;
+		SandSpout;
 	}
 	
 	private enum HealingAbilities

--- a/src/com/projectkorra/ProjectKorra/Flight.java
+++ b/src/com/projectkorra/ProjectKorra/Flight.java
@@ -11,6 +11,7 @@ import com.projectkorra.ProjectKorra.airbending.AirScooter;
 import com.projectkorra.ProjectKorra.airbending.AirSpout;
 import com.projectkorra.ProjectKorra.airbending.Tornado;
 import com.projectkorra.ProjectKorra.earthbending.Catapult;
+import com.projectkorra.ProjectKorra.earthbending.SandSpout;
 import com.projectkorra.ProjectKorra.firebending.FireJet;
 import com.projectkorra.ProjectKorra.waterbending.Bloodbending;
 import com.projectkorra.ProjectKorra.waterbending.WaterSpout;
@@ -81,6 +82,7 @@ public class Flight {
 		ArrayList<Player> airscooterplayers = new ArrayList<Player>();
 		ArrayList<Player> waterspoutplayers = new ArrayList<Player>();
 		ArrayList<Player> airspoutplayers = new ArrayList<Player>();
+		ArrayList<Player> sandspoutplayers = new ArrayList<Player>();
 
 		players.addAll(Tornado.getPlayers());
 //		players.addAll(Speed.getPlayers());
@@ -90,13 +92,15 @@ public class Flight {
 		airscooterplayers = AirScooter.getPlayers();
 		waterspoutplayers = WaterSpout.getPlayers();
 		airspoutplayers = AirSpout.getPlayers();
+		sandspoutplayers = SandSpout.getPlayers();
 
 		for (Player player : instances.keySet()) {
 			Flight flight = instances.get(player);
 			if (avatarstateplayers.contains(player)
 					|| airscooterplayers.contains(player)
 					|| waterspoutplayers.contains(player)
-					|| airspoutplayers.contains(player)) {
+					|| airspoutplayers.contains(player) 
+					|| sandspoutplayers.contains(player)) {
 				continue;
 			}
 			if (Bloodbending.isBloodbended(player)) {

--- a/src/com/projectkorra/ProjectKorra/PKListener.java
+++ b/src/com/projectkorra/ProjectKorra/PKListener.java
@@ -109,6 +109,7 @@ import com.projectkorra.ProjectKorra.earthbending.LavaFlow.AbilityType;
 import com.projectkorra.ProjectKorra.earthbending.LavaSurge;
 import com.projectkorra.ProjectKorra.earthbending.LavaWave;
 import com.projectkorra.ProjectKorra.earthbending.MetalClips;
+import com.projectkorra.ProjectKorra.earthbending.SandSpout;
 import com.projectkorra.ProjectKorra.earthbending.Shockwave;
 import com.projectkorra.ProjectKorra.earthbending.Tremorsense;
 import com.projectkorra.ProjectKorra.firebending.ArcOfFire;
@@ -366,7 +367,7 @@ public class PKListener implements Listener {
         if (player.getGameMode() != GameMode.CREATIVE) {
             HashMap<Integer, String> bound = GeneralMethods.getBendingPlayer(player.getName()).getAbilities();
             for (String str : bound.values()) {
-                if (str.equalsIgnoreCase("AirSpout") || str.equalsIgnoreCase("WaterSpout")) {
+                if (str.equalsIgnoreCase("AirSpout") || str.equalsIgnoreCase("WaterSpout") || str.equalsIgnoreCase("SandSpout")) {
                     final Player fplayer = player;
                     new BukkitRunnable() {
                         public void run() {
@@ -645,7 +646,7 @@ public class PKListener implements Listener {
 			}
 		}
 
-		if (WaterSpout.instances.containsKey(event.getPlayer()) || AirSpout.getPlayers().contains(event.getPlayer())) {
+		if (WaterSpout.instances.containsKey(event.getPlayer()) || AirSpout.getPlayers().contains(event.getPlayer()) || SandSpout.getPlayers().contains(event.getPlayer())) {
 			Vector vel = new Vector();
 			vel.setX(event.getTo().getX() - event.getFrom().getX());
 			vel.setY(event.getTo().getY() - event.getFrom().getY());
@@ -962,6 +963,10 @@ public class PKListener implements Listener {
 				
 				if (abil.equalsIgnoreCase("EarthSmash")) {
 					new EarthSmash(player, ClickType.LEFT_CLICK);
+				}
+				
+				if (abil.equalsIgnoreCase("SandSpout")) {
+					new SandSpout(player);
 				}
 			}
 			if (FireMethods.isFireAbility(abil)) {

--- a/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
@@ -356,6 +356,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.IceBlast.Enabled", true);
 			config.addDefault("Abilities.Water.IceBlast.Damage", 3);
 			config.addDefault("Abilities.Water.IceBlast.Range", 20);
+			config.addDefault("Abilities.Water.IceBlast.Cooldown", 1500);
 			config.addDefault("Abilities.Water.IceBlast.Description", "This ability offers a powerful ice utility for Waterbenders. It can be used to fire an explosive burst of ice at an opponent, spraying ice and snow around it. To use, simply tap sneak (Default: Shift) while targeting a block of ice to select it as a source. From there, you can just left click to send the blast off at your opponent.");
 
 			config.addDefault("Abilities.Water.IceSpike.Enabled", true);
@@ -675,6 +676,12 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.Shockwave.Damage", 5);
 			config.addDefault("Abilities.Earth.Shockwave.Knockback", 1.1);
 			config.addDefault("Abilities.Earth.Shockwave.Range", 15);
+			
+			config.addDefault("Abilities.Earth.SandSpout.Enabled", true);
+			config.addDefault("Abilities.Earth.SandSpout.Description", "SandSpout is a core move for travelling, evasion, and mobility for sandbenders. To use, simply left click while over sand or sandstone, and a column of sand will form at your feet, enabling you to levitate. Any mobs or players that touch your column will receive damage and be blinded. Beware, as the spout will stop working when no longer over sand!");
+			config.addDefault("Abilities.Earth.SandSpout.Height", 7);
+			config.addDefault("Abilities.Earth.SandSpout.BlindnessTime", 10);
+			config.addDefault("Abilities.Earth.SandSpout.SpoutDamage", 1);
 
 			config.addDefault("Abilities.Earth.Tremorsense.Enabled", true);
 			config.addDefault("Abilities.Earth.Tremorsense.Description", "This is a pure utility ability for earthbenders. If you are in an area of low-light and are standing on top of an earthbendable block, this ability will automatically turn that block into glowstone, visible *only by you*. If you lose contact with a bendable block, the light will go out as you have lost contact with the earth and cannot 'see' until you can touch earth again. Additionally, if you click with this ability selected, smoke will appear above nearby earth with pockets of air beneath them.");

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthMethods.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthMethods.java
@@ -26,6 +26,7 @@ import com.projectkorra.ProjectKorra.ProjectKorra;
 import com.projectkorra.ProjectKorra.TempBlock;
 import com.projectkorra.ProjectKorra.Ability.AbilityModuleManager;
 import com.projectkorra.ProjectKorra.Utilities.BlockSource;
+import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 
 public class EarthMethods {
 	
@@ -92,6 +93,18 @@ public class EarthMethods {
 	 */
 	public static boolean canLavabend(Player player) {
 		return player.hasPermission("bending.earth.lavabending");
+	}
+	
+	public static void displaySandParticle(Location loc, float xOffset, float yOffset, float zOffset, float amount, float speed) {
+		if(amount <= 0)
+			return;
+		
+		for(int x = 0; x < amount; x++){
+			
+			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte)0), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
+			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SANDSTONE, (byte)0), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
+		
+		}
 	}
 	
 	/**
@@ -507,6 +520,12 @@ public class EarthMethods {
 		} else {
 			target.setType(info.getState().getType());
 			target.setData(info.getState().getRawData());
+		}
+	}
+	
+	public static void playSandBendingSound(Location loc) {
+		if (plugin.getConfig().getBoolean("Properties.Earth.PlaySound")) {
+			loc.getWorld().playSound(loc, Sound.DIG_SAND, 1.5f, 5);
 		}
 	}
 	

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthbendingManager.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthbendingManager.java
@@ -31,6 +31,7 @@ public class EarthbendingManager implements Runnable {
 			LavaSurge.progressAll();
 			LavaFlow.progressAll();
 			EarthSmash.progressAll();
+			SandSpout.spoutAll();
 		} catch (Exception e) {
 			GeneralMethods.logError(e, false);
 		}

--- a/src/com/projectkorra/ProjectKorra/earthbending/SandSpout.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/SandSpout.java
@@ -1,0 +1,205 @@
+package com.projectkorra.ProjectKorra.earthbending;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import com.projectkorra.ProjectKorra.Flight;
+import com.projectkorra.ProjectKorra.GeneralMethods;
+import com.projectkorra.ProjectKorra.ProjectKorra;
+
+public class SandSpout {
+
+	public static ConcurrentHashMap<Player, SandSpout> instances = new ConcurrentHashMap<Player, SandSpout>();
+
+	private static final double HEIGHT = ProjectKorra.plugin.getConfig().getDouble("Abilities.Earth.SandSpout.Height");
+	private static final int BTIME = ProjectKorra.plugin.getConfig().getInt("Abilities.Earth.SandSpout.BlindnessTime");
+	private static final int SPOUTDAMAGE = ProjectKorra.plugin.getConfig().getInt("Abilities.Earth.SandSpout.SpoutDamage");
+	private static final long interval = 100;
+
+	private Player player;
+	private long time;
+	private int angle = 0;
+	private double height = HEIGHT;
+	private int bTime = BTIME;
+	private double spoutDamage = SPOUTDAMAGE;
+
+	public SandSpout(Player player) {
+
+		if (instances.containsKey(player)) {
+			instances.get(player).remove();
+			return;
+		}
+		this.player = player;
+		time = System.currentTimeMillis();
+		Block topBlock = GeneralMethods.getTopBlock(player.getLocation(), 0, -50);
+		if(topBlock == null)
+			topBlock = player.getLocation().getBlock();
+		Material mat = topBlock.getType();
+		if(mat != Material.SAND && mat != Material.SANDSTONE)
+			return;
+		new Flight(player);
+		instances.put(player, this);
+		spout();
+	}
+
+	public static void spoutAll() {
+		for (Player player : instances.keySet()) {
+			instances.get(player).spout();
+		}
+	}
+
+	public static ArrayList<Player> getPlayers() {
+		ArrayList<Player> players = new ArrayList<Player>();
+		players.addAll(instances.keySet());
+		return players;
+	}
+
+	private void spout() {
+		if (!GeneralMethods.canBend(player.getName(), "SandSpout")
+//				|| !Methods.hasAbility(player, Abilities.SandSpout)
+				|| player.getEyeLocation().getBlock().isLiquid()
+				|| GeneralMethods.isSolid(player.getEyeLocation().getBlock())
+				|| player.isDead() || !player.isOnline()) {
+			remove();
+			return;
+		}
+		player.setFallDistance(0);
+		player.setSprinting(false);
+		if (GeneralMethods.rand.nextInt(2) == 0) {
+			EarthMethods.playSandBendingSound(player.getLocation());
+		}
+		Block block = getGround();
+		if (block != null && (block.getType() == Material.SAND || block.getType() == Material.SANDSTONE)) {
+			double dy = player.getLocation().getY() - block.getY();
+			if (dy > height) {
+				removeFlight();
+			} else {
+				allowFlight();
+			}
+			rotateSandColumn(block);
+		} else {
+			remove();
+		}
+	}
+
+	private void allowFlight() {
+		player.setAllowFlight(true);
+		player.setFlying(true);
+		player.setFlySpeed(.05f);
+	}
+
+	private void removeFlight() {
+		player.setAllowFlight(false);
+		player.setFlying(false);
+	}
+
+	private Block getGround() {
+		Block standingblock = player.getLocation().getBlock();
+		for (int i = 0; i <= height + 5; i++) {
+			Block block = standingblock.getRelative(BlockFace.DOWN, i);
+			if (GeneralMethods.isSolid(block) || block.isLiquid()) {
+				return block;
+			}
+		}
+		return null;
+	}
+
+	private void rotateSandColumn(Block block) {
+
+		if (System.currentTimeMillis() >= time + interval) {
+			time = System.currentTimeMillis();
+
+			Location location = block.getLocation();
+			Location playerloc = player.getLocation();
+			location = new Location(location.getWorld(), playerloc.getX(),
+					location.getY(), playerloc.getZ());
+
+			double dy = playerloc.getY() - block.getY();
+			if (dy > height)
+				dy = height;
+			Integer[] directions = { 0, 1, 2, 3, 5, 6, 7, 8 };
+			int index = angle;
+
+			angle++;
+			if (angle >= directions.length)
+				angle = 0;
+			for (int i = 1; i <= dy; i++) {
+
+				index += 1;
+				if (index >= directions.length)
+					index = 0;
+
+				Location effectloc2 = new Location(location.getWorld(),
+						location.getX(), block.getY() + i, location.getZ());
+
+				EarthMethods.displaySandParticle(effectloc2,2f,3f,2f,40,.2f);
+				
+				Collection<Player> players = GeneralMethods.getPlayersAroundPoint(effectloc2, 1.5f);
+				if(!players.isEmpty())
+					for(Player sPlayer: players){
+						if(!sPlayer.equals(player)){
+							sPlayer.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, bTime*20, 1));
+							GeneralMethods.damageEntity(player, sPlayer, spoutDamage);
+						}
+					}
+			}
+		}
+	}
+
+	public static boolean removeSpouts(Location loc0, double radius,
+			Player sourceplayer) {
+		boolean removed = false;
+		for (Player player : instances.keySet()) {
+			if (!player.equals(sourceplayer)) {
+				Location loc1 = player.getLocation().getBlock().getLocation();
+				loc0 = loc0.getBlock().getLocation();
+				double dx = loc1.getX() - loc0.getX();
+				double dy = loc1.getY() - loc0.getY();
+				double dz = loc1.getZ() - loc0.getZ();
+
+				double distance = Math.sqrt(dx * dx + dz * dz);
+
+				if (distance <= radius && dy > 0 && dy < HEIGHT){
+					instances.get(player).remove();
+					removed = true;
+				}
+			}
+		}
+		return removed;
+	}
+
+	private void remove() {
+		removeFlight();
+		player.setFlySpeed(.1f);
+		instances.remove(player);
+	}
+
+	public static void removeAll() {
+		for (Player player : instances.keySet()) {
+			instances.get(player).remove();
+		}
+	}
+
+	public Player getPlayer() {
+		return player;
+	}
+
+	public double getHeight() {
+		return height;
+	}
+
+	public void setHeight(double height) {
+		this.height = height;
+	}
+
+}

--- a/src/com/projectkorra/ProjectKorra/waterbending/IceBlast.java
+++ b/src/com/projectkorra/ProjectKorra/waterbending/IceBlast.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -29,6 +30,7 @@ public class IceBlast {
 	public static ConcurrentHashMap<Integer, IceBlast> instances = new ConcurrentHashMap<Integer, IceBlast>();
 	private static double defaultrange = ProjectKorra.plugin.getConfig().getDouble("Abilities.Water.IceBlast.Range");
 	private static int DAMAGE = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.IceBlast.Damage");
+	private static int COOLDOWN = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.IceBlast.Cooldown");
 	private static int ID = Integer.MIN_VALUE;
 	
 	private static final long interval = 20;
@@ -49,10 +51,16 @@ public class IceBlast {
 	private Player player;
 	public TempBlock source;
 	private double defaultdamage = DAMAGE;
+	private long cooldown = COOLDOWN;
 	
 	public IceBlast(Player player) {
 		if(!WaterMethods.canIcebend(player))
 			return;
+		BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
+		if(bPlayer.isOnCooldown("IceBlast")) {
+			return;
+		}
+		
 		
 		block(player);
 		range = WaterMethods.waterbendingNightAugment(defaultrange, player.getWorld());
@@ -74,10 +82,12 @@ public class IceBlast {
 				ice.cancel();
 			}
 		}
+
 		sourceblock = block;
 		location = sourceblock.getLocation();
 		prepared = true;
-		createInstance();
+		if(getInstances(player).isEmpty())
+			createInstance();
 	}
 	
 	private void createInstance() {
@@ -148,7 +158,8 @@ public class IceBlast {
 				source.revertBlock();
 			progressing = false;
 		}
-
+		BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
+		bPlayer.addCooldown("IceBlast", cooldown);
 		instances.remove(id);
 	}
 	
@@ -181,8 +192,8 @@ public class IceBlast {
 		}
 		AirMethods.breakBreathbendingHold(entity);
 		
-		for(Location loc : GeneralMethods.getCircle(entity.getLocation(), 6, 7, false, false, 0)) {
-			ParticleEffect.SNOW_SHOVEL.display(loc, (float) Math.random(), (float) Math.random(), (float) Math.random(), 0, 10);
+		for(int x = 0; x < 30; x++) {
+			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte)0), new Vector(((Math.random()-0.5)*.5), ((Math.random() - 0.5)*.5), ((Math.random() - 0.5)*.5)), .3f, location, 257.0D);
 		}
 	}
 	
@@ -216,7 +227,8 @@ public class IceBlast {
 	}
 	
 	private void progress() {
-		if (player.isDead() || !player.isOnline() || !GeneralMethods.canBend(player.getName(), "IceBlast")) {
+		BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
+		if (player.isDead() || !player.isOnline() || !GeneralMethods.canBend(player.getName(), "IceBlast") || bPlayer.isOnCooldown("IceBlast")) {
 			cancel();
 			return;
 		}
@@ -228,9 +240,11 @@ public class IceBlast {
 
 		if (player.getEyeLocation().distance(location) >= range) {
 			if (progressing) {
+				breakParticles(20);
 				cancel();
 				returnWater();
 			} else {
+				breakParticles(20);
 				cancel();
 			}
 			return;
@@ -278,6 +292,7 @@ public class IceBlast {
 			if (EarthMethods.isTransparentToEarthbending(player, block) && !block.isLiquid()) {
 				GeneralMethods.breakBlock(block);
 			} else if (!WaterMethods.isWater(block)) {
+				breakParticles(20);
 				cancel();
 				returnWater();
 				return;
@@ -305,8 +320,10 @@ public class IceBlast {
 			sourceblock = block;
 			source = new TempBlock(sourceblock, Material.PACKED_ICE, data);
 			
-			ParticleEffect.SNOWBALL_POOF.display(location, (float) Math.random(), (float) Math.random(), (float) Math.random(), 0, 100);
-			ParticleEffect.SNOW_SHOVEL.display(location, (float) Math.random(), (float) Math.random(), (float) Math.random(), 0, 100);
+			for(int x = 0; x < 10; x++) {
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte)0), new Vector(((Math.random()-0.5)*.5), ((Math.random() - 0.5)*.5), ((Math.random() - 0.5)*.5)), .5f, location, 257.0D);
+				ParticleEffect.SNOW_SHOVEL.display(location, (float) (Math.random()-0.5), (float) (Math.random()-0.5), (float) (Math.random()-0.5), 0, 5);
+			}
 			if (GeneralMethods.rand.nextInt(4) == 0) {
 				WaterMethods.playIcebendingSound(location);
 			}
@@ -341,6 +358,15 @@ public class IceBlast {
 
 	public void setRange(double range) {
 		this.range = range;
+		
+	}
+
+	public void breakParticles(int amount) {
+		for(int x = 0; x < amount; x++) {
+			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte)0), new Vector(((Math.random()-0.5)*.5), ((Math.random() - 0.5)*.5), ((Math.random() - 0.5)*.5)), 2f, location, 257.0D);
+			ParticleEffect.SNOW_SHOVEL.display(location, (float) Math.random(), (float) Math.random(), (float) Math.random(), 0, 2);
+		}
+			location.getWorld().playSound(location, Sound.GLASS, 5, 1.3f);
 	}
 
 }

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -130,6 +130,7 @@ permissions:
       bending.ability.LavaSurge: true
       bending.ability.LavaFlow: true
       bending.ability.EarthSmash: true
+      bending.ability.SandSpout: true
   bending.fire:
     default: true
     description: Grants access to all firebending abilities.


### PR DESCRIPTION
New sandbending move: SandSpout
Requires the user to have the sandbending subelement.
SandSpoutis slower and lower then AirSpout and WaterSpout by default.
Requires the player to be above sand/sandstone to use (like how
waterspout relies on a water source)
Any players caught in the spout will be dealt small amounts of damage
over time and will be blinded from standing in the whirlwind of sand.
Config options:
Height - Max height the spout can achieve.
BlindnessTime - How long a player will be blinded for standing in a
spout. (in seconds)
Spout Damage - How much damage the spout does over time for standing in
it.

Slight Iceblast rework
Added default cooldown of 1.5 seconds.
Iceblast is now much less laggy and looks/acts nicer.
Added an on collision sound and effect.