### PR TITLE
VineWhip

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1,6 +1,67 @@
 package com.projectkorra.projectkorra;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockFadeEvent;
+import org.bukkit.event.block.BlockFormEvent;
+import org.bukkit.event.block.BlockFromToEvent;
+import org.bukkit.event.block.BlockIgniteEvent;
+import org.bukkit.event.block.BlockPhysicsEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.LeavesDecayEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.entity.EntityCombustEvent;
+import org.bukkit.event.entity.EntityDamageByBlockEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.entity.EntityInteractEvent;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
+import org.bukkit.event.entity.EntityTeleportEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.entity.SlimeSplitEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerAnimationEvent;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
 import com.projectkorra.projectkorra.ability.AvatarState;
+import com.projectkorra.projectkorra.ability.api.CoreAbility;
 import com.projectkorra.projectkorra.ability.combo.ComboManager;
 import com.projectkorra.projectkorra.ability.multiability.MultiAbilityManager;
 import com.projectkorra.projectkorra.airbending.AirBlast;
@@ -41,13 +102,13 @@ import com.projectkorra.projectkorra.earthbending.EarthTunnel;
 import com.projectkorra.projectkorra.earthbending.EarthWall;
 import com.projectkorra.projectkorra.earthbending.Extraction;
 import com.projectkorra.projectkorra.earthbending.LavaFlow;
+import com.projectkorra.projectkorra.earthbending.LavaFlow.AbilityType;
 import com.projectkorra.projectkorra.earthbending.LavaSurge;
 import com.projectkorra.projectkorra.earthbending.LavaWave;
 import com.projectkorra.projectkorra.earthbending.MetalClips;
 import com.projectkorra.projectkorra.earthbending.SandSpout;
 import com.projectkorra.projectkorra.earthbending.Shockwave;
 import com.projectkorra.projectkorra.earthbending.Tremorsense;
-import com.projectkorra.projectkorra.earthbending.LavaFlow.AbilityType;
 import com.projectkorra.projectkorra.event.PlayerBendingDeathEvent;
 import com.projectkorra.projectkorra.event.PlayerGrappleEvent;
 import com.projectkorra.projectkorra.firebending.ArcOfFire;
@@ -80,7 +141,9 @@ import com.projectkorra.projectkorra.waterbending.IceSpike2;
 import com.projectkorra.projectkorra.waterbending.Melt;
 import com.projectkorra.projectkorra.waterbending.OctopusForm;
 import com.projectkorra.projectkorra.waterbending.PlantArmor;
+import com.projectkorra.projectkorra.waterbending.Plantbending;
 import com.projectkorra.projectkorra.waterbending.Torrent;
+import com.projectkorra.projectkorra.waterbending.VineWhip;
 import com.projectkorra.projectkorra.waterbending.WaterArms;
 import com.projectkorra.projectkorra.waterbending.WaterManipulation;
 import com.projectkorra.projectkorra.waterbending.WaterMethods;
@@ -89,65 +152,6 @@ import com.projectkorra.projectkorra.waterbending.WaterSpout;
 import com.projectkorra.projectkorra.waterbending.WaterWall;
 import com.projectkorra.projectkorra.waterbending.WaterWave;
 import com.projectkorra.projectkorra.waterbending.Wave;
-
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.GameMode;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Item;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
-import org.bukkit.event.block.Action;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockFadeEvent;
-import org.bukkit.event.block.BlockFormEvent;
-import org.bukkit.event.block.BlockFromToEvent;
-import org.bukkit.event.block.BlockIgniteEvent;
-import org.bukkit.event.block.BlockPhysicsEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.entity.EntityChangeBlockEvent;
-import org.bukkit.event.entity.EntityCombustEvent;
-import org.bukkit.event.entity.EntityDamageByBlockEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.EntityInteractEvent;
-import org.bukkit.event.entity.EntityShootBowEvent;
-import org.bukkit.event.entity.EntityTargetEvent;
-import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
-import org.bukkit.event.entity.EntityTeleportEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.entity.ProjectileHitEvent;
-import org.bukkit.event.entity.ProjectileLaunchEvent;
-import org.bukkit.event.entity.SlimeSplitEvent;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryType.SlotType;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.PlayerAnimationEvent;
-import org.bukkit.event.player.PlayerFishEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerKickEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.event.player.PlayerToggleFlightEvent;
-import org.bukkit.event.player.PlayerToggleSneakEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.Vector;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 public class PKListener implements Listener {
 
@@ -354,6 +358,8 @@ public class PKListener implements Listener {
 			return;
 
 		Entity entity = event.getEntity();
+		event.setCancelled(VineWhip.dontsolidify.contains(entity));
+		
 		if (Paralyze.isParalyzed(entity) || ChiComboManager.isParalyzed(entity) || Bloodbending.isBloodbended(entity) || Suffocate.isBreathbent(entity))
 			event.setCancelled(true);
 
@@ -1163,6 +1169,9 @@ public class PKListener implements Listener {
 				if (abil.equalsIgnoreCase("WaterArms")) {
 					new WaterArms(player);
 				}
+				if (abil.equalsIgnoreCase("VineWhip")) {
+					new VineWhip(player);
+				}
 			}
 
 			if (EarthMethods.isEarthAbility(abil)) {
@@ -1347,6 +1356,17 @@ public class PKListener implements Listener {
 				if (abil.equalsIgnoreCase("Torrent")) {
 					new Torrent(player);
 				}
+				if (abil.equalsIgnoreCase("VineWhip")) {
+					if(CoreAbility.containsPlayer(player, VineWhip.class)) {
+						VineWhip pw = (VineWhip) CoreAbility.getAbilityFromPlayer(player, VineWhip.class);
+						if(!pw.clicked) pw.clicked = true;
+						if(pw.targetLoc == null) {
+							new Plantbending(pw.source);
+							pw.source.setType(Material.AIR);
+						}
+						pw.targetLoc = VineWhip.getTargetLocation(player, ConfigManager.defaultConfig.get().getDouble("Abilities.Water.VineWhip.Range"));
+					}
+				}
 			}
 
 			if (EarthMethods.isEarthAbility(abil)) {
@@ -1488,7 +1508,15 @@ public class PKListener implements Listener {
 			event.setCancelled(p.getGameMode() != GameMode.CREATIVE);
 		}
 	}
-
+	
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void leafDecay(LeavesDecayEvent e){
+		if(VineWhip.revert.contains(e.getBlock())){
+			e.setCancelled(true);
+			e.getBlock().getDrops().clear();
+		}
+	}
+	
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onProjectileHit(ProjectileHitEvent event) {
 		Integer id = event.getEntity().getEntityId();

--- a/src/com/projectkorra/projectkorra/ability/AbilityModuleManager.java
+++ b/src/com/projectkorra/projectkorra/ability/AbilityModuleManager.java
@@ -1,15 +1,15 @@
 package com.projectkorra.projectkorra.ability;
 
-import com.projectkorra.projectkorra.Element;
-import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.util.AbilityLoader;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+
+import com.projectkorra.projectkorra.Element;
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.util.AbilityLoader;
 
 public class AbilityModuleManager {
 
@@ -146,6 +146,8 @@ public class AbilityModuleManager {
 						shiftabilities.add(a.name());
 					if (a == StockAbility.WaterArms)
 						shiftabilities.add(a.name());
+					if (a == StockAbility.VineWhip)
+						shiftabilities.add(a.name());
 
 					// Water Sub Abilities
 					if (a == StockAbility.HealingWaters)
@@ -160,6 +162,8 @@ public class AbilityModuleManager {
 						subabilities.add(a.name());
 					if (a == StockAbility.PlantArmor)
 						subabilities.add(a.name());
+					if (a == StockAbility.VineWhip)
+						subabilities.add(a.name());
 
 					if (a == StockAbility.HealingWaters)
 						healingabilities.add(a.name());
@@ -172,6 +176,8 @@ public class AbilityModuleManager {
 					if (a == StockAbility.IceBlast)
 						iceabilities.add(a.name());
 					if (a == StockAbility.PlantArmor)
+						plantabilities.add(a.name());
+					if (a == StockAbility.VineWhip)
 						plantabilities.add(a.name());
 				}
 			} else if (StockAbility.isEarthbending(a)) {

--- a/src/com/projectkorra/projectkorra/ability/StockAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/StockAbility.java
@@ -21,14 +21,14 @@ public enum StockAbility {
 	AvatarState,
 
 	// Project Korra
-	Extraction, MetalClips, Smokescreen, Combustion, LavaFlow, Suffocate, IceBlast, WarriorStance, AcrobatStance, QuickStrike, SwiftKick, EarthSmash, Flight, WaterArms, SandSpout, PlantArmor;
+	Extraction, MetalClips, Smokescreen, Combustion, LavaFlow, Suffocate, IceBlast, WarriorStance, AcrobatStance, QuickStrike, SwiftKick, EarthSmash, Flight, WaterArms, SandSpout, PlantArmor, VineWhip;
 
 	public enum AirbendingAbilities {
 		AirBlast, AirBubble, AirShield, AirSuction, AirSwipe, Tornado, AirScooter, AirSpout, AirBurst, Suffocate, Flight;
 	}
 
 	public enum WaterbendingAbilities {
-		WaterBubble, PhaseChange, HealingWaters, WaterManipulation, Surge, Bloodbending, WaterSpout, IceSpike, IceBlast, OctopusForm, Torrent, WaterArms, PlantArmor;
+		WaterBubble, PhaseChange, HealingWaters, WaterManipulation, Surge, Bloodbending, WaterSpout, IceSpike, IceBlast, OctopusForm, Torrent, WaterArms, PlantArmor, VineWhip;
 
 	}
 
@@ -85,7 +85,7 @@ public enum StockAbility {
 	}
 
 	public enum PlantbendingAbilities {
-		PlantArmor;
+		PlantArmor, VineWhip;
 	}
 
 	public enum MultiAbilities {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -44,6 +44,7 @@ public class ConfigManager {
 				config.addDefault("Water.OctopusForm", "{victim} was slapped by {attacker}'s {ability}");
 				config.addDefault("Water.Bloodbending", "{victim} was destroyed by {attacker}'s {ability}");
 				config.addDefault("Water.WaterCombo", "{victim} was overwhelmed by {attacker}'s skill {ability}");
+				config.addDefault("Water.PlantWhip", "{victim} was smashed to death by {attacker} using {ability}!");
 
 				config.addDefault("Earth.Collapse", "{victim} was suffocated by {attacker}'s {ability}");
 				config.addDefault("Earth.EarthBlast", "{victim} was broken apart by {attacker}'s {ability}");
@@ -373,7 +374,20 @@ public class ConfigManager {
 				config.addDefault("Abilities.Water.Torrent.Wave.Height", 1);
 
 				config.addDefault("Abilities.Water.Plantbending.RegrowTime", 180000);
-
+				
+				config.addDefault("Abilities.Water.VineWhip.Enabled", true);
+				config.addDefault("Abilities.Water.VineWhip.Description", "This ability allows a plantbender to create a big whip of plants, "
+						+ "damaging and knocking back anything it hits. To do this, sneak (Default shift) while looking at a "
+						+ "plant. Smoke will appear, indicating you have succesfully selected a source. Then, you must left click in any direction "
+						+ "you want, to launch the whip in that direction. To redirect the whip, you must left click again, the whip's course will "
+						+ "change into the direction you clicked.");
+				config.addDefault("Abilities.Water.VineWhip.Range", 25);
+				config.addDefault("Abilities.Water.VineWhip.Damage", 4);
+				config.addDefault("Abilities.Water.VineWhip.SourceRange", 10);
+				config.addDefault("Abilities.Water.VineWhip.RevertTime", 3500);
+				config.addDefault("Abilities.Water.VineWhip.CoolDown", 3000);
+				config.addDefault("Abilities.Water.VineWhip.Speed", 0.8);
+				
 				config.addDefault("Abilities.Water.WaterArms.Enabled", true);
 				config.addDefault("Abilities.Water.WaterArms.Description", "One of the most diverse moves in a Waterbender's arsenal, this move creates tendrils " + "of water from the players arms to emulate their actual arms. Each water arms mode will be binded to a slot, switch slots to change mode. " + "To deactive the arms, hold Sneak and Double Left-Click." + "\nPull - Use your Arms to pull blocks, items, mobs or even players towards you!" + "\nPunch - An offensive attack, harming players or mobs!" + "\nGrapple - Scale walls and speed across battlefields, using your Arms as a grappling hook!" + "\nGrab - Grab an entity with your arm, and swing them about!" + "\nFreeze - Use your Arms to fire small blasts of ice in any direction!" + "\nSpear - Throw your Arms in any direction, freezing whatever it hits!");
 				config.addDefault("Abilities.Water.WaterArms.SneakMessage", "Active Ability:");

--- a/src/com/projectkorra/projectkorra/waterbending/VineWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/VineWhip.java
@@ -1,0 +1,212 @@
+package com.projectkorra.projectkorra.waterbending;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.StockAbility;
+import com.projectkorra.projectkorra.ability.api.CoreAbility;
+import com.projectkorra.projectkorra.configuration.ConfigManager;
+import com.projectkorra.projectkorra.earthbending.EarthMethods;
+import com.projectkorra.projectkorra.util.TempBlock;
+
+public class VineWhip extends CoreAbility {
+	
+	public FileConfiguration config = ConfigManager.defaultConfig.get();
+	
+	private double RANGE = config.getDouble("Abilities.Water.VineWhip.Range");
+	private double DAMAGE = config.getDouble("Abilities.Water.VineWhip.Damage");
+	private int SELECT = config.getInt("Abilities.Water.VineWhip.SourceRange");
+	private long REVERT = config.getLong("Abilities.Water.VineWhip.RevertTime");
+	private double SPEED = config.getDouble("Abilities.Water.VineWhip.Speed");
+	private long COOLDOWN = config.getLong("Abilities.Water.VineWhip.CoolDown");
+	
+	public static ConcurrentHashMap<Block, Long> revert = new ConcurrentHashMap<Block, Long>();
+	public static ArrayList<FallingBlock> dontsolidify = new ArrayList<FallingBlock>();
+	public Boolean clicked;
+	public Player player;
+	public Vector dir;
+	public Location whip;
+	public Block source;
+	public boolean Hit;
+	private int rangeCount;
+	public Location targetLoc;
+	
+	static boolean canBend(Player player) {
+		  if (GeneralMethods.getBoundAbility(player) == null) return false;
+		  if (!GeneralMethods.canBend(player.getName(), "VineWhip")) return false;
+		  if (GeneralMethods.isRegionProtectedFromBuild(player, "VineWhip", player.getLocation())) return false;
+		  if (GeneralMethods.getBendingPlayer(player.getName()).isOnCooldown("VineWhip")) return false;
+		  if (GeneralMethods.getBendingPlayer(player).isChiBlocked()) return false;
+		  if (!GeneralMethods.getBendingPlayer(player).isToggled()) return false;
+		  if (GeneralMethods.getBoundAbility(player).equalsIgnoreCase("VineWhip")) return true;
+		  return false;
+	  	}
+	
+	public VineWhip(Player player){
+		if(!canBend(player))
+			return;
+		
+		Block block = WaterMethods.getPlantSourceBlock(player, this.SELECT, false);
+		if(block != null && !TempBlock.isTempBlock(block)) {
+			if(containsPlayer(player, VineWhip.class)) {
+				VineWhip vw = (VineWhip) getAbilityFromPlayer(player, VineWhip.class);
+				vw.remove();
+			}
+			this.player = player;
+			source = block;
+			whip = this.source.getLocation().add(0.5, 0.5, 0.5);
+			rangeCount = 0;
+			clicked = false;
+			targetLoc = null;
+			putInstance(player, this);
+		}
+	}
+	
+	@SuppressWarnings("deprecation")
+	public static void revertBlocks() {
+		for(Block b : revert.keySet()){
+			long time = revert.get(b);
+			if(System.currentTimeMillis() > time){
+				TempBlock.revertBlock(b, Material.AIR);
+				FallingBlock fb = GeneralMethods.spawnFallingBlock(b.getLocation().add(0.5, 0.5, 0.5), Material.LEAVES, b.getData());
+				dontsolidify.add(fb);
+				fb.setDropItem(false);
+				revert.remove(b);
+			}
+		}
+	}
+	
+	static void repeat() {
+		revertBlocks();
+		progressAll(VineWhip.class);
+	}
+
+	@SuppressWarnings("deprecation")
+	public boolean progress() {
+		if(player.isDead() || !player.isOnline()){
+			stop();
+			return false;
+		}
+		if(GeneralMethods.getBoundAbility(player) == null || !GeneralMethods.getBoundAbility(player).equals("VineWhip")){
+			stop();
+			return false;
+		}
+		if(player.getWorld() != this.source.getWorld() || player.getWorld() != this.whip.getWorld()) {
+			stop();
+			return false;
+		}
+		if(!clicked){
+			
+			this.source.getWorld().playEffect(this.source.getLocation().add(0.5, 0.5, 0.5), Effect.SMOKE, 4, (int) SELECT);
+			
+			if(player.getLocation().distance(this.source.getLocation().add(0.5, 0.5, 0.5)) > SELECT){
+				stop();
+				return false;
+			}
+			
+		}else{
+			this.dir = GeneralMethods.getDirection(this.whip, targetLoc).normalize().multiply(SPEED);
+			if(revert.containsKey(this.targetLoc.getBlock())) {
+				stop();
+				return false;
+			}
+			if(rangeCount > RANGE){
+				stop();
+				return false;
+			}
+			this.whip.add(this.dir);
+				
+			if(!revert.containsKey(this.whip.getBlock())){
+				if(EarthMethods.isTransparentToEarthbending(player, this.whip.getBlock()) || WaterMethods.isPlantbendable(this.whip.getBlock(), false)){
+						
+					new TempBlock(this.whip.getBlock(), Material.LEAVES, this.source.getData());
+					revert.put(this.whip.getBlock(), System.currentTimeMillis() + REVERT);
+					if(GeneralMethods.isRegionProtectedFromBuild(player, "VineWhip", this.whip)) {
+						stop();
+						return false;
+					}
+					rangeCount++;
+						
+					for(Entity e : GeneralMethods.getEntitiesAroundPoint(this.whip, 2D)){
+						if(e instanceof LivingEntity && e.getEntityId() != player.getEntityId()
+								&& !(e instanceof ArmorStand)){
+							GeneralMethods.damageEntity(player, e, DAMAGE);
+							e.setVelocity(GeneralMethods.getDirection(this.whip, e.getLocation()).normalize().multiply(0.6));
+							stop();
+							return true;
+						}
+					}
+						
+				}else{
+						
+					stop();
+						
+				}
+			}
+		}
+		return true;
+	}
+	
+	@SuppressWarnings("deprecation")
+	public static Location getTargetLocation(Player player, double range) {
+		ArrayList<Entity> avoid = new ArrayList<Entity>();
+		Entity victim = GeneralMethods.getTargetedEntity(player, range, avoid);
+		if(victim != null) {
+			return victim.getLocation();
+		} else {
+			Integer[] avoidBlocks = {Material.LEAVES.getId(), Material.LEAVES_2.getId(), 0, 6, 8, 9, 10, 11, 27, 28, 30, 31, 32, 37, 38, 39, 40, 50, 51, 55, 59, 66, 68, 69, 70, 72,
+					75, 76, 77, 78, 83, 90, 93, 94, 104, 105, 106, 111, 115, 119, 127, 131, 132, 175};
+			return GeneralMethods.getTargetedLocation(player, range, avoidBlocks);
+		}
+	}
+	
+	public void stop() {
+		GeneralMethods.getBendingPlayer(player).addCooldown("VineWhip", COOLDOWN);
+		remove();
+	}
+	
+	public static void clear() {
+		removeAll(VineWhip.class);
+		
+		for(Block b : revert.keySet()){
+			TempBlock.revertBlock(b, Material.AIR);
+			revert.remove(b);
+		}
+	}
+
+	@Override
+	public void reloadVariables() {
+		// TODO Auto-generated method stub
+		this.RANGE = config.getDouble("Abilities.Water.VineWhip.Range");
+		this.DAMAGE = config.getDouble("Abilities.Water.VineWhip.Damage");
+		this.SELECT = config.getInt("Abilities.Water.VineWhip.SourceRange");
+		this.REVERT = config.getLong("Abilities.Water.VineWhip.RevertTime");
+		this.SPEED = config.getDouble("Abilities.Water.VineWhip.Speed");
+		this.COOLDOWN = config.getLong("Abilities.Water.VineWhip.CoolDown");
+	}
+	
+	public InstanceType getInstanceType() {
+		return InstanceType.SINGLE;
+	}
+	
+	@Override
+	public StockAbility getStockAbility() {
+		// TODO Auto-generated method stub
+		return StockAbility.VineWhip;
+	}
+
+	
+}

--- a/src/com/projectkorra/projectkorra/waterbending/WaterbendingManager.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterbendingManager.java
@@ -34,6 +34,7 @@ public class WaterbendingManager implements Runnable {
 		WaterWave.progressAll();
 		WaterCombo.progressAll();
 		WaterArms.progressAll();
+		VineWhip.repeat();
 	}
 
 }

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -95,6 +95,7 @@ permissions:
       bending.ability.WaterSpout.Wave: true
       bending.ability.WaterCombo: true
       bending.ability.PlantArmor: true
+      bending.ability.VineWhip: true
       bending.water.plantbending: true
       bending.message.nightmessage: true
       bending.water.passive: true


### PR DESCRIPTION
Added the vine whip ability. Added a config option for most things.
Description:
“This ability allows a plantbender to create a big whip of plants,
damaging and knocking back anything it hits. To do this, sneak (Default
shift) while looking at a plant. Smoke will appear, indicating you have
succesfully selected a source. Then, you must left click in any
direction you want, to launch the whip in that direction. To redirect
the whip, you must left click again, the whip's course will”

If the description is terrible, (which I assume it is) please just
change it. I’m not great at writing.