### PR TITLE
Major fixes to Toggle command, Firebending instances fixes

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -829,12 +829,12 @@ public class GeneralMethods {
 	 * 
 	 * @see #getBendingPlayer(UUID)
 	 */
-	public static BendingPlayer getBendingPlayer(String playerName) {
-		OfflinePlayer player = Bukkit.getPlayer(playerName);
+	public static BendingPlayer getBendingPlayer(String player) {
+		OfflinePlayer oPlayer = Bukkit.getPlayer(player);
 		if (player == null) {
-			player = Bukkit.getOfflinePlayer(playerName);
+			oPlayer = Bukkit.getOfflinePlayer(oPlayer.getUniqueId());
 		}
-		return BendingPlayer.getPlayers().get(player.getUniqueId());
+		return BendingPlayer.getPlayers().get(oPlayer.getUniqueId());
 	}
 
 	public static List<Block> getBlocksAlongLine(Location ploc, Location tloc, World w) {

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -612,9 +612,6 @@ public class PKListener implements Listener {
 
 	@EventHandler
 	public void onHorizontalCollision(HorizontalVelocityChangeEvent e) {
-		if (!plugin.getConfig().getBoolean("Properties.HorizontalCollisionPhysics.Enabled"))
-			return;
-
 		if (e.getEntity() instanceof LivingEntity) {
 			if (e.getEntity().getEntityId() != e.getInstigator().getEntityId()) {
 				double minimumDistance = plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageMinimumDistance");

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -1,8 +1,16 @@
 package com.projectkorra.projectkorra.airbending;
 
-import java.util.HashMap;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.AvatarState;
+import com.projectkorra.projectkorra.command.Commands;
+import com.projectkorra.projectkorra.configuration.ConfigLoadable;
+import com.projectkorra.projectkorra.earthbending.EarthBlast;
+import com.projectkorra.projectkorra.earthbending.SandSpout;
+import com.projectkorra.projectkorra.firebending.Combustion;
+import com.projectkorra.projectkorra.firebending.FireBlast;
+import com.projectkorra.projectkorra.firebending.FireStream;
+import com.projectkorra.projectkorra.waterbending.WaterManipulation;
+import com.projectkorra.projectkorra.waterbending.WaterSpout;
 
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -12,13 +20,9 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
-import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.AvatarState;
-import com.projectkorra.projectkorra.command.Commands;
-import com.projectkorra.projectkorra.configuration.ConfigLoadable;
-import com.projectkorra.projectkorra.firebending.Combustion;
-import com.projectkorra.projectkorra.firebending.FireBlast;
-import com.projectkorra.projectkorra.firebending.FireStream;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AirShield implements ConfigLoadable {
 
@@ -159,6 +163,10 @@ public class AirShield implements ConfigLoadable {
 		FireStream.removeAroundPoint(origin, radius);
 		AirBlast.removeAirBlastsAroundPoint(origin, radius);
 		AirSuction.removeAirSuctionsAroundPoint(origin, radius);
+		EarthBlast.removeAroundPoint(origin, radius);
+		SandSpout.removeSpouts(origin, radius, player);
+		WaterSpout.removeSpouts(origin, radius, player);
+		WaterManipulation.removeAroundPoint(origin, radius);
 
 		for (Entity entity : GeneralMethods.getEntitiesAroundPoint(origin, radius)) {
 			if (GeneralMethods.isRegionProtectedFromBuild(player, "AirShield", entity.getLocation()))

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -194,7 +194,7 @@ public class AirSwipe implements ConfigLoadable {
 				public void run() {
 					if (GeneralMethods.isRegionProtectedFromBuild(player, "AirSwipe", entity.getLocation()))
 						return;
-					if (entity.getEntityId() != player.getEntityId()) {
+					if (entity.getEntityId() != player.getEntityId() && entity instanceof LivingEntity) {
 						if (entity instanceof Player) {
 							if (Commands.invincible.contains(((Player) entity).getName()))
 								return;
@@ -217,6 +217,12 @@ public class AirSwipe implements ConfigLoadable {
 						AirMethods.breakBreathbendingHold(entity);
 						if (elements.containsKey(fDirection)) {
 							elements.remove(fDirection);
+						}
+					} else if (entity.getEntityId() != player.getEntityId() && !(entity instanceof LivingEntity)) {
+						if (AvatarState.isAvatarState(player)) {
+							GeneralMethods.setVelocity(entity, fDirection.multiply(AvatarState.getValue(pushfactor)));
+						} else {
+							GeneralMethods.setVelocity(entity, fDirection.multiply(pushfactor));
 						}
 					}
 				}

--- a/src/com/projectkorra/projectkorra/command/BendingTabComplete.java
+++ b/src/com/projectkorra/projectkorra/command/BendingTabComplete.java
@@ -22,38 +22,32 @@ import com.projectkorra.projectkorra.object.Preset;
  * 
  * @author StrangeOne101
  * */
-public class BendingTabComplete implements TabCompleter 
-{	
+public class BendingTabComplete implements TabCompleter {
 	@Override
-	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) 
-	{
-		if (args.length == 0 || args[0].equals("")) return getPossibleCompletionsForGivenArgs(args, getCommandsForUser(sender));	
-		if (args.length >= 2) 
-		{
-			if (args[0].equalsIgnoreCase("bind") || args[0].equalsIgnoreCase("b"))
-			{
-				if (args.length > 3 || !sender.hasPermission("bending.command.bind") || !(sender instanceof Player)) return new ArrayList<String>();
+	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		if (args.length == 0 || args[0].equals(""))
+			return getPossibleCompletionsForGivenArgs(args, getCommandsForUser(sender));
+		if (args.length >= 2) {
+			if (args[0].equalsIgnoreCase("bind") || args[0].equalsIgnoreCase("b")) {
+				if (args.length > 3 || !sender.hasPermission("bending.command.bind") || !(sender instanceof Player))
+					return new ArrayList<String>();
 				List<String> abilities = new ArrayList<String>();
-				if (args.length == 2)
-				{
+				if (args.length == 2) {
 					for (String abil : AbilityModuleManager.abilities) {
 						if (GeneralMethods.canBend(sender.getName(), abil)) {
 							abilities.add(abil);
 						}
 					}
-				}
-				else
-				{
+				} else {
 					for (int i = 1; i < 10; i++) {
 						abilities.add("" + i);
 					}
 				}
 				Collections.sort(abilities);
 				return getPossibleCompletionsForGivenArgs(args, abilities);
-			}
-			else if (args[0].equalsIgnoreCase("display") || args[0].equalsIgnoreCase("d"))
-			{
-				if (args.length > 2 || !sender.hasPermission("bending.command.display")) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("display") || args[0].equalsIgnoreCase("d")) {
+				if (args.length > 2 || !sender.hasPermission("bending.command.display"))
+					return new ArrayList<String>();
 				List<String> list = new ArrayList<String>();
 				list.add("Air");
 				list.add("Earth");
@@ -67,10 +61,9 @@ public class BendingTabComplete implements TabCompleter
 				list.add("ChiCombos");
 				list.add("Avatar");
 				return getPossibleCompletionsForGivenArgs(args, list);
-			}
-			else if (args[0].equalsIgnoreCase("add") || args[0].equalsIgnoreCase("a") || args[0].equalsIgnoreCase("choose") || args[0].equalsIgnoreCase("ch"))
-			{
-				if (args.length > 3 || !sender.hasPermission("bending.command.add")) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("add") || args[0].equalsIgnoreCase("a") || args[0].equalsIgnoreCase("choose") || args[0].equalsIgnoreCase("ch")) {
+				if (args.length > 3 || !sender.hasPermission("bending.command.add"))
+					return new ArrayList<String>();
 				List<String> l = new ArrayList<String>();
 				l.add("Air");
 				l.add("Earth");
@@ -78,19 +71,17 @@ public class BendingTabComplete implements TabCompleter
 				l.add("Water");
 				l.add("Chi");
 				return getPossibleCompletionsForGivenArgs(args, l);
-			}
-			else if (args[0].equalsIgnoreCase("clear") || args[0].equalsIgnoreCase("cl") || args[0].equalsIgnoreCase("c"))
-			{
-				if (args.length > 2 || !sender.hasPermission("bending.command.clear")) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("clear") || args[0].equalsIgnoreCase("cl") || args[0].equalsIgnoreCase("c")) {
+				if (args.length > 2 || !sender.hasPermission("bending.command.clear"))
+					return new ArrayList<String>();
 				List<String> l = new ArrayList<String>();
 				for (int i = 1; i < 10; i++) {
 					l.add("" + i);
 				}
 				return l;
-			}
-			else if (args[0].equalsIgnoreCase("help") || args[0].equalsIgnoreCase("h"))
-			{
-				if (args.length > 2 || !sender.hasPermission("bending.command.help")) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("help") || args[0].equalsIgnoreCase("h")) {
+				if (args.length > 2 || !sender.hasPermission("bending.command.help"))
+					return new ArrayList<String>();
 				List<String> list = new ArrayList<String>();
 				for (Element e : Element.values()) {
 					list.add(e.toString());
@@ -107,53 +98,44 @@ public class BendingTabComplete implements TabCompleter
 				Collections.sort(abils);
 				list.addAll(abils);
 				return getPossibleCompletionsForGivenArgs(args, list);
-			}
-			else if (args[0].equalsIgnoreCase("permaremove") || args[0].equalsIgnoreCase("pr") || args[0].equalsIgnoreCase("premove") || args[0].equalsIgnoreCase("permremove"))
-			{
-				if (args.length > 2 || !sender.hasPermission("bending.command.permaremove")) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("permaremove") || args[0].equalsIgnoreCase("pr") || args[0].equalsIgnoreCase("premove") || args[0].equalsIgnoreCase("permremove")) {
+				if (args.length > 2 || !sender.hasPermission("bending.command.permaremove"))
+					return new ArrayList<String>();
 				List<String> players = new ArrayList<String>();
 				for (Player p : Bukkit.getOnlinePlayers()) {
 					players.add(p.getName());
 				}
 				return getPossibleCompletionsForGivenArgs(args, players);
-			}
-			else if (args[0].equalsIgnoreCase("preset") || args[0].equalsIgnoreCase("presets") || args[0].equalsIgnoreCase("pre") || args[0].equalsIgnoreCase("set") || args[0].equalsIgnoreCase("p"))
-			{
-				if (args.length > 3 || !sender.hasPermission("bending.command.preset") || !(sender instanceof Player)) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("preset") || args[0].equalsIgnoreCase("presets") || args[0].equalsIgnoreCase("pre") || args[0].equalsIgnoreCase("set") || args[0].equalsIgnoreCase("p")) {
+				if (args.length > 3 || !sender.hasPermission("bending.command.preset") || !(sender instanceof Player))
+					return new ArrayList<String>();
 				List<String> l = new ArrayList<String>();
-				if (args.length == 2)
-				{
+				if (args.length == 2) {
 					l.add("create");
 					l.add("delete");
 					l.add("list");
 					l.add("bind");
 					return getPossibleCompletionsForGivenArgs(args, l);
-				}
-				else if (args.length == 3 && Arrays.asList(new String[] {"delete", "d", "del", "bind", "b"}).contains(args[1].toLowerCase()))
-				{
-					List<Preset> presets = Preset.presets.get(((Player)sender).getUniqueId());
+				} else if (args.length == 3 && Arrays.asList(new String[] { "delete", "d", "del", "bind", "b" }).contains(args[1].toLowerCase())) {
+					List<Preset> presets = Preset.presets.get(((Player) sender).getUniqueId());
 					List<String> presetNames = new ArrayList<String>();
 					if (presets != null && presets.size() != 0) {
 						for (Preset preset : presets) {
 							presetNames.add(preset.getName());
 						}
-					}
-					else return new ArrayList<String>();
+					} else
+						return new ArrayList<String>();
 					return getPossibleCompletionsForGivenArgs(args, presetNames);
 				}
-			}
-			else if (args[0].equalsIgnoreCase("remove") || args[0].equalsIgnoreCase("rm"))
-			{
-				if (args.length > 3 || !sender.hasPermission("bending.command.remove")) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("remove") || args[0].equalsIgnoreCase("rm")) {
+				if (args.length > 3 || !sender.hasPermission("bending.command.remove"))
+					return new ArrayList<String>();
 				List<String> l = new ArrayList<String>();
-				if (args.length == 2)
-				{
+				if (args.length == 2) {
 					for (Player p : Bukkit.getOnlinePlayers()) {
 						l.add(p.getName());
 					}
-				}
-				else
-				{
+				} else {
 					l.add("Air");
 					l.add("Earth");
 					l.add("Fire");
@@ -161,60 +143,58 @@ public class BendingTabComplete implements TabCompleter
 					l.add("Chi");
 				}
 				return getPossibleCompletionsForGivenArgs(args, l);
-			}
-			else if (args[0].equalsIgnoreCase("who") || args[0].equalsIgnoreCase("w"))
-			{
-				if (args.length > 2 || !sender.hasPermission("bending.command.remove")) return new ArrayList<String>();
+			} else if (args[0].equalsIgnoreCase("who") || args[0].equalsIgnoreCase("w")) {
+				if (args.length > 2 || !sender.hasPermission("bending.command.who"))
+					return new ArrayList<String>();
 				List<String> l = new ArrayList<String>();
 				for (Player p : Bukkit.getOnlinePlayers()) {
 					l.add(p.getName());
 				}
 				return getPossibleCompletionsForGivenArgs(args, l);
-			}	
-			else if (!PKCommand.instances.keySet().contains(args[0].toLowerCase()))
-			{
+			} else if (!PKCommand.instances.keySet().contains(args[0].toLowerCase())) {
 				return new ArrayList<String>();
 			}
-		}
-		else
-		{
+		} else {
 			return getPossibleCompletionsForGivenArgs(args, getCommandsForUser(sender));
 		}
 		return new ArrayList<String>();
 	}
-	
-	/**Breaks down the possible list and returns what is applicble depending on what the user has currently typed.
+
+	/**
+	 * Breaks down the possible list and returns what is applicble depending on
+	 * what the user has currently typed.
 	 * 
-	 * @author D4rKDeagle<br><br>(Found at <a>https://bukkit.org/threads/help-with-bukkit-tab-completion-api.166436</a>)
+	 * @author D4rKDeagle<br>
+	 * <br>
+	 *         (Found at
+	 *         <a>https://bukkit.org/threads/help-with-bukkit-tab-completion
+	 *         -api.166436</a>)
 	 * @param args Args of the command. Provide all of them.
-	 * @param possibilitiesOfCompletion List of things that can be given*/
-	public static List<String> getPossibleCompletionsForGivenArgs(String[] args, List<String> possibilitiesOfCompletion)
-	{
-		String argumentToFindCompletionFor = args[args.length-1];
-	 
+	 * @param possibilitiesOfCompletion List of things that can be given
+	 */
+	public static List<String> getPossibleCompletionsForGivenArgs(String[] args, List<String> possibilitiesOfCompletion) {
+		String argumentToFindCompletionFor = args[args.length - 1];
+
 		List<String> listOfPossibleCompletions = new ArrayList<String>();
-	 
-		for (String foundString : possibilitiesOfCompletion)
-		{	 
-			if (foundString.regionMatches(true, 0, argumentToFindCompletionFor, 0, argumentToFindCompletionFor.length()))
-			{
+
+		for (String foundString : possibilitiesOfCompletion) {
+			if (foundString.regionMatches(true, 0, argumentToFindCompletionFor, 0, argumentToFindCompletionFor.length())) {
 				listOfPossibleCompletions.add(foundString);
 			}
 		}
 		return listOfPossibleCompletions;
 	}
-	
-	public static List<String> getPossibleCompletionsForGivenArgs(String[] args, String[] possibilitiesOfCompletion)
-	{
+
+	public static List<String> getPossibleCompletionsForGivenArgs(String[] args, String[] possibilitiesOfCompletion) {
 		return getPossibleCompletionsForGivenArgs(args, Arrays.asList(possibilitiesOfCompletion));
 	}
-	
-	/**Returns a list of subcommands the sender can use.*/
-	public static List<String> getCommandsForUser(CommandSender sender)
-	{
+
+	/** Returns a list of subcommands the sender can use. */
+	public static List<String> getCommandsForUser(CommandSender sender) {
 		List<String> list = new ArrayList<String>();
 		for (String cmd : PKCommand.instances.keySet()) {
-			if (sender.hasPermission("bending.command." + cmd.toLowerCase())) list.add(cmd);
+			if (sender.hasPermission("bending.command." + cmd.toLowerCase()))
+				list.add(cmd);
 		}
 		Collections.sort(list);
 		return list;

--- a/src/com/projectkorra/projectkorra/command/PermaremoveCommand.java
+++ b/src/com/projectkorra/projectkorra/command/PermaremoveCommand.java
@@ -72,17 +72,17 @@ public class PermaremoveCommand extends PKCommand {
 	}
 
 	/**
-	 * Checks if the sender has the permission 'bending.admin.permremove'. If
+	 * Checks if the sender has the permission 'bending.admin.permaremove'. If
 	 * not, it tells them they don't have permission to use the command.
 	 * 
 	 * @return True if they have the permission, false otherwise
 	 */
 	@Override
 	public boolean hasPermission(CommandSender sender) {
-		if (sender.hasPermission("bending.admin.permremove")) {
+		if (!sender.hasPermission("bending.admin.permaremove")) {
 			sender.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
-			return true;
+			return false;
 		}
-		return false;
+		return true;
 	}
 }

--- a/src/com/projectkorra/projectkorra/command/ToggleCommand.java
+++ b/src/com/projectkorra/projectkorra/command/ToggleCommand.java
@@ -9,6 +9,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -60,8 +61,8 @@ public class ToggleCommand extends PKCommand {
 				if (!(sender instanceof Player))
 					sender.sendMessage(ChatColor.RED + "Bending has been toggled off for all players.");
 			}
-		} else if (sender instanceof Player && args.size() == 1 && Element.getType(args.get(0)) != null && sender.hasPermission("bending." + args.get(0).toLowerCase())) {
-			Element e = Element.getType(args.get(0));
+		} else if (sender instanceof Player && args.size() == 1 && Element.getType(args.get(0)) != null && sender.hasPermission("bending." + getElement(args.get(0)))) {
+			Element e = Element.getType(getElement(args.get(0)));
 			BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(sender.getName());
 			bPlayer.toggleElement(e);
 			if (bPlayer.isElementToggled(e) == false) {
@@ -77,12 +78,13 @@ public class ToggleCommand extends PKCommand {
 					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled on your " + args.get(0).toLowerCase() + "bending");
 				}
 			}
-		} else if (sender instanceof Player && args.size() == 2 && Element.getType(args.get(0)) != null && sender.hasPermission("bending." + args.get(0).toLowerCase())) {
+		} else if (sender instanceof Player && args.size() == 2 && Element.getType(args.get(0)) != null && sender.hasPermission("bending." + getElement(args.get(0)))) {
 			Player target = Bukkit.getPlayer(args.get(1));
+			if (!hasAdminPermission(sender)) return;
 			if (target == null) {
 				sender.sendMessage(ChatColor.RED + "Target is not found.");
 			}
-			Element e = Element.getType(args.get(0));
+			Element e = Element.getType(getElement(args.get(0)));
 			BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(target.getName());
 			if (bPlayer.isElementToggled(e) == true) {
 				if (e == Element.Chi) {
@@ -107,4 +109,20 @@ public class ToggleCommand extends PKCommand {
 		}
 	}
 
+	public String getElement(String string) {
+		if (Arrays.asList(Commands.airaliases).contains(string)) return "air";
+		if (Arrays.asList(Commands.chialiases).contains(string)) return "chi";
+		if (Arrays.asList(Commands.earthaliases).contains(string)) return "earth";
+		if (Arrays.asList(Commands.firealiases).contains(string)) return "fire";
+		if (Arrays.asList(Commands.wateraliases).contains(string)) return "water";
+		return null;
+	}
+
+	public boolean hasAdminPermission(CommandSender sender) {
+		if (!sender.hasPermission("bending.admin.toggle")) {
+			sender.sendMessage(ChatColor.RED + "You don't have permission to do that.");
+			return false;
+		}
+		return true;
+	}
 }

--- a/src/com/projectkorra/projectkorra/firebending/FireStream.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireStream.java
@@ -78,6 +78,14 @@ public class FireStream implements ConfigLoadable {
 	public static String getDescription() {
 		return "This ability no longer exists.";
 	}
+	
+	public static void handleDissipation() {
+		for (Block block : ignitedblocks.keySet()) {
+			if (block.getType() != Material.FIRE) {
+				ignitedblocks.remove(block);
+			}
+		}
+	}
 
 	public static boolean isIgnitable(Player player, Block block) {
 

--- a/src/com/projectkorra/projectkorra/firebending/FirebendingManager.java
+++ b/src/com/projectkorra/projectkorra/firebending/FirebendingManager.java
@@ -2,9 +2,6 @@ package com.projectkorra.projectkorra.firebending;
 
 import com.projectkorra.projectkorra.ProjectKorra;
 
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-
 public class FirebendingManager implements Runnable {
 
 	public ProjectKorra plugin;
@@ -14,6 +11,8 @@ public class FirebendingManager implements Runnable {
 	}
 
 	public void run() {
+		FireStream.handleDissipation();
+		Enflamed.handleFlames();
 		FirePassive.handlePassive();
 		FireJet.progressAll();
 		Cook.progressAll();
@@ -25,11 +24,6 @@ public class FirebendingManager implements Runnable {
 		Lightning.progressAll();
 		WallOfFire.progressAll();
 		Combustion.progressAll();
-		for (Block block : FireStream.ignitedblocks.keySet()) {
-			if (block.getType() != Material.FIRE) {
-				FireStream.ignitedblocks.remove(block);
-			}
-		}
 		FireMethods.removeFire();
 		HeatControl.progressAll();
 		FireStream.dissipateAll();

--- a/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
+++ b/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
@@ -40,6 +40,9 @@ public class HorizontalVelocityTracker {
 	public static String[] abils = {"AirBlast", "AirBurst", "AirSuction", "Bloodbending"};
 
 	public HorizontalVelocityTracker(Entity e, Player instigator, long delay, String ability, Element element, SubElement se) {
+		if (!ProjectKorra.plugin.getConfig().getBoolean("Properties.HorizontalCollisionPhysics.Enabled"))
+			return;
+
 		remove(e);
 		entity = e;
 		this.instigator = instigator;
@@ -58,6 +61,11 @@ public class HorizontalVelocityTracker {
 
 	public void update() {
 		if (System.currentTimeMillis() < fireTime + delay) {
+			return;
+		}
+		
+		if (entity.isOnGround()) {
+			remove();
 			return;
 		}
 

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -27,6 +27,7 @@ permissions:
       bending.ability.MetalClips.4clips: true
       bending.command.import: true
       bending.command.toggle.all: true
+      bending.admin.toggle: true
       bending.command.give: true
       bending.command.invincible: true
       bending.command.check: true


### PR DESCRIPTION
- Fixed AirShield not blocking earth and water abilities.
- Fixed AirSwipe stopping when it hit a non living entity
- Fixed AutoTab not allowing player names with who command
- Fixed Permaremove command permissions
- Fixed Enflamed instances being managed
- Fixed FireStream dissipation being managed
- Fixed HorizontalVelocity:
  - Entity not being removed from instances when landing and not hitting
wall
  - Still adding entities to instances when disabled
- Fixed toggle element command working for everyone, see below:
- Added bending.admin.toggle permission, used for toggling elements of
another player (need to add other player bending toggling but Chris
rushed me)
- Changed getBendingPlayer to be more exact with uuids