### PR TITLE
Fix ChiBlocking and Configurations, Remove import

### DIFF
--- a/src/com/projectkorra/projectkorra/chiblocking/ChiPassive.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/ChiPassive.java
@@ -12,8 +12,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-import java.util.Random;
-
 public class ChiPassive {
 
 	private static FileConfiguration config = ProjectKorra.plugin.getConfig();
@@ -21,18 +19,22 @@ public class ChiPassive {
 	public static double FallReductionFactor = config.getDouble("Abilities.Chi.Passive.FallReductionFactor");
 	public static int jumpPower = config.getInt("Abilities.Chi.Passive.Jump");
 	public static int speedPower = config.getInt("Abilities.Chi.Passive.Speed");
-	public static double dodgeChance = config.getDouble("Abilities.Chi.Passive.BlockChi.DodgeChance");
+	public static double chance = config.getDouble("Abilities.Chi.Passive.BlockChi.Chance");
 	public static int duration = config.getInt("Abilities.Chi.Passive.BlockChi.Duration");
 
 	static long ticks = (duration / 1000) * 20;
 
 	public static boolean willChiBlock(Player attacker, Player player) {
 		if (AcrobatStance.isInAcrobatStance(attacker)) {
-			dodgeChance = dodgeChance - AcrobatStance.CHI_BLOCK_BOOST;
+			chance = chance + AcrobatStance.CHI_BLOCK_BOOST;
 		}
-
-		Random rand = new Random();
-		if (rand.nextInt(99) + 1 < dodgeChance) {
+		if (GeneralMethods.getBoundAbility(player) == "QuickStrike") {
+			chance = chance + QuickStrike.blockChance;
+		}
+		if (GeneralMethods.getBoundAbility(player) == "SwiftKick") {
+			chance = chance + SwiftKick.blockChance;
+		}
+		if (Math.random() > chance/100) {
 			return false;
 		}
 		if (ChiMethods.isChiBlocked(player.getName())) {

--- a/src/com/projectkorra/projectkorra/chiblocking/QuickStrike.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/QuickStrike.java
@@ -23,7 +23,7 @@ public class QuickStrike {
 
 		GeneralMethods.damageEntity(player, e, damage, "QuickStrike");
 
-		if (GeneralMethods.rand.nextInt(100) < blockChance && e instanceof Player) {
+		if (e instanceof Player && ChiPassive.willChiBlock(player, (Player)e)) {
 			ChiPassive.blockChi((Player) e);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/chiblocking/SwiftKick.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/SwiftKick.java
@@ -23,7 +23,7 @@ public class SwiftKick {
 
 		GeneralMethods.damageEntity(player, e, damage, "SwiftKick");
 
-		if (GeneralMethods.rand.nextInt(100) < blockChance && e instanceof Player) {
+		if (e instanceof Player && ChiPassive.willChiBlock(player, (Player)e)) {
 			ChiPassive.blockChi((Player) e);
 		}
 

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -737,8 +737,8 @@ public class ConfigManager {
 				config.addDefault("Abilities.Chi.Passive.FallReductionFactor", 0.5);
 				config.addDefault("Abilities.Chi.Passive.Speed", 1);
 				config.addDefault("Abilities.Chi.Passive.Jump", 1);
+				config.addDefault("Abilities.Chi.Passive.BlockChi.Chance", 35);
 				config.addDefault("Abilities.Chi.Passive.BlockChi.Duration", 1000);
-				config.addDefault("Abilities.Chi.Passive.DodgeChange", 25);
 
 				config.addDefault("Abilities.Chi.ChiCombo.Enabled", true);
 				config.addDefault("Abilities.Chi.ChiCombo.Immobilize.ParalyzeDuration", 4000);
@@ -746,7 +746,7 @@ public class ConfigManager {
 
 				config.addDefault("Abilities.Chi.AcrobatStance.Enabled", true);
 				config.addDefault("Abilities.Chi.AcrobatStance.Description", "AcrobatStance gives a Chiblocker a higher probability of blocking a Bender's Chi while granting them a Speed and Jump Boost. It also increases the rate at which the hunger bar depletes. To use, simply left click. Left clicking again will de-activate the stance.");
-				config.addDefault("Abilities.Chi.ChiBlockBoost", 0.1);
+				config.addDefault("Abilities.Chi.AcrobatStance.ChiBlockBoost", 5);
 
 				config.addDefault("Abilities.Chi.HighJump.Enabled", true);
 				config.addDefault("Abilities.Chi.HighJump.Description", "To use this ability, simply click. You will jump quite high. This ability has a short cooldown.");
@@ -761,9 +761,9 @@ public class ConfigManager {
 				config.addDefault("Abilities.Chi.RapidPunch.Enabled", true);
 				config.addDefault("Abilities.Chi.RapidPunch.Description", "This ability allows the chiblocker to punch rapidly in a short period. To use, simply punch. This has a short cooldown.");
 				config.addDefault("Abilities.Chi.RapidPunch.Damage", 1);
-				config.addDefault("Abilities.Chi.RapidPunch.Distance", 4);
+				config.addDefault("Abilities.Chi.RapidPunch.Distance", 3);
 				config.addDefault("Abilities.Chi.RapidPunch.Cooldown", 6000);
-				config.addDefault("Abilities.Chi.RapidPunch.Punches", 4);
+				config.addDefault("Abilities.Chi.RapidPunch.Punches", 3);
 
 				config.addDefault("Abilities.Chi.Smokescreen.Enabled", true);
 				config.addDefault("Abilities.Chi.Smokescreen.Description", "Smokescren, if used correctly, can serve as a defensive and offensive ability for Chiblockers. To use, simply left click and you will toss out a Smoke Bomb. When the bomb hits the ground, it will explode and give all players within a small radius of the explosion temporary blindness, allowing you to either get away, or move in for the kill. This ability has a long cooldown.");
@@ -779,12 +779,12 @@ public class ConfigManager {
 				config.addDefault("Abilities.Chi.QuickStrike.Enabled", true);
 				config.addDefault("Abilities.Chi.QuickStrike.Description", "QuickStrike enables a chiblocker to quickly strike an enemy, potentially blocking their chi.");
 				config.addDefault("Abilities.Chi.QuickStrike.Damage", 1);
-				config.addDefault("Abilities.Chi.QuickStrike.ChiBlockChance", 15);
+				config.addDefault("Abilities.Chi.QuickStrike.ChiBlockChance", 10);
 
 				config.addDefault("Abilities.Chi.SwiftKick.Enabled", true);
 				config.addDefault("Abilities.Chi.SwiftKick.Description", "SwiftKick allows a chiblocker to swiftly kick an enemy, potentially blocking their chi. The chiblocker must be in the air to use this ability.");
 				config.addDefault("Abilities.Chi.SwiftKick.Damage", 2);
-				config.addDefault("Abilities.Chi.SwiftKick.ChiBlockChance", 25);
+				config.addDefault("Abilities.Chi.SwiftKick.ChiBlockChance", 15);
 
 				config.addDefault("Storage.engine", "sqlite");
 

--- a/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
+++ b/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
@@ -7,7 +7,6 @@ import com.projectkorra.projectkorra.earthbending.EarthMethods;
 import com.projectkorra.projectkorra.event.HorizontalVelocityChangeEvent;
 import com.projectkorra.projectkorra.waterbending.WaterMethods;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;


### PR DESCRIPTION
- Removed unused Bukkit import in HorizontalVelocityTracker
- Fixed AcrobatStance config options
- Fixed ChiPassive config options
- Made SwiftKick and QuickStrike "ChiBlockChance" into passive augments
- Fixed willChiBlock method in ChiPassive, incorrect way of checking percent
- Add SwiftKick and QuickStrike augments to willChiBlock()
- Change SwiftKick and QuickStrike to use willChiBlock()