### PR TITLE
[BUGFIX] Remove extra code, Update reloadPlugin(), stopPlugin()

### DIFF
--- a/src/com/projectkorra/ProjectKorra/DBConnection.java
+++ b/src/com/projectkorra/ProjectKorra/DBConnection.java
@@ -20,7 +20,7 @@ public class DBConnection {
 			sql = new MySQL(ProjectKorra.log, "[ProjectKorra] Establishing MySQL Connection...", host, port, user, pass, db);
 			if (((MySQL) sql).open() == null) {
 				ProjectKorra.log.severe("Disabling due to database error");
-				ProjectKorra.plugin.stopPlugin();
+				GeneralMethods.stopPlugin();
 				return;
 			}
             
@@ -70,7 +70,7 @@ public class DBConnection {
 			sql = new SQLite(ProjectKorra.log, "[ProjectKorra] Establishing SQLite Connection.", "projectkorra.db", ProjectKorra.plugin.getDataFolder().getAbsolutePath());
 			if (((SQLite) sql).open() == null) {
 				ProjectKorra.log.severe("Disabling due to database error");
-				ProjectKorra.plugin.stopPlugin();
+				GeneralMethods.stopPlugin();
 				return;
 			}
 

--- a/src/com/projectkorra/ProjectKorra/GeneralMethods.java
+++ b/src/com/projectkorra/ProjectKorra/GeneralMethods.java
@@ -83,8 +83,10 @@ import com.projectkorra.ProjectKorra.Ability.AbilityModuleManager;
 import com.projectkorra.ProjectKorra.Ability.StockAbilities;
 import com.projectkorra.ProjectKorra.Ability.Combo.ComboAbilityModule;
 import com.projectkorra.ProjectKorra.Ability.Combo.ComboModuleManager;
+import com.projectkorra.ProjectKorra.Ability.MultiAbility.MultiAbilityModuleManager;
 import com.projectkorra.ProjectKorra.CustomEvents.BendingReloadEvent;
 import com.projectkorra.ProjectKorra.CustomEvents.PlayerBendingDeathEvent;
+import com.projectkorra.ProjectKorra.Objects.Preset;
 import com.projectkorra.ProjectKorra.Utilities.ParticleEffect;
 import com.projectkorra.ProjectKorra.airbending.AirCombo;
 import com.projectkorra.ProjectKorra.airbending.AirMethods;
@@ -1437,22 +1439,33 @@ public class GeneralMethods {
 	}
 
 	public static void reloadPlugin() {
-		DBConnection.sql.close();
-		ConfigManager.defaultConfig.reloadConfig();
-		ConfigManager.deathMsgConfig.reloadConfig();
-		GeneralMethods.stopBending();
+		ProjectKorra.log.info("Reloading ProjectKorra and configuration");
 		BendingReloadEvent event = new BendingReloadEvent();
 		Bukkit.getServer().getPluginManager().callEvent(event);
+		if (DBConnection.isOpen != false) {
+			DBConnection.sql.close();
+		}
+		GeneralMethods.stopBending();
+		ConfigManager.defaultConfig.reloadConfig();
+		ConfigManager.deathMsgConfig.reloadConfig();
 		new AbilityModuleManager(plugin);
+		new MultiAbilityModuleManager();
 		DBConnection.host = plugin.getConfig().getString("Storage.MySQL.host");
 		DBConnection.port = plugin.getConfig().getInt("Storage.MySQL.port");
 		DBConnection.pass = plugin.getConfig().getString("Storage.MySQL.pass");
 		DBConnection.db = plugin.getConfig().getString("Storage.MySQL.db");
 		DBConnection.user = plugin.getConfig().getString("Storage.MySQL.user");
 		DBConnection.init();
+		if (DBConnection.isOpen() == false) {
+			ProjectKorra.log.severe("Unable to enable ProjectKorra due to the database not being open");
+			stopPlugin();
+		}
 		for (Player player: Bukkit.getOnlinePlayers()) {
 			GeneralMethods.createBendingPlayer(player.getUniqueId(), player.getName());
+			Preset.loadPresets(player);
 		}
+		plugin.updater.checkUpdate();
+		ProjectKorra.log.info("Reload complete");
 	}
 
 	public static void removeBlock(Block block) {

--- a/src/com/projectkorra/ProjectKorra/GeneralMethods.java
+++ b/src/com/projectkorra/ProjectKorra/GeneralMethods.java
@@ -1691,6 +1691,10 @@ public class GeneralMethods {
 		TempBlock.removeAll();
 		MultiAbilityManager.removeAll();
 	}
+	
+	public static void stopPlugin() {
+		plugin.getServer().getPluginManager().disablePlugin(plugin);
+	}
 
 	public static void writeToDebug(String message) {
 		try {

--- a/src/com/projectkorra/ProjectKorra/ProjectKorra.java
+++ b/src/com/projectkorra/ProjectKorra/ProjectKorra.java
@@ -64,7 +64,7 @@ public class ProjectKorra extends JavaPlugin {
 		DBConnection.user = getConfig().getString("Storage.MySQL.user");
 		DBConnection.init();
 		if (DBConnection.isOpen() == false) {
-			//TODO: Log a proper message displaying database problem, pk will not function
+			//Message is logged by DBConnection
 			return;
 		}
 
@@ -103,7 +103,4 @@ public class ProjectKorra extends JavaPlugin {
 		handler.close();
 	}
 	
-	public void stopPlugin() {
-		getServer().getPluginManager().disablePlugin(plugin);
-	}
 }

--- a/src/com/projectkorra/ProjectKorra/Utilities/Updater.java
+++ b/src/com/projectkorra/ProjectKorra/Utilities/Updater.java
@@ -75,7 +75,7 @@ public class Updater {
 			plugin.getLogger().info("You are running version " + getCurrentVersion());
 			plugin.getLogger().info("The latest version avaliable is " + getUpdateVersion());
 		} else {
-			plugin.getLogger().info("You are running the latest version of" + pluginName);
+			plugin.getLogger().info("You are running the latest version of " + pluginName);
 		}
 	}
 	

--- a/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/ProjectKorra/configuration/ConfigManager.java
@@ -67,7 +67,6 @@ public class ConfigManager {
 			config.addDefault("Chi.RapidPunch", "{victim} took all the hits against {attacker}'s {ability}");
 			config.addDefault("Chi.ChiCombo", "{victim} was overwhelmed by {attacker}'s skill {ability}");
 			
-			config.options().copyDefaults(true);
 			deathMsgConfig.saveConfig();
 			break;
 		case DEFAULT:
@@ -912,7 +911,6 @@ public class ConfigManager {
 
 			config.addDefault("debug", false);
 			
-			config.options().copyDefaults(true);
 			defaultConfig.saveConfig();
 			break;
 		}


### PR DESCRIPTION
* Remove config.options().copyDefaults(true); since it is already called when config.saveConfig() is called
* Fix spacing error in Updater
* Updated reloadPlugin()
  * Now attempts to reload everything in the correct order
  * Has safety checks where necessary and will disable the plugin upon failure
  * Logs reloading messages
  * Now reloads Presets
  * Checks for update upon reload
  * Generates a BendingReloadEvent upon the call of the method (was in an incorrect position before)
  * Now reloads MultiAbilities
* Moved stopPlugin() to GeneralMethods and made it static