### PR TITLE
Redone Temporary Fire

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -254,6 +254,8 @@ public class PKListener implements Listener {
 			EarthMethods.removeRevertIndex(block);
 		} else if (TempBlock.isTempBlock(block)) {
 			TempBlock.revertBlock(block, Material.AIR);
+		} else if (FireMethods.tempFire.keySet().contains(block.getLocation())) {
+			FireMethods.revertTempFire(block.getLocation());
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1,7 +1,5 @@
 package com.projectkorra.projectkorra.configuration;
 
-import com.projectkorra.projectkorra.ProjectKorra;
-
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.io.File;
@@ -166,6 +164,8 @@ public class ConfigManager {
 				config.addDefault("Properties.Fire.DayMessage", "You feel the strength of the rising sun empowering your firebending.");
 				config.addDefault("Properties.Fire.SolarEclipseMessage", "A solar eclipse is out! Firebenders are temporarily powerless.");
 				config.addDefault("Properties.Fire.CometMessage", "Sozin's Comet is passing overhead! Firebending is now at its most powerful.");
+				config.addDefault("Properties.Fire.FireGriefing", false);
+				config.addDefault("Properties.Fire.RevertTicks", 12000L);
 
 				config.addDefault("Properties.Chi.CanBendWithWeapons", true);
 

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -223,10 +223,15 @@ public class FireBlast extends CoreAbility {
 	private void ignite(Location location) {
 		for (Block block : GeneralMethods.getBlocksAroundPoint(location, affectingradius)) {
 			if (FireStream.isIgnitable(player, block) && !safe.contains(block)) {
-				if (WaterMethods.isPlantbendable(block)) {
+				/*if (WaterMethods.isPlantbendable(block)) {
 					new Plantbending(block);
+				}*/
+				if (FireMethods.canFireGrief()) {
+					if (WaterMethods.isPlantbendable(block)) new Plantbending(block);
+					block.setType(Material.FIRE);
 				}
-				block.setType(Material.FIRE);
+				else FireMethods.createTempFire(block.getLocation());
+				//block.setType(Material.FIRE);
 				if (dissipate) {
 					FireStream.ignitedblocks.put(block, player);
 					FireStream.ignitedtimes.put(block, System.currentTimeMillis());

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -43,7 +43,10 @@ public class FireJet extends CoreAbility {
 		Block block = player.getLocation().getBlock();
 		if (FireStream.isIgnitable(player, block) || block.getType() == Material.AIR || AvatarState.isAvatarState(player)) {
 			player.setVelocity(player.getEyeLocation().getDirection().clone().normalize().multiply(factor));
-			block.setType(Material.FIRE);
+			if (FireMethods.canFireGrief()) {
+				FireMethods.createTempFire(block.getLocation());
+			}
+			else block.setType(Material.FIRE);
 			this.player = player;
 			// canfly = player.getAllowFlight();
 			new Flight(player);

--- a/src/com/projectkorra/projectkorra/firebending/Fireball.java
+++ b/src/com/projectkorra/projectkorra/firebending/Fireball.java
@@ -257,6 +257,9 @@ public class Fireball extends AddonAbility {
 	private void ignite(Location location) {
 		for (Block block : GeneralMethods.getBlocksAroundPoint(location, FireBlast.AFFECTING_RADIUS)) {
 			if (FireStream.isIgnitable(player, block)) {
+				if (block.getType() != Material.FIRE) {
+					FireStream.replacedBlocks.put(block.getLocation(), block.getState().getData());
+				}
 				block.setType(Material.FIRE);
 				if (FireBlast.dissipate) {
 					FireStream.ignitedblocks.put(block, player);

--- a/src/com/projectkorra/projectkorra/firebending/FirebendingManager.java
+++ b/src/com/projectkorra/projectkorra/firebending/FirebendingManager.java
@@ -30,6 +30,7 @@ public class FirebendingManager implements Runnable {
 				FireStream.ignitedblocks.remove(block);
 			}
 		}
+		FireMethods.removeFire();
 		HeatControl.progressAll(HeatControl.class);
 		FireStream.dissipateAll();
 		FireStream.progressAll(FireStream.class);


### PR DESCRIPTION
Fire has a new temporary block system that reverts back after the fire
either dissipates or is destroyed.

• New Config Setting: Properties.Fire.FireGriefing
• Fire will no longer replace blocks with this setting on, but instead
reverts as soon as the fire dissipates or is destroyed
• Defaults to false
• New Config Setting: Properties.Fire.RevertTicks
• Fire will automatically revert after so many ticks. This only applies
if FireGriefing is false, however.
• Fixed fire destroying blocks for good this time