### PR TITLE
MetalClips fix and miscellaneous

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1080,7 +1080,7 @@ public class PKListener implements Listener {
 		}
 
 		for (Player p : MetalClips.instances.keySet()) {
-			if (MetalClips.instances.get(p).getTarget() != null && MetalClips.instances.get(p).getTarget().getEntityId() == event.getPlayer().getEntityId()) {
+			if (MetalClips.instances.get(p).getTarget() != null) {
 				MetalClips.instances.get(p).remove();
 			}
 		}
@@ -1419,8 +1419,10 @@ public class PKListener implements Listener {
 					} else if (MetalClips.instances.containsKey(player)) {
 						if (MetalClips.instances.get(player).metalclips < (player.hasPermission("bending.ability.MetalClips.4clips") ? 4 : 3))
 							MetalClips.instances.get(player).shootMetal();
-						else
-							MetalClips.instances.get(player).launch();
+						else {
+							if (MetalClips.isControllingEntity(player))
+								MetalClips.instances.get(player).launch();
+						}
 					}
 				}
 				if (abil.equalsIgnoreCase("LavaSurge")) {

--- a/src/com/projectkorra/projectkorra/ability/AbilityModuleManager.java
+++ b/src/com/projectkorra/projectkorra/ability/AbilityModuleManager.java
@@ -6,7 +6,6 @@ import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.util.AbilityLoader;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -87,7 +86,6 @@ public class AbilityModuleManager {
 		fill();
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private void fill() {
 
 		for (StockAbility a : StockAbility.values()) {

--- a/src/com/projectkorra/projectkorra/command/ClearCommand.java
+++ b/src/com/projectkorra/projectkorra/command/ClearCommand.java
@@ -4,7 +4,6 @@ import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.multiability.MultiAbilityManager;
 
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -570,13 +570,14 @@ public class ConfigManager {
 				//			config.addDefault("Abilities.Earth.LavaSurge.SourceCanBeEarth", true);
 
 				config.addDefault("Abilities.Earth.MetalClips.Enabled", true);
-				config.addDefault("Abilities.Earth.MetalClips.Description", "MetalClips has the potential to be both an offensive and a utility ability. To start, you must carry smelted Iron Ingots in your inventory. To apply the clips onto an entity, simply click at them. If the entity is a Zombie, a Skeleton, or a Player, the clips will form armor around the entity, giving you some control over them. Each additional clip will give you more control. If you have permission to do so, you may crush the entity against a wall with a 4th clip, hurting them. Without explicit permissions, you will only be able to strap three clips on your target. If the entity is not one of the above, the clip will simply do damage and fall to the ground, to be collected.");
+				config.addDefault("Abilities.Earth.MetalClips.Description", "MetalClips has the potential to be both an offensive and a utility ability. To start, you must carry smelted Iron Ingots in your inventory. To apply the clips onto an entity, simply click at them. If the entity is a Zombie, a Skeleton, or a Player, the clips will form armor around the entity, giving you some control over them. Each additional clip will give you more control. If you have permission to do so, you may crush the entity against a wall with a 4th clip, hurting them. Without explicit permissions, you will only be able to strap three clips on your target. If the entity is not one of the above, the clip will simply do damage and fall to the ground, to be collected. Another permission requiring action is throwing entities. To do so, click while controlling a metalclipped entity");
 				config.addDefault("Abilities.Earth.MetalClips.Damage", 2);
 				config.addDefault("Abilities.Earth.MetalClips.DamageInterval", 500);
 				config.addDefault("Abilities.Earth.MetalClips.MagnetRange", 20);
 				config.addDefault("Abilities.Earth.MetalClips.MagnetPower", 0.6);
 				config.addDefault("Abilities.Earth.MetalClips.Cooldown", 1000);
 				config.addDefault("Abilities.Earth.MetalClips.Duration", 10000);
+				config.addDefault("Abilities.Earth.MetalClips.ThrowEnabled", false);
 
 				config.addDefault("Abilities.Earth.RaiseEarth.Enabled", true);
 				config.addDefault("Abilities.Earth.RaiseEarth.Description", "To use, simply left-click on an earthbendable block. " + "A column of earth will shoot upwards from that location. " + "Anything in the way of the column will be brought up with it, " + "leaving talented benders the ability to trap brainless entities up there. " + "Additionally, simply sneak (default shift) looking at an earthbendable block. " + "A wall of earth will shoot upwards from that location. " + "Anything in the way of the wall will be brought up with it. ");

--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class MetalClips {
+	
 	public static ConcurrentHashMap<Player, MetalClips> instances = new ConcurrentHashMap<Player, MetalClips>();
 	public static ConcurrentHashMap<Entity, Integer> clipped = new ConcurrentHashMap<Entity, Integer>();
 	public static int armorTime = ProjectKorra.plugin.getConfig().getInt("Abilities.Earth.MetalClips.Duration");
@@ -55,6 +56,7 @@ public class MetalClips {
 			return;
 
 		player = p;
+		canThrow = ((ProjectKorra.plugin.getConfig().getBoolean("Abilities.Earth.MetalClips.ThrowEnabled") && player.hasPermission("bending.ability.metalclips.throw")) ? true : false);
 		this.var = var;
 
 		if (!isEligible())
@@ -417,8 +419,7 @@ public class MetalClips {
 				for (Entity e : GeneralMethods.getEntitiesAroundPoint(ii.getLocation(), 2)) {
 					if (e instanceof LivingEntity && e.getEntityId() != player.getEntityId()) {
 						if (e instanceof Player || e instanceof Zombie || e instanceof Skeleton) {
-							if (targetent == null)
-								targetent = (LivingEntity) e;
+							targetent = (LivingEntity) e;
 
 							formArmor();
 						}
@@ -458,15 +459,17 @@ public class MetalClips {
 		resetArmor();
 		trackedIngots.clear();
 		instances.remove(player);
+		metalclips = 0;
+		if (targetent != null)
+			clipped.remove(targetent);
 	}
 
 	public static void removeAll() {
 		for (Player p : instances.keySet()) {
 			instances.get(p).remove();
 		}
-		for (Entity ent : clipped.keySet()) {
-			clipped.remove(ent);
-		}
+		if (!clipped.isEmpty())
+			clipped.clear();
 	}
 
 	public static void progressAll() {
@@ -482,5 +485,9 @@ public class MetalClips {
 			}
 		}
 		return false;
+	}
+	
+	public static boolean isControllingEntity(Player player) {
+		return (instances.containsKey(player) && player.isSneaking() && targetent != null);
 	}
 }

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -125,6 +125,7 @@ permissions:
       bending.ability.MetalClips: true
       bending.ability.MetalClips.loot: false
       bending.ability.MetalClips.4clips: false
+      bending.ability.MetalClips.throw: false
       bending.earth.passive: true
       bending.earth.metalbending: true
       bending.earth.lavabending: true
@@ -176,6 +177,9 @@ permissions:
   bending.ability.MetalClips.loot:
     default: false
     description: Lets a Metalbender loot a player's inventory of its iron.
+  bending.ability.MetalClips.throw:
+    default: false
+    description: Lets a Metalbending throw a controlled entity.
   bending.ability.AirCombo:
     default: false
     description: Grants access to all AirCombos.


### PR DESCRIPTION
- Fixes MetalClips errors:
    - Only being able to metalclip one entity, even when hitting other
entities
    - MetalClips stops working after killing targeted entity
- Removes unused imports and suppresswarnings
- Adds MetalClips throwing config option and permission, both false by default. Used when the
player is controlling an entity and clicks. (Recommended: Delete the
MetalClips description line in the config, then reload server)