### PR TITLE
Update PKListener.java

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -354,6 +354,10 @@ public class PKListener implements Listener {
 		if (Paralyze.isParalyzed(player) || ChiCombo.isParalyzed(player) || Bloodbending.isBloodbended(player) || Suffocate.isBreathbent(player)) {
 			event.setCancelled(true);
 		}
+		
+		/*dNiym - Hack to fix bending activating on right clicks */
+		BendingPlayer bp = GeneralMethods.getBendingPlayer(event.getPlayer().getName());
+		bp.addCooldown("RightClickFix", 40);
 	}
 	
 	@EventHandler(priority = EventPriority.NORMAL)
@@ -1290,6 +1294,11 @@ public class PKListener implements Listener {
 			return;
 
 		Player player = event.getPlayer();
+		
+		/*dNiym - Hack to fix bending activating on right clicks */
+		if(bp.isOnCooldown("RightClickFix"))
+			return;
+			
 		ComboManager.addComboAbility(player, ClickType.LEFT_CLICK);
 
 		if (Suffocate.isBreathbent(player)) {


### PR DESCRIPTION
Added a hackish fix to correct bending activating on block place.
Problem:
PlayerAnimationEvent event
fires on both left click and on block place, however NOT on right clicking a block.

Using a fake cooldown fixes the bug until a permanent solution can be found.