### PR TITLE
Update /b debug to display more variables

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1845,8 +1845,9 @@ public class GeneralMethods {
 			for (final ClassPath.ClassInfo info : ClassPath.from(loader).getTopLevelClasses()) {
 				if (info.getName().startsWith("com.projectkorra.")) {
 					final Class<?> clazz = info.load();				    
-				    for (Field field : clazz.getFields()) {
+				    for (Field field : clazz.getDeclaredFields()) {
 				    	String simpleName = clazz.getSimpleName();
+				    	field.setAccessible(true);
 				    	try {
 				    		Object obj = field.get(null);
 				    		if (obj instanceof Collection) {


### PR DESCRIPTION
The /b debug command will now display the size of collections and maps for both public and private fields. Previously it only displayed public fields.