### PR TITLE
Fix commands, Fix EarthSmash bug

### DIFF
--- a/src/com/projectkorra/projectkorra/command/RemoveCommand.java
+++ b/src/com/projectkorra/projectkorra/command/RemoveCommand.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.command;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.chiblocking.ChiMethods;
 import com.projectkorra.projectkorra.event.PlayerChangeElementEvent;
 import com.projectkorra.projectkorra.event.PlayerChangeElementEvent.Result;
 
@@ -11,6 +12,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -30,6 +32,23 @@ public class RemoveCommand extends PKCommand {
 
 		Player player = Bukkit.getPlayer(args.get(0));
 		if (player == null) {
+			Element e = Element.getType(getElement(args.get(0)));
+			if (e != null && sender instanceof Player) {
+				if (GeneralMethods.getBendingPlayer(sender.getName()).hasElement(e)) {
+					GeneralMethods.getBendingPlayer(sender.getName()).getElements().remove(e);
+					GeneralMethods.saveElements(GeneralMethods.getBendingPlayer(sender.getName()));
+					GeneralMethods.removeUnusableAbilities(sender.getName());
+					if (e == Element.Chi) {
+						sender.sendMessage(ChiMethods.getChiColor() + "You have removed your chiblocking.");
+						return;
+					}
+					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have removed your " + e.toString().toLowerCase() + "bending.");
+					return;
+				} else {
+					sender.sendMessage(ChatColor.RED + "You do not have that element!");
+					return;
+				}
+			}
 			sender.sendMessage(ChatColor.RED + "That player is not online.");
 			return;
 		}
@@ -40,26 +59,33 @@ public class RemoveCommand extends PKCommand {
 			bPlayer = GeneralMethods.getBendingPlayer(player.getName());
 		}
 		if (args.size() == 2) {
-			if (Element.getType(args.get(1)) != null) {
-				bPlayer.getElements().remove(Element.getType(args.get(1)));
-				GeneralMethods.removeUnusableAbilities(player.getName());
-				if (Element.getType(args.get(1)) == Element.Chi) {
-					sender.sendMessage(ChatColor.GREEN + "You have removed the " + args.get(1).toLowerCase() + "blocking of " + ChatColor.DARK_AQUA + player.getName());
-					player.sendMessage(ChatColor.GREEN + "Your " + args.get(1).toLowerCase() + "blocking has been removed by " + ChatColor.DARK_AQUA + sender.getName());
-				} else {
-					sender.sendMessage(ChatColor.GREEN + "You have removed the " + args.get(1).toLowerCase() + "bending of " + ChatColor.DARK_AQUA + player.getName());
-					player.sendMessage(ChatColor.GREEN + "Your " + args.get(1).toLowerCase() + "bending has been removed by " + ChatColor.DARK_AQUA + sender.getName());
+			Element e = Element.getType(getElement(args.get(1)));
+			if (e != null) {
+				if (!bPlayer.hasElement(e)) {
+					sender.sendMessage(ChatColor.DARK_RED + "Targeted player does not have that element");
+					return;
 				}
-				Bukkit.getServer().getPluginManager().callEvent(new PlayerChangeElementEvent(sender, player, Element.getType(args.get(1)), Result.REMOVE));
+				bPlayer.getElements().remove(e);
+				GeneralMethods.saveElements(bPlayer);
+				GeneralMethods.removeUnusableAbilities(player.getName());
+				if (e == Element.Chi) {
+					sender.sendMessage(ChiMethods.getChiColor() + "You have removed the chiblocking of " + ChatColor.DARK_AQUA + player.getName());
+					player.sendMessage(ChiMethods.getChiColor() + "Your chiblocking has been removed by " + ChatColor.DARK_AQUA + sender.getName());
+				} else {
+					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have removed the " + getElement(args.get(1)).toLowerCase() + "bending of " + ChatColor.DARK_AQUA + player.getName());
+					player.sendMessage(GeneralMethods.getElementColor(e) + "Your " + getElement(args.get(1)).toLowerCase() + "bending has been removed by " + ChatColor.DARK_AQUA + sender.getName());
+				}
+				Bukkit.getServer().getPluginManager().callEvent(new PlayerChangeElementEvent(sender, player, e, Result.REMOVE));
 				return;
 			}
+		} else if (args.size() == 1) {
+			bPlayer.getElements().clear();
+			GeneralMethods.saveElements(bPlayer);
+			GeneralMethods.removeUnusableAbilities(player.getName());
+			sender.sendMessage(ChatColor.YELLOW + "You have removed the bending of " + ChatColor.DARK_AQUA + player.getName());
+			player.sendMessage(ChatColor.YELLOW + "Your bending has been removed by " + ChatColor.DARK_AQUA + sender.getName());
+			Bukkit.getServer().getPluginManager().callEvent(new PlayerChangeElementEvent(sender, player, null, Result.REMOVE));
 		}
-		bPlayer.getElements().clear();
-		GeneralMethods.saveElements(bPlayer);
-		GeneralMethods.removeUnusableAbilities(player.getName());
-		sender.sendMessage(ChatColor.GREEN + "You have removed the bending of " + ChatColor.DARK_AQUA + player.getName());
-		player.sendMessage(ChatColor.GREEN + "Your bending has been removed by " + ChatColor.DARK_AQUA + sender.getName());
-		Bukkit.getServer().getPluginManager().callEvent(new PlayerChangeElementEvent(sender, player, null, Result.REMOVE));
 	}
 
 	/**
@@ -75,5 +101,14 @@ public class RemoveCommand extends PKCommand {
 		}
 		sender.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
 		return false;
+	}
+	
+	public String getElement(String string) {
+		if (Arrays.asList(Commands.airaliases).contains(string)) return "air";
+		if (Arrays.asList(Commands.chialiases).contains(string)) return "chi";
+		if (Arrays.asList(Commands.earthaliases).contains(string)) return "earth";
+		if (Arrays.asList(Commands.firealiases).contains(string)) return "fire";
+		if (Arrays.asList(Commands.wateraliases).contains(string)) return "water";
+		return null;
 	}
 }

--- a/src/com/projectkorra/projectkorra/command/ToggleCommand.java
+++ b/src/com/projectkorra/projectkorra/command/ToggleCommand.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.command;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.chiblocking.ChiMethods;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -61,24 +62,24 @@ public class ToggleCommand extends PKCommand {
 				if (!(sender instanceof Player))
 					sender.sendMessage(ChatColor.RED + "Bending has been toggled off for all players.");
 			}
-		} else if (sender instanceof Player && args.size() == 1 && Element.getType(args.get(0)) != null && sender.hasPermission("bending." + getElement(args.get(0)))) {
+		} else if (sender instanceof Player && args.size() == 1 && Element.getType(getElement(args.get(0))) != null && GeneralMethods.getBendingPlayer(sender.getName()).hasElement(Element.getType(getElement(args.get(0))))) {
 			Element e = Element.getType(getElement(args.get(0)));
 			BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(sender.getName());
 			bPlayer.toggleElement(e);
 			if (bPlayer.isElementToggled(e) == false) {
 				if (e == Element.Chi) {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled off your " + args.get(0).toLowerCase() + "blocking");
+					sender.sendMessage(ChiMethods.getChiColor() + "You have toggled off your chiblocking");
 				} else {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled off your " + args.get(0).toLowerCase() + "bending");
+					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled off your " + getElement(args.get(0)).toLowerCase() + "bending");
 				}
 			} else {
 				if (e == Element.Chi) {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled on your " + args.get(0).toLowerCase() + "blocking");
+					sender.sendMessage(ChiMethods.getChiColor() + "You have toggled on your chiblocking");
 				} else {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled on your " + args.get(0).toLowerCase() + "bending");
+					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled on your " + getElement(args.get(0)).toLowerCase() + "bending");
 				}
 			}
-		} else if (sender instanceof Player && args.size() == 2 && Element.getType(args.get(0)) != null && sender.hasPermission("bending." + getElement(args.get(0)))) {
+		} else if (sender instanceof Player && args.size() == 2 && Element.getType(getElement(args.get(0))) != null && GeneralMethods.getBendingPlayer(sender.getName()).hasElement(Element.getType(getElement(args.get(0))))) {
 			Player target = Bukkit.getPlayer(args.get(1));
 			if (!hasAdminPermission(sender)) return;
 			if (target == null) {
@@ -88,19 +89,19 @@ public class ToggleCommand extends PKCommand {
 			BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(target.getName());
 			if (bPlayer.isElementToggled(e) == true) {
 				if (e == Element.Chi) {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled off " + ChatColor.DARK_AQUA + target.getName() + "'s " + args.get(0).toLowerCase() + "blocking");
-					target.sendMessage(GeneralMethods.getElementColor(e) + "Your " + args.get(0).toLowerCase() + "blocking has been toggled off by " + ChatColor.DARK_AQUA + sender.getName());
+					sender.sendMessage(ChiMethods.getChiColor() + "You have toggled off " + ChatColor.DARK_AQUA + target.getName() + "'s chiblocking");
+					target.sendMessage(ChiMethods.getChiColor() + "Your chiblocking has been toggled off by " + ChatColor.DARK_AQUA + sender.getName());
 				} else {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled off " + ChatColor.DARK_AQUA + target.getName() + "'s " + args.get(0).toLowerCase() + "bending");
-					target.sendMessage(GeneralMethods.getElementColor(e) + "Your " + args.get(0).toLowerCase() + "bending has been toggled off by " + ChatColor.DARK_AQUA + sender.getName());
+					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled off " + ChatColor.DARK_AQUA + target.getName() + "'s " + getElement(args.get(0)).toLowerCase() + "bending");
+					target.sendMessage(GeneralMethods.getElementColor(e) + "Your " + getElement(args.get(0)).toLowerCase() + "bending has been toggled off by " + ChatColor.DARK_AQUA + sender.getName());
 				}
 			} else {
 				if (e == Element.Chi) {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled on " + ChatColor.DARK_AQUA + target.getName() + "'s " + args.get(0).toLowerCase() + "blocking");
-					target.sendMessage(GeneralMethods.getElementColor(e) + "Your " + args.get(0).toLowerCase() + "blocking has been toggled on by " + ChatColor.DARK_AQUA + sender.getName());
+					sender.sendMessage(ChiMethods.getChiColor() + "You have toggled on " + ChatColor.DARK_AQUA + target.getName() + "'s chiblocking");
+					target.sendMessage(ChiMethods.getChiColor() + "Your chiblocking has been toggled on by " + ChatColor.DARK_AQUA + sender.getName());
 				} else {
-					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled on " + ChatColor.DARK_AQUA + target.getName() + "'s " + args.get(0).toLowerCase() + "bending");
-					target.sendMessage(GeneralMethods.getElementColor(e) + "Your " + args.get(0).toLowerCase() + "bending has been toggled on by " + ChatColor.DARK_AQUA + sender.getName());
+					sender.sendMessage(GeneralMethods.getElementColor(e) + "You have toggled on " + ChatColor.DARK_AQUA + target.getName() + "'s " + getElement(args.get(0)).toLowerCase() + "bending");
+					target.sendMessage(GeneralMethods.getElementColor(e) + "Your " + getElement(args.get(0)).toLowerCase() + "bending has been toggled on by " + ChatColor.DARK_AQUA + sender.getName());
 				}
 			}
 			bPlayer.toggleElement(e);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthMethods.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthMethods.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.earthbending;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.AbilityModuleManager;
+import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.util.BlockSource;
 import com.projectkorra.projectkorra.util.Information;
 import com.projectkorra.projectkorra.util.ParticleEffect;
@@ -31,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EarthMethods {
 
 	static ProjectKorra plugin;
-	private static FileConfiguration config = ProjectKorra.plugin.getConfig();
+	private static FileConfiguration config = ConfigManager.defaultConfig.get();
 
 	public static ConcurrentHashMap<Block, Information> movedearth = new ConcurrentHashMap<Block, Information>();
 	public static ConcurrentHashMap<Integer, Information> tempair = new ConcurrentHashMap<Integer, Information>();
@@ -161,7 +162,7 @@ public class EarthMethods {
 	@SuppressWarnings("deprecation")
 	public static Block getEarthSourceBlock(Player player, double range) {
 		Block testblock = player.getTargetBlock(getTransparentEarthbending(), (int) range);
-		if (isEarthbendable(player, testblock))
+		if (isEarthbendable(player, testblock) || isMetalbendable(player, testblock.getType()))
 			return testblock;
 		Location location = player.getEyeLocation();
 		Vector vector = location.getDirection().clone().normalize();
@@ -305,15 +306,25 @@ public class EarthMethods {
 			valid = true;
 		}
 
-		if (!valid)
-			return false;
-
 		if (tempNoEarthbending.contains(block))
-			return false;
+			valid = false;
 
-		if (!GeneralMethods.isRegionProtectedFromBuild(player, ability, block.getLocation()))
-			return true;
-		return false;
+		if (GeneralMethods.isRegionProtectedFromBuild(player, ability, block.getLocation()))
+			valid = false;
+		return valid;
+	}
+	
+	public static boolean isMetalbendable(Player player, Material mat) {
+		boolean valid = false;
+		for (String s : config.getStringList("Properties.Earth.MetalBlocks")) {
+			if (mat == Material.getMaterial(s)) {
+				valid = true;
+				break;
+			}
+		}
+		if (!player.hasPermission("bending.earth.metalbending"))
+			valid = false;
+		return valid;
 	}
 
 	public static boolean isMetalBlock(Block block) {

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -301,7 +301,7 @@ public class EarthSmash {
 								remove();
 								return;
 							}
-							if (isEarthbendableMaterial(block.getType()))
+							if (EarthMethods.isEarthbendable(player, block))
 								totalBendableBlocks++;
 						}
 				if (totalBendableBlocks < REQUIRED_BENDABLE_BLOCKS) {
@@ -331,13 +331,13 @@ public class EarthSmash {
 					for (int z = -1; z <= 1; z++) {
 						if ((Math.abs(x) + Math.abs(z)) % 2 == 1) {
 							Block block = loc.clone().add(x, -2, z).getBlock();
-							if (isEarthbendableMaterial(block.getType()))
+							if (EarthMethods.isEarthbendable(player, block))
 								EarthMethods.addTempAirBlock(block);
 						}
 
 						//Remove the first level of dirt
 						Block block = loc.clone().add(x, -1, z).getBlock();
-						if (isEarthbendableMaterial(block.getType()))
+						if (EarthMethods.isEarthbendable(player, block))
 							EarthMethods.addTempAirBlock(block);
 
 					}
@@ -466,7 +466,7 @@ public class EarthSmash {
 	public Material selectMaterialForRepresenter(Material mat) {
 		Material tempMat = selectMaterial(mat);
 		Random rand = new Random();
-		if (!isEarthbendableMaterial(tempMat)) {
+		if (!EarthMethods.isEarthbendable(tempMat) || !EarthMethods.isMetalbendable(player, tempMat)) {
 			if (currentBlocks.size() < 1)
 				return Material.DIRT;
 			else
@@ -548,14 +548,6 @@ public class EarthSmash {
 			}
 		}
 		return null;
-	}
-
-	public static boolean isEarthbendableMaterial(Material mat) {
-		for (String s : ProjectKorra.plugin.getConfig().getStringList("Properties.Earth.EarthbendableBlocks")) {
-			if (mat == Material.getMaterial(s))
-				return true;
-		}
-		return false;
 	}
 
 	public static void progressAll() {


### PR DESCRIPTION
- Remove command:
    - Fixed element aliases not working
    - Added argument /b remove <element> which only removes a single element
from you if you have it. Tells you if you don't
- Fixed toggle command aliases and message messing up
- EarthMethods:
    - Added isMetalbendable(Player player, Material mat)
        - Checks for the material being in the metalblocks list in config and if
the player has metalbending permission
    - Added check for metal blocks in getEarthSourceBlock()
- Fixed EarthSmash having problems with metal blocks