### PR TITLE
Fix EarthBlast using blocks outside range

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
@@ -74,6 +74,9 @@ public class EarthBlast {
 		Block block = BlockSource.getEarthSourceBlock(player, range, ClickType.SHIFT_DOWN);
 		block(player);
 		if (block != null) {
+			if (block.getLocation().distance(player.getLocation()) > preparerange) {
+				return false;
+			}
 			sourceblock = block;
 			focusBlock();
 			return true;


### PR DESCRIPTION
Dynamic sourcing allowed earthblast to use blocks outside the prepare
range as a source