### PR TITLE
SandSpout + EarthMethods

### DIFF
--- a/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
@@ -682,6 +682,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.SandSpout.Height", 7);
 			config.addDefault("Abilities.Earth.SandSpout.BlindnessTime", 10);
 			config.addDefault("Abilities.Earth.SandSpout.SpoutDamage", 1);
+			config.addDefault("Abilities.Earth.SandSpout.Spiral", true);
 
 			config.addDefault("Abilities.Earth.Tremorsense.Enabled", true);
 			config.addDefault("Abilities.Earth.Tremorsense.Description", "This is a pure utility ability for earthbenders. If you are in an area of low-light and are standing on top of an earthbendable block, this ability will automatically turn that block into glowstone, visible *only by you*. If you lose contact with a bendable block, the light will go out as you have lost contact with the earth and cannot 'see' until you can touch earth again. Additionally, if you click with this ability selected, smoke will appear above nearby earth with pockets of air beneath them.");

--- a/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
@@ -517,6 +517,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.WaterCombo.IceBullet.Cooldown", 10000);
 
 			config.addDefault("Abilities.Earth.Passive.Duration", 2500);
+			config.addDefault("Properties.Earth.Passive.SandRunPower", 1);
 
 			config.addDefault("Abilities.Earth.Catapult.Enabled", true);
 			config.addDefault("Abilities.Earth.Catapult.Description", "To use, left-click while looking in the direction you want to be launched. "

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthMethods.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthMethods.java
@@ -95,14 +95,18 @@ public class EarthMethods {
 		return player.hasPermission("bending.earth.lavabending");
 	}
 	
-	public static void displaySandParticle(Location loc, float xOffset, float yOffset, float zOffset, float amount, float speed) {
+	public static void displaySandParticle(Location loc, float xOffset, float yOffset, float zOffset, float amount, float speed, boolean red) {
 		if(amount <= 0)
 			return;
 		
 		for(int x = 0; x < amount; x++){
-			
-			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte)0), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
-			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SANDSTONE, (byte)0), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
+			if(!red){
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte)0), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SANDSTONE, (byte)0), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
+			}else if(red){
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte)1), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.RED_SANDSTONE, (byte)0), new Vector(((Math.random()-0.5)*xOffset), ((Math.random() - 0.5)*yOffset), ((Math.random() - 0.5)*zOffset)), speed, loc, 257.0D);
+			}
 		
 		}
 	}

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthPassive.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthPassive.java
@@ -9,6 +9,8 @@ import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 import com.projectkorra.ProjectKorra.Element;
 import com.projectkorra.ProjectKorra.GeneralMethods;
@@ -21,6 +23,7 @@ public class EarthPassive {
 	public static ConcurrentHashMap<Block, Material> sandidentities = new ConcurrentHashMap<Block, Material>();
 	
 	private static final long duration = ProjectKorra.plugin.getConfig().getLong("Abilities.Earth.Passive.Duration");
+	private static int sandspeed = ProjectKorra.plugin.getConfig().getInt("Properties.Earth.Passive.SandRunPower");
 
 	public static boolean softenLanding(Player player) {
 		Block block = player.getLocation().getBlock().getRelative(BlockFace.DOWN);
@@ -73,6 +76,19 @@ public class EarthPassive {
 		}
 	}
 	
+	public static void sandSpeed() {
+		for(Player p : Bukkit.getOnlinePlayers()){
+			if(EarthMethods.canSandbend(p)){
+				if(p.getLocation().getBlock().getRelative(BlockFace.DOWN).getType() == Material.SAND || 
+						p.getLocation().getBlock().getRelative(BlockFace.DOWN).getType() == Material.SANDSTONE ||
+						p.getLocation().getBlock().getRelative(BlockFace.DOWN).getType() == Material.RED_SANDSTONE){
+					p.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 60, sandspeed - 1));
+				}
+			}
+		}
+	}
+	
+	@SuppressWarnings("deprecation")
 	public static void handleMetalPassives() {
 		for (Player player: Bukkit.getOnlinePlayers()) {
 			if (GeneralMethods.canBendPassive(player.getName(), Element.Earth) && EarthMethods.canMetalbend(player)) {

--- a/src/com/projectkorra/ProjectKorra/earthbending/EarthbendingManager.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/EarthbendingManager.java
@@ -16,6 +16,7 @@ public class EarthbendingManager implements Runnable {
 	public void run() {
 		EarthPassive.revertSands();
 		EarthPassive.handleMetalPassives();
+		EarthPassive.sandSpeed();
 		RevertChecker.revertEarthBlocks();
 		EarthTunnel.progressAll();
 		EarthArmor.moveArmorAll();

--- a/src/com/projectkorra/ProjectKorra/earthbending/SandSpout.java
+++ b/src/com/projectkorra/ProjectKorra/earthbending/SandSpout.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -24,6 +23,7 @@ public class SandSpout {
 	private static final double HEIGHT = ProjectKorra.plugin.getConfig().getDouble("Abilities.Earth.SandSpout.Height");
 	private static final int BTIME = ProjectKorra.plugin.getConfig().getInt("Abilities.Earth.SandSpout.BlindnessTime");
 	private static final int SPOUTDAMAGE = ProjectKorra.plugin.getConfig().getInt("Abilities.Earth.SandSpout.SpoutDamage");
+	private static final boolean SPIRAL = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Earth.SandSpout.Spiral");
 	private static final long interval = 100;
 
 	private Player player;
@@ -32,6 +32,7 @@ public class SandSpout {
 	private double height = HEIGHT;
 	private int bTime = BTIME;
 	private double spoutDamage = SPOUTDAMAGE;
+	private double y = 0D;
 
 	public SandSpout(Player player) {
 
@@ -45,7 +46,7 @@ public class SandSpout {
 		if(topBlock == null)
 			topBlock = player.getLocation().getBlock();
 		Material mat = topBlock.getType();
-		if(mat != Material.SAND && mat != Material.SANDSTONE)
+		if(mat != Material.SAND && mat != Material.SANDSTONE && mat != Material.RED_SANDSTONE)
 			return;
 		new Flight(player);
 		instances.put(player, this);
@@ -79,7 +80,7 @@ public class SandSpout {
 			EarthMethods.playSandBendingSound(player.getLocation());
 		}
 		Block block = getGround();
-		if (block != null && (block.getType() == Material.SAND || block.getType() == Material.SANDSTONE)) {
+		if (block != null && (block.getType() == Material.SAND || block.getType() == Material.SANDSTONE || block.getType() == Material.RED_SANDSTONE)) {
 			double dy = player.getLocation().getY() - block.getY();
 			if (dy > height) {
 				removeFlight();
@@ -114,6 +115,7 @@ public class SandSpout {
 		return null;
 	}
 
+	@SuppressWarnings("deprecation")
 	private void rotateSandColumn(Block block) {
 
 		if (System.currentTimeMillis() >= time + interval) {
@@ -141,8 +143,15 @@ public class SandSpout {
 
 				Location effectloc2 = new Location(location.getWorld(),
 						location.getX(), block.getY() + i, location.getZ());
-
-				EarthMethods.displaySandParticle(effectloc2,2f,3f,2f,40,.2f);
+				
+				if(SPIRAL){
+					displayHelix(block.getLocation(), this.player.getLocation(), block);
+				}
+				if (block != null && ((block.getType() == Material.SAND && block.getData() == (byte)0) || block.getType() == Material.SANDSTONE)) {
+					EarthMethods.displaySandParticle(effectloc2, 1f ,3f ,1f , 20, .2f, false);
+				}else if (block != null && ((block.getType() == Material.SAND && block.getData() == (byte)1) || block.getType() == Material.RED_SANDSTONE)) {
+					EarthMethods.displaySandParticle(effectloc2, 1f ,3f ,1f , 20, .2f, true);
+				}
 				
 				Collection<Player> players = GeneralMethods.getPlayersAroundPoint(effectloc2, 1.5f);
 				if(!players.isEmpty())
@@ -153,6 +162,31 @@ public class SandSpout {
 						}
 					}
 			}
+		}
+	}
+
+	@SuppressWarnings("deprecation")
+	private void displayHelix(Location location, Location player, Block block) {
+		// TODO Auto-generated method stub
+		//double radius = 1.5;
+		this.y += 0.1;
+		if(this.y >= player.getY() - location.getY()){
+			this.y = 0D;
+		}
+			for(int points = 0; points <= 5; points++){
+				double x = Math.cos(y);
+				double z = Math.sin(y);
+				double nx = x * -1;
+				double nz = z * -1;
+				Location newloc = new Location(player.getWorld(), location.getX() + x, location.getY() + y, location.getZ() + z);
+				Location secondloc = new Location(player.getWorld(), location.getX() + nx, location.getY() + y, location.getZ() + nz);
+				if (block != null && ((block.getType() == Material.SAND && block.getData() == (byte)0) || block.getType() == Material.SANDSTONE)) {
+					EarthMethods.displaySandParticle(newloc.add(0.5, 0.5, 0.5), 0.1F, 0.1F, 0.1F, 2, 1, false);
+		        	EarthMethods.displaySandParticle(secondloc.add(0.5, 0.5, 0.5), 0.1F, 0.1F, 0.1F, 2, 1, false);
+				}else if (block != null && ((block.getType() == Material.SAND && block.getData() == (byte)1) || block.getType() == Material.RED_SANDSTONE)) {
+					EarthMethods.displaySandParticle(newloc.add(0.5, 0.5, 0.5), 0.1F, 0.1F, 0.1F, 2, 1, true);
+		        	EarthMethods.displaySandParticle(secondloc.add(0.5, 0.5, 0.5), 0.1F, 0.1F, 0.1F, 2, 1, true);
+				}
 		}
 	}
 


### PR DESCRIPTION
Added a spiral to the SandSpout ability, which can be turned on and off in the config file. The option can be found at "spiral" under SandSpout. Also added a boolean to the .displaySandParticle method. If set to true, it will spawn red sand and red sandstone particles instead of the normal yellow ones.