### PR TITLE
Various Fixes (read desc)

### DIFF
--- a/src/com/projectkorra/projectkorra/BendingManager.java
+++ b/src/com/projectkorra/projectkorra/BendingManager.java
@@ -177,7 +177,7 @@ public class BendingManager implements Runnable, ConfigLoadable {
 			handleCooldowns();
 		}
 		catch (Exception e) {
-			GeneralMethods.stopBending();
+			//GeneralMethods.stopBending();
 			e.printStackTrace();
 		}
 	}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1160,7 +1160,9 @@ public class PKListener implements Listener {
 
 		if (Suffocate.isBreathbent(player)) {
 			if (!GeneralMethods.getBoundAbility(player).equalsIgnoreCase("AirSwipe") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("FireBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("EarthBlast") || !GeneralMethods.getBoundAbility(player).equalsIgnoreCase("WaterManipulation")) {
-				event.setCancelled(true);
+				if(!player.isSneaking()) {
+					event.setCancelled(true);
+				}
 			}
 		}
 

--- a/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -78,7 +78,8 @@ public class PresetCommand extends PKCommand {
 				sender.sendMessage(ChatColor.RED + "You don't have a preset with that name.");
 				return;
 			}
-			boolean boundAll = Preset.bindPreset(player, name);
+			Preset preset = Preset.getPreset(player, name);
+			boolean boundAll = Preset.bindPreset(player, preset);
 			sender.sendMessage(ChatColor.GREEN + "Your bound slots have been set to match the " + ChatColor.YELLOW + name + ChatColor.GREEN + " preset.");
 			if (!boundAll) {
 				sender.sendMessage(ChatColor.RED + "Some abilities were not bound because you cannot bend the required element.");
@@ -100,7 +101,7 @@ public class PresetCommand extends PKCommand {
 				return;
 			HashMap<Integer, String> abilities = bPlayer.getAbilities();
 			Preset preset = new Preset(player.getUniqueId(), name, abilities);
-			preset.save();
+			preset.save(player);
 			sender.sendMessage(ChatColor.GREEN + "Created preset with the name: " + ChatColor.YELLOW + name);
 		} else {
 			help(sender, false);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthMethods.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthMethods.java
@@ -177,7 +177,7 @@ public class EarthMethods {
 	@SuppressWarnings("deprecation")
 	public static Block getEarthSourceBlock(Player player, int range, boolean earth, boolean sand, boolean metal) {
 	Block testblock = player.getTargetBlock(getTransparentEarthbending(), range);
-		if (isEarthbendable(testblock.getType()) && earth == true) 
+		if (isEarthbendable(testblock) && earth == true) 
 			return testblock;
 		if (isSand(testblock) && sand == true)
 			return testblock;
@@ -218,7 +218,7 @@ public class EarthMethods {
 				continue;
 			}
 			if (isTransparentToEarthbending(player, block.getRelative(BlockFace.UP))) {
-				if (isEarthbendable(block.getType()) && earth == true) {
+				if (isEarthbendable(block) && earth == true) {
 					BlockSource.randomBlocks.add(block);
 					return block;
 				}
@@ -258,7 +258,7 @@ public class EarthMethods {
 				Block block = GeneralMethods.getTopBlock(searchLoc, maxVertical);
 
 				if (block != null) {
-					if (isEarthbendable(block.getType()) && earth == true)
+					if (isEarthbendable(block) && earth == true)
 						return block;
 					if (isSand(block) && sand == true)
 						return block;
@@ -342,10 +342,16 @@ public class EarthMethods {
 		return isEarthbendable(player, "RaiseEarth", block);
 	}
 
+	public static boolean isEarth(Block block) {
+		Material material = block.getType();
+		return config.getStringList("Properties.Earth.EarthbendableBlocks").contains(material.toString());
+	}
+	
 	public static boolean isMetal(Block block) {
 		Material material = block.getType();
 		return config.getStringList("Properties.Earth.MetalBlocks").contains(material.toString());
 	}
+	
 	public static boolean isSand(Block block) {
 		Material material = block.getType();
 		return config.getStringList("Properties.Earth.SandBlocks").contains(material.toString());
@@ -354,12 +360,16 @@ public class EarthMethods {
 	public static double getMetalAugment(double value) {
 		return value * config.getDouble("Properties.Earth.MetalPowerFactor");
 	}
-
-	public static boolean isEarthbendable(Material mat) {
-		for (String s : config.getStringList("Properties.Earth.EarthbendableBlocks")) {
-			if (mat == Material.getMaterial(s)) {
-				return true;
-			}
+	
+	public static boolean isEarthbendable(Block block) {
+		if (isEarth(block)) {
+			return true;
+		}
+		if (isSand(block)) {
+			return true;
+		}
+		if (isMetal(block)) {
+			return true;
 		}
 		return false;
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -46,7 +46,7 @@ public class EarthSmash {
 
 	private static int REQUIRED_BENDABLE_BLOCKS = 11;
 	private static int MAX_BLOCKS_TO_PASS_THROUGH = 3;
-	private static double GRAB_DETECTION_RADIUS = 2.5;
+	private static double GRAB_DETECTION_RADIUS = 5;
 	private static double FLIGHT_DETECTION_RADIUS = 3.8;
 	private static long SHOOTING_ANIMATION_COOLDOWN = 25;
 	private static long FLYING_ANIMATION_COOLDOWN = 0;
@@ -168,7 +168,7 @@ public class EarthSmash {
 		if (state == State.START && progressCounter > 1) {
 			if (!player.isSneaking()) {
 				if (System.currentTimeMillis() - time > chargeTime) {
-					origin = EarthMethods.getEarthSourceBlock(player, grabRange, true, EarthMethods.canSandbend(player), false);
+					origin = EarthMethods.getEarthSourceBlock(player, grabRange, true, EarthMethods.canSandbend(player), EarthMethods.canMetalbend(player));
 					if (origin == null) {
 						remove();
 						return;
@@ -302,8 +302,9 @@ public class EarthSmash {
 								remove();
 								return;
 							}
-							if (EarthMethods.isEarthbendable(player, block))
+							if (EarthMethods.isEarthbendable(player, block)) {
 								totalBendableBlocks++;
+							}
 						}
 				if (totalBendableBlocks < REQUIRED_BENDABLE_BLOCKS) {
 					remove();
@@ -324,7 +325,7 @@ public class EarthSmash {
 						for (int z = -1; z <= 1; z++)
 							if ((Math.abs(x) + Math.abs(y) + Math.abs(z)) % 2 == 0) {
 								Block block = tempLoc.clone().add(x, y, z).getBlock();
-								currentBlocks.add(new BlockRepresenter(x, y, z, selectMaterialForRepresenter(block.getType()), block.getData()));
+								currentBlocks.add(new BlockRepresenter(x, y, z, selectMaterialForRepresenter(block), block.getData()));
 							}
 
 				//Remove the design of the second level of removed dirt
@@ -464,12 +465,13 @@ public class EarthSmash {
 			return mat;
 	}
 
-	public Material selectMaterialForRepresenter(Material mat) {
-		Material tempMat = selectMaterial(mat);
+	public Material selectMaterialForRepresenter(Block block) {
+		Material tempMat = selectMaterial(block.getType());
 		Random rand = new Random();
-		if (!EarthMethods.isEarthbendable(tempMat) || !EarthMethods.isMetalbendable(player, tempMat)) {
-			if (currentBlocks.size() < 1)
+		if (!EarthMethods.isEarthbendable(player, block)) {
+			if (currentBlocks.size() < 1) {
 				return Material.DIRT;
+			}
 			else
 				return currentBlocks.get(rand.nextInt(currentBlocks.size())).getType();
 		}

--- a/src/com/projectkorra/projectkorra/object/Preset.java
+++ b/src/com/projectkorra/projectkorra/object/Preset.java
@@ -37,9 +37,9 @@ public class Preset {
 	static String updateQuery1 = "UPDATE pk_presets SET slot";
 	static String updateQuery2 = " = ? WHERE uuid = ? AND name = ?";
 
-	UUID uuid;
-	HashMap<Integer, String> abilities;
-	String name;
+	public UUID uuid;
+	public HashMap<Integer, String> abilities;
+	public String name;
 
 	/**
 	 * Creates a new {@link Preset}
@@ -107,6 +107,16 @@ public class Preset {
 			}
 		}.runTaskAsynchronously(ProjectKorra.plugin);
 	}
+	
+	/**
+	 * Reload a Player's Presets from those stored in memory.
+	 * 
+	 * @param player The Player who's Presets should be unloaded
+	 */
+	public static void reloadPreset(Player player) {
+		unloadPreset(player);
+		loadPresets(player);
+	}
 
 	/**
 	 * Binds the abilities from a Preset for the given Player.
@@ -115,22 +125,15 @@ public class Preset {
 	 * @param name The name of the Preset that should be bound
 	 * @return True if all abilities were successfully bound, or false otherwise
 	 */
-	@SuppressWarnings("unchecked")
-	public static boolean bindPreset(Player player, String name) {
+	public static boolean bindPreset(Player player, Preset preset) {
 		BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
-		if (bPlayer == null)
+		if (bPlayer == null) {
 			return false;
-		if (!presets.containsKey(player.getUniqueId()))
+		}
+		if (!presets.containsKey(player.getUniqueId())) {
 			return false;
-		HashMap<Integer, String> abilities = null;
-		for (Preset preset : presets.get(player.getUniqueId())) {
-			if (preset.name.equalsIgnoreCase(name)) { // We found it
-				abilities = (HashMap<Integer, String>) preset.abilities.clone();
-			}
 		}
-		if (abilities == null) {
-
-		}
+		HashMap<Integer, String> abilities = preset.abilities;
 		boolean boundAll = true;
 		for (int i = 1; i <= 9; i++) {
 			if (!GeneralMethods.canBend(player.getName(), abilities.get(i))) {
@@ -224,7 +227,7 @@ public class Preset {
 	/**
 	 * Saves the Preset to the database.
 	 */
-	public void save() {
+	public void save(final Player player) {
 		try {
 			PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement(loadNameQuery);
 			ps.setString(1, uuid.toString());
@@ -259,5 +262,19 @@ public class Preset {
 				}
 			}.runTaskAsynchronously(ProjectKorra.plugin);
 		}
+		
+		new BukkitRunnable() {
+
+			@Override
+			public void run() {
+				try {
+					Thread.sleep(1500);
+					reloadPreset(player);
+				}
+				catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+		}.runTaskAsynchronously(ProjectKorra.plugin);
 	}
 }

--- a/src/com/projectkorra/projectkorra/util/BlockSource.java
+++ b/src/com/projectkorra/projectkorra/util/BlockSource.java
@@ -149,7 +149,7 @@ public class BlockSource {
 		BlockSourceInformation info = getValidBlockSourceInformation(player, selectRange, sourceType, clickType);
 		if (info != null) {
 			Block tempBlock = info.getBlock();
-			if (EarthMethods.isEarthbendable(tempBlock.getType()) && earth) {
+			if (EarthMethods.isEarth(tempBlock) && earth) {
 				return tempBlock;
 			}
 			if (EarthMethods.isSand(tempBlock) && sand) {

--- a/src/com/projectkorra/projectkorra/util/RevertChecker.java
+++ b/src/com/projectkorra/projectkorra/util/RevertChecker.java
@@ -73,6 +73,7 @@ public class RevertChecker implements Runnable {
 		if (config.getBoolean("Properties.Earth.RevertEarthbending")) {
 
 			try {
+				if(plugin.isEnabled()) {
 				returnFuture = plugin.getServer().getScheduler().callSyncMethod(plugin, new getOccupiedChunks(plugin.getServer()));
 				ArrayList<Chunk> chunks = returnFuture.get();
 
@@ -107,6 +108,7 @@ public class RevertChecker implements Runnable {
 					if (remove) {
 						addToAirRevertQueue(i);
 					}
+				}
 				}
 			}
 			catch (Exception e) {


### PR DESCRIPTION
Fixes exceptions reloading the plugin
Fixes Presets (now work full as intended)
Fixes EarthSmash reacting with metal
Fixes Suffocation cancelling all shift events
Fixed disable error in RevertChecker

Removes isEarthbendable(material)

Adds isEarth(block) method to replace isEarthbendable(material), returns
true if block is in Earthbendables config list
Adds isEarthbendable(block), returns true if block is on the
Earthbendable, Sandbendable, or Metalbendable config lists
Adds metalbending capabilities to EarthSmash
Adds reloadPresets(player) method

Changes bindPreset(player, string) to bindPreset(player, Preset)
Changes save() to save(player)