### PR TITLE
Adds config options for Bloodbending and AirBlast

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -37,6 +37,12 @@ public class AirBlast extends CoreAbility {
 	public static double defaultrange = config.get().getDouble("Abilities.Air.AirBlast.Range");
 	public static double affectingradius = config.get().getDouble("Abilities.Air.AirBlast.Radius");
 	public static double defaultpushfactor = config.get().getDouble("Abilities.Air.AirBlast.Push");
+	
+	public static boolean flickLevers = config.get().getBoolean("Abilities.Air.AirBlast.CanFlickLevers");
+	public static boolean openDoors = config.get().getBoolean("Abilities.Air.AirBlast.CanOpenDoors");
+	public static boolean pressButtons = config.get().getBoolean("Abilities.Air.AirBlast.CanPressButtons");
+	public static boolean coolLava = config.get().getBoolean("Abilities.Air.AirBlast.CanCoolLava");
+	
 	private static double originselectrange = 10;
 	private static final int maxticks = 10000;
 	/* Package visible variables */
@@ -287,8 +293,10 @@ public class AirBlast extends CoreAbility {
 				testblock.getWorld().playEffect(testblock.getLocation(), Effect.EXTINGUISH, 0);
 			}
 
+			if (GeneralMethods.isRegionProtectedFromBuild(getPlayer(), "AirBlast", block.getLocation())) continue;
+			
 			Material doorTypes[] = { Material.WOODEN_DOOR, Material.SPRUCE_DOOR, Material.BIRCH_DOOR, Material.JUNGLE_DOOR, Material.ACACIA_DOOR, Material.DARK_OAK_DOOR };
-			if (Arrays.asList(doorTypes).contains(block.getType())) {
+			if (Arrays.asList(doorTypes).contains(block.getType()) && openDoors) {
 				if (block.getData() >= 8) {
 					block = block.getRelative(BlockFace.DOWN);
 				}
@@ -301,7 +309,7 @@ public class AirBlast extends CoreAbility {
 					block.getWorld().playSound(block.getLocation(), Sound.DOOR_OPEN, 10, 1);
 				}
 			}
-			if ((block.getType() == Material.LEVER) && !affectedlevers.contains(block)) {
+			if ((block.getType() == Material.LEVER) && !affectedlevers.contains(block) && flickLevers) {
 				// BlockState state = block.getState();
 				// Lever lever = (Lever) (state.getData());
 				// lever.setPowered(!lever.isPowered());
@@ -331,7 +339,7 @@ public class AirBlast extends CoreAbility {
 
 				affectedlevers.add(block);
 
-			} else if ((block.getType() == Material.STONE_BUTTON) && !affectedlevers.contains(block)) {
+			} else if ((block.getType() == Material.STONE_BUTTON) && !affectedlevers.contains(block) && pressButtons) {
 
 				final Button button = new Button(Material.STONE_BUTTON, block.getData());
 				button.setPowered(!button.isPowered());
@@ -365,7 +373,7 @@ public class AirBlast extends CoreAbility {
 				}.runTaskLater(ProjectKorra.plugin, 10);
 
 				affectedlevers.add(block);
-			} else if ((block.getType() == Material.WOOD_BUTTON) && !affectedlevers.contains(block)) {
+			} else if ((block.getType() == Material.WOOD_BUTTON) && !affectedlevers.contains(block) && pressButtons) {
 
 				final Button button = new Button(Material.WOOD_BUTTON, block.getData());
 				button.setPowered(!button.isPowered());
@@ -401,7 +409,7 @@ public class AirBlast extends CoreAbility {
 				affectedlevers.add(block);
 			}
 		}
-		if ((GeneralMethods.isSolid(block) || block.isLiquid()) && !affectedlevers.contains(block)) {
+		if ((GeneralMethods.isSolid(block) || block.isLiquid()) && !affectedlevers.contains(block) && coolLava) {
 			if (block.getType() == Material.LAVA || block.getType() == Material.STATIONARY_LAVA) {
 				if (block.getData() == full) {
 					block.setType(Material.OBSIDIAN);
@@ -439,6 +447,11 @@ public class AirBlast extends CoreAbility {
 		defaultrange = config.get().getDouble("Abilities.Air.AirBlast.Range");
 		affectingradius = config.get().getDouble("Abilities.Air.AirBlast.Radius");
 		defaultpushfactor = config.get().getDouble("Abilities.Air.AirBlast.Push");
+		
+		flickLevers = config.get().getBoolean("Abilities.Air.AirBlast.CanFlickLevers");
+		openDoors = config.get().getBoolean("Abilities.Air.AirBlast.CanOpenDoors");
+		pressButtons = config.get().getBoolean("Abilities.Air.AirBlast.CanPressButtons");
+		coolLava = config.get().getBoolean("Abilities.Air.AirBlast.CanCoolLava");
 		maxspeed = 1. / defaultpushfactor;
 		range = defaultrange;
 		pushfactor = defaultpushfactor;

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -201,6 +201,10 @@ public class ConfigManager {
 				config.addDefault("Abilities.Air.AirBlast.Range", 20);
 				config.addDefault("Abilities.Air.AirBlast.Radius", 2);
 				config.addDefault("Abilities.Air.AirBlast.Push", 3.5);
+				config.addDefault("Abilities.Air.AirBlast.CanFlickLevers", true);
+				config.addDefault("Abilities.Air.AirBlast.CanOpenDoors", true);
+				config.addDefault("Abilities.Air.AirBlast.CanPressButtons", true);
+				config.addDefault("Abilities.Air.AirBlast.CanCoolLava", true);
 
 				config.addDefault("Abilities.Air.AirBubble.Enabled", true);
 				config.addDefault("Abilities.Air.AirBubble.Description", "To use, the bender must merely have the ability selected. All water around the user in a small bubble will vanish, replacing itself once the user either gets too far away or selects a different ability.");

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -314,7 +314,8 @@ public class ConfigManager {
 				config.addDefault("Abilities.Water.Bloodbending.HoldTime", 0);
 				config.addDefault("Abilities.Water.Bloodbending.Cooldown", 0);
 				config.addDefault("Abilities.Water.Bloodbending.CanOnlyBeUsedDuringFullMoon", false);
-
+				config.addDefault("Abilities.Water.Bloodbending.CanBloodbendOtherBloodbenders", false);
+				
 				config.addDefault("Abilities.Water.HealingWaters.Enabled", true);
 				config.addDefault("Abilities.Water.HealingWaters.Description", "To use, the bender must be at least partially submerged in water. " + "If the user is not sneaking, this ability will automatically begin " + "working provided the user has it selected. If the user is sneaking, " + "he/she is channeling the healing to their target in front of them. " + "In order for this channel to be successful, the user and the target must " + "be at least partially submerged in water.");
 				config.addDefault("Abilities.Water.HealingWaters.Radius", 5);

--- a/src/com/projectkorra/projectkorra/waterbending/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Bloodbending.java
@@ -32,11 +32,12 @@ public class Bloodbending {
 	private static final boolean onlyUsableAtNight = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Water.Bloodbending.CanOnlyBeUsedAtNight");
 	private static boolean canBeUsedOnUndead = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Water.Bloodbending.CanBeUsedOnUndeadMobs");
 	private static final boolean onlyUsableDuringMoon = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Water.Bloodbending.CanOnlyBeUsedDuringFullMoon");
-
+	private boolean canBloodbendBloodbenders = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Water.Bloodbending.CanBloodbendOtherBloodbenders");
+	
 	private int RANGE = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.Bloodbending.Range");
 	private long HOLD_TIME = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.Bloodbending.HoldTime");
 	private long COOLDOWN = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.Bloodbending.Cooldown");
-
+	
 	private Player player;
 	private long time;
 	private double factor = FACTOR;
@@ -84,7 +85,7 @@ public class Bloodbending {
 			if (!(target instanceof LivingEntity) || GeneralMethods.isRegionProtectedFromBuild(player, "Bloodbending", target.getLocation()))
 				return;
 			if (target instanceof Player) {
-				if (GeneralMethods.canBend(((Player) target).getName(), "Bloodbending") || AvatarState.isAvatarState((Player) target))
+				if ((GeneralMethods.canBend(((Player) target).getName(), "Bloodbending") && !canBloodbendBloodbenders) || AvatarState.isAvatarState((Player) target))
 					if (!FireMethods.isDay(target.getWorld()) || WaterMethods.canBloodbendAtAnytime((Player) target))
 						return;
 			}


### PR DESCRIPTION
• Adds a CanFlickLever, CanOpenDoors, CanPushButtons and CanCoolLava options to AirBlast in the config. All of which default to true.
• Adds a CanBloodbendOtherBloodbenders option for Bloodbending in the config. Defaults to false.
• Fixes issues where AirBlast could flick levers, etc, in regions without explicit permission