### PR TITLE
Adds External Presets/Fixes EarthSmash & Updater

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -59,6 +59,7 @@ import com.projectkorra.projectkorra.firebending.FireBlast;
 import com.projectkorra.projectkorra.firebending.FireCombo;
 import com.projectkorra.projectkorra.firebending.FireMethods;
 import com.projectkorra.projectkorra.firebending.FireShield;
+import com.projectkorra.projectkorra.object.Preset;
 import com.projectkorra.projectkorra.storage.DBConnection;
 import com.projectkorra.projectkorra.util.Flight;
 import com.projectkorra.projectkorra.util.ParticleEffect;
@@ -1679,6 +1680,8 @@ public class GeneralMethods {
 		GeneralMethods.stopBending();
 		ConfigManager.defaultConfig.reload();
 		ConfigManager.deathMsgConfig.reload();
+		ConfigManager.presetConfig.reload();
+		Preset.loadExternalPresets();
 		BendingManager.getInstance().reloadVariables();
 		new AbilityModuleManager(plugin);
 		new ComboManager();

--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -11,6 +11,7 @@ import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.earthbending.EarthbendingManager;
 import com.projectkorra.projectkorra.firebending.FirebendingManager;
+import com.projectkorra.projectkorra.object.Preset;
 import com.projectkorra.projectkorra.storage.DBConnection;
 import com.projectkorra.projectkorra.util.MetricsLite;
 import com.projectkorra.projectkorra.util.RevertChecker;
@@ -51,13 +52,15 @@ public class ProjectKorra extends JavaPlugin {
 		}
 		new ConfigManager();
 		new GeneralMethods(this);
-		updater = new Updater(this, "http://projectkorra.com/forum/forums/dev-builds.16/index.rss");
+		updater = new Updater(this, "http://projectkorra.com/forums/dev-builds.16/index.rss");
 		new Commands(this);
 		abManager = new AbilityModuleManager(this);
 		new MultiAbilityModuleManager();
 		new MultiAbilityManager();
 		new ComboModuleManager();
 		new ComboManager();
+		
+		Preset.loadExternalPresets();
 
 		DBConnection.host = getConfig().getString("Storage.MySQL.host");
 		DBConnection.port = getConfig().getInt("Storage.MySQL.port");

--- a/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -5,6 +5,7 @@ import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.multiability.MultiAbilityManager;
 import com.projectkorra.projectkorra.object.Preset;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -30,7 +31,7 @@ public class PresetCommand extends PKCommand {
 
 	@Override
 	public void execute(CommandSender sender, List<String> args) {
-		if (!isPlayer(sender) || !correctLength(sender, args.size(), 1, 2)) {
+		if (!isPlayer(sender) || !correctLength(sender, args.size(), 1, 3)) {
 			return;
 		} else if (MultiAbilityManager.hasMultiAbilityBound((Player) sender)) {
 			sender.sendMessage(ChatColor.RED + "You can't edit your binds right now!");
@@ -74,15 +75,45 @@ public class PresetCommand extends PKCommand {
 			sender.sendMessage(ChatColor.GREEN + "You have deleted your preset named: " + ChatColor.YELLOW + name);
 			return;
 		} else if (Arrays.asList(bindaliases).contains(args.get(0)) && hasPermission(sender, "bind")) { //bending preset bind name
-			if (!Preset.presetExists(player, name)) {
-				sender.sendMessage(ChatColor.RED + "You don't have a preset with that name.");
-				return;
-			}
-			Preset preset = Preset.getPreset(player, name);
-			boolean boundAll = Preset.bindPreset(player, preset);
-			sender.sendMessage(ChatColor.GREEN + "Your bound slots have been set to match the " + ChatColor.YELLOW + name + ChatColor.GREEN + " preset.");
-			if (!boundAll) {
-				sender.sendMessage(ChatColor.RED + "Some abilities were not bound because you cannot bend the required element.");
+			if (args.size() < 3) {
+				boolean boundAll = false;
+				if (Preset.presetExists(player, name)) {
+					Preset preset = Preset.getPreset(player, name);
+					boundAll = Preset.bindPreset(player, preset);
+				} else if (Preset.externalPresetExists(name) && hasPermission(sender, "bind.external")) {
+					boundAll = Preset.bindExternalPreset(player, name);
+				} else if (!Preset.externalPresetExists(name) && hasPermission(sender, "bind.external")) {
+					sender.sendMessage(ChatColor.RED + "No external preset with that name exists.");
+					return;
+				} else {
+					sender.sendMessage(ChatColor.RED + "You don't have a preset with that name.");
+					return;
+				}
+
+				sender.sendMessage(ChatColor.GREEN + "Your bound slots have been set to match the " + ChatColor.YELLOW + name + ChatColor.GREEN + " preset.");
+				if (!boundAll) {
+					sender.sendMessage(ChatColor.RED + "Some abilities were not bound because you cannot bend the required element.");
+				}
+			} 
+			else if (hasPermission(sender, "bind.external.other")) {
+				if (!Preset.externalPresetExists(name)) {
+					sender.sendMessage(ChatColor.RED + "No external preset with that name exists.");
+					return;
+				}
+				
+				Player player2 = Bukkit.getPlayer(args.get(2));
+				if (player2 != null && player2.isOnline()) {
+					boolean boundAll = Preset.bindExternalPreset(player2, name);
+					
+					sender.sendMessage(ChatColor.GREEN + "The bound slots of " + ChatColor.YELLOW + player2.getName() + ChatColor.GREEN + " have been set to match the " + ChatColor.YELLOW + name + ChatColor.GREEN + " preset.");
+					player2.sendMessage(ChatColor.GREEN + "Your bound slots have been set to match the " + ChatColor.YELLOW + name + ChatColor.GREEN + " preset.");
+					if (!boundAll) {
+						player2.sendMessage(ChatColor.RED + "Some abilities were not bound, either the preset");
+					}
+					return;
+				} else {
+					sender.sendMessage(ChatColor.RED + "Player not found.");
+				}
 			}
 			return;
 		} else if (Arrays.asList(createaliases).contains(args.get(0)) && hasPermission(sender, "create")) { //bending preset create name

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -7,19 +7,41 @@ import java.util.ArrayList;
 
 public class ConfigManager {
 
+	public static Config presetConfig;
 	public static Config deathMsgConfig;
 	public static Config defaultConfig;
 
 	public ConfigManager() {
+		presetConfig = new Config(new File("presets.yml"));
 		deathMsgConfig = new Config(new File("deathmessages.yml"));
 		defaultConfig = new Config(new File("config.yml"));
 		configCheck(ConfigType.DEFAULT);
 		configCheck(ConfigType.DEATH_MESSAGE);
+		configCheck(ConfigType.PRESETS);
 	}
 
 	public static void configCheck(ConfigType type) {
 		FileConfiguration config;
 		switch (type) {
+			case PRESETS:
+				config = presetConfig.get();
+
+				ArrayList<String> abilities = new ArrayList<String>();
+				abilities.add("FireBlast");
+				abilities.add("AirBlast");
+				abilities.add("WaterManipulation");
+				abilities.add("EarthBlast");
+				abilities.add("FireBurst");
+				abilities.add("AirBurst");
+				abilities.add("Torrent");
+				abilities.add("Shockwave");
+				abilities.add("AvatarState");
+				
+				config.addDefault("Example", abilities);
+
+				presetConfig.save();
+				break;
+			
 			case DEATH_MESSAGE:
 				config = deathMsgConfig.get();
 
@@ -606,7 +628,8 @@ public class ConfigManager {
 				config.addDefault("Abilities.Earth.EarthSmash.AllowGrab", true);
 				config.addDefault("Abilities.Earth.EarthSmash.AllowShooting", true);
 				config.addDefault("Abilities.Earth.EarthSmash.AllowFlight", true);
-				config.addDefault("Abilities.Earth.EarthSmash.GrabRange", 10);
+				config.addDefault("Abilities.Earth.EarthSmash.SelectRange", 10);
+				config.addDefault("Abilities.Earth.EarthSmash.GrabRange", 3.0);
 				config.addDefault("Abilities.Earth.EarthSmash.ChargeTime", 1500);
 				config.addDefault("Abilities.Earth.EarthSmash.Cooldown", 2500);
 				config.addDefault("Abilities.Earth.EarthSmash.ShotRange", 30);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigType.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigType.java
@@ -14,5 +14,9 @@ public enum ConfigType {
 	/**
 	 * Death Message configuration represented by deathmessages.yml
 	 */
-	DEATH_MESSAGE;
+	DEATH_MESSAGE,
+	/**
+	 * Preset configuration represented by presets.yml
+	 */
+	PRESETS;
 }

--- a/src/com/projectkorra/projectkorra/util/ActionBar.java
+++ b/src/com/projectkorra/projectkorra/util/ActionBar.java
@@ -35,14 +35,14 @@ public class ActionBar {
 		return initialised;
 	}
 
-	public static boolean sendActionBar(String message, Player... p) {
+	public static boolean sendActionBar(String message, Player... player) {
 		if (!initialised) {
 			return false;
 		}
 		try {
 			Object o = chatSer.newInstance(message);
 			Object packet = packetChat.newInstance(o, (byte) 2);
-			sendTo(packet, p);
+			sendTo(packet, player);
 		}
 		catch (ReflectiveOperationException e) {
 			e.printStackTrace();
@@ -51,8 +51,8 @@ public class ActionBar {
 		return initialised;
 	}
 
-	private static void sendTo(Object packet, Player... pl) throws ReflectiveOperationException {
-		for (Player p : pl) {
+	private static void sendTo(Object packet, Player... player) throws ReflectiveOperationException {
+		for (Player p : player) {
 			Object entityplayer = getHandle.invoke(p);
 			Object PlayerConnection = playerConnection.get(entityplayer);
 			sendPacket.invoke(PlayerConnection, packet);

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -33,6 +33,8 @@ permissions:
       bending.command.give: true
       bending.command.invincible: true
       bending.command.check: true
+      bending.command.preset.bind.external: true
+      bending.command.preset.bind.external.other: true
       bending.admin.debug: true
       bending.admin.remove: true
   bending.player:


### PR DESCRIPTION
Adds ./b p b [external] <player> command to assign external presets to
yourself or another player
Adds presets.yml, used to define external presets
Adds "bending.command.preset.bind.external" node to determine whether
players can bind external presets to themselves, default: op
Adds "bending.command.preset.bind.external.other" node to determine
whether players can bind external presets to others, default: op
Adds loadExternalPresets() method to register all external presets
Adds bindExternalPresets(player, name) method to bind an external preset
Adds GrabRange config option to EarthSmash, used to determine how close
you must be to grab a smash
Adds SelectRange config option to EarthSmash, used to determine how
close you must select to create a smash

Fixes EarthSmash damage when blocks are broken
Fixes UpdateChecker for new website setup