### PR TITLE
Fix WaterManipulation stalling on slot change

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -228,7 +228,7 @@ public class WaterManipulation {
 			time = System.currentTimeMillis();
 
 			if (GeneralMethods.getBoundAbility(player) == null) {
-				unfocusBlock();
+				breakBlock();
 				return false;
 			}
 			if (!progressing && !falling && !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("WaterManipulation")) {


### PR DESCRIPTION
When switching to a slot with no ability equipped while a WaterManip was active, the water would stop moving in mid air.