### PR TITLE
Fix chat error

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -181,7 +181,7 @@ public class PKListener implements Listener {
 		String append = "";
 		ChatColor color = null;
 		boolean chatEnabled = ProjectKorra.plugin.getConfig().getBoolean("Properties.Chat.Enable");
-		if ((player.hasPermission("bending.avatar") || GeneralMethods.getBendingPlayer(player.getName()).getElements().size() > 1) && chatEnabled) {
+		if (GeneralMethods.getBendingPlayer(player.getName()).getElements().size() > 1 && chatEnabled) {
 			append = plugin.getConfig().getString("Properties.Chat.Prefixes.Avatar");
 			color = ChatColor.valueOf(plugin.getConfig().getString("Properties.Chat.Colors.Avatar"));
 		} else if (GeneralMethods.isBender(player.getName(), Element.Air) && chatEnabled) {
@@ -199,6 +199,9 @@ public class PKListener implements Listener {
 		} else if (GeneralMethods.isBender(player.getName(), Element.Chi) && chatEnabled) {
 			append = plugin.getConfig().getString("Properties.Chat.Prefixes.Chi");
 			color = ChiMethods.getChiColor();
+		} else {
+			append = "[Nonbender]";
+			color = ChatColor.WHITE;
 		}
 		
 		if (chatEnabled) {
@@ -383,6 +386,9 @@ public class PKListener implements Listener {
 		} else if (e == Element.Chi && chatEnabled) {
 			append = plugin.getConfig().getString("Properties.Chat.Prefixes.Chi");
 			color = ChiMethods.getChiColor();
+		} else {
+			append = "[Nonbender]";
+			color = ChatColor.WHITE;
 		}
 		
 		if (chatEnabled) {


### PR DESCRIPTION
- Fixed players without elements chat appearing as "null<playername>". Now says [Nonbender] in white.
- Removed unnecessary bending.avatar permission check on login.