### PR TITLE
Adds Copy command/Fixes Earthsmash & Presets

### DIFF
--- a/src/com/projectkorra/projectkorra/command/Commands.java
+++ b/src/com/projectkorra/projectkorra/command/Commands.java
@@ -80,6 +80,7 @@ public class Commands {
 		PluginCommand projectkorra = plugin.getCommand("projectkorra");
 		new AddCommand();
 		new BindCommand();
+		new CopyCommand();
 		new CheckCommand();
 		new ChooseCommand();
 		new ClearCommand();

--- a/src/com/projectkorra/projectkorra/command/CopyCommand.java
+++ b/src/com/projectkorra/projectkorra/command/CopyCommand.java
@@ -1,0 +1,101 @@
+package com.projectkorra.projectkorra.command;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
+
+public class CopyCommand extends PKCommand {
+	
+	public CopyCommand() {
+		super("copy", "/bending copy <Player> [Player]", "This command will allow the user to copy the binds of another player either for himself or assign them to <Player> if specified.", new String[] { "copy", "co" });
+	}
+
+	@Override
+	public void execute(CommandSender sender, List<String> args) {
+		if (!correctLength(sender, args.size(), 1, 2)) {
+			return;
+		} else if (args.size() == 1) {
+			if (!hasPermission(sender) || !isPlayer(sender)) {
+				return;
+			}
+
+			Player orig = Bukkit.getPlayer(args.get(0));
+
+			if (orig == null || !orig.isOnline()) {
+				sender.sendMessage(ChatColor.RED + "Player not found.");
+				return;
+			}
+
+
+			boolean boundAll = assignAbilities(sender, orig, (Player) sender, true);
+			sender.sendMessage(ChatColor.GREEN + "Your bound abilities have been made the same as " + ChatColor.YELLOW + orig.getName());
+			if (!boundAll) {
+				sender.sendMessage(ChatColor.RED + "Some abilities were not bound because you cannot bend the required element.");
+			}
+		} else if (args.size() == 2) {
+			if (!sender.hasPermission("copy.assign")) {
+				sender.sendMessage(ChatColor.RED + "You don't have permission to do that.");
+				return;
+			}
+
+			Player orig = ProjectKorra.plugin.getServer().getPlayer(args.get(0));
+			Player target = ProjectKorra.plugin.getServer().getPlayer(args.get(1));
+
+			if ((orig == null || !orig.isOnline()) || (target == null || !target.isOnline())) {
+				sender.sendMessage(ChatColor.RED + "That player is not online.");
+				return;
+			}
+
+			boolean boundAll = assignAbilities(sender, orig, target, false);
+			sender.sendMessage(ChatColor.GREEN + "The bound abilities of " + ChatColor.YELLOW + target.getName() + ChatColor.GREEN + " have been been made the same as " + ChatColor.YELLOW + orig.getName());
+			target.sendMessage(ChatColor.GREEN + "Your bound abilities have been made the same as " + ChatColor.YELLOW + orig.getName());
+			if (!boundAll) {
+				sender.sendMessage(ChatColor.RED + "Some abilities were not bound because you cannot bend the required element.");
+			}
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private boolean assignAbilities(CommandSender sender, Player player, Player player2, boolean self) {
+
+		BendingPlayer orig = GeneralMethods.getBendingPlayer(player.getName());
+		BendingPlayer target = GeneralMethods.getBendingPlayer(player2.getName());
+
+		if (orig == null) {
+			GeneralMethods.createBendingPlayer(((Player) player).getUniqueId(), player.getName());
+			orig = GeneralMethods.getBendingPlayer(player.getName());
+		}
+		if (target == null) {
+			GeneralMethods.createBendingPlayer(((Player) player2).getUniqueId(), player2.getName());
+			target = GeneralMethods.getBendingPlayer(player2.getName());
+		}
+		if (orig.isPermaRemoved()) {
+			if (self) {
+				player.sendMessage(ChatColor.RED + "Your bending was permanently removed.");
+			} else {
+				sender.sendMessage(ChatColor.RED + "That players bending was permanently removed.");
+			}
+			return false;
+		}
+		
+		HashMap<Integer, String> abilities = (HashMap<Integer, String>) orig.getAbilities().clone();
+		boolean boundAll = true;
+		for (int i = 1; i <= 9; i++) {
+			if (!GeneralMethods.canBend(player2.getName(), abilities.get(i))) {
+				abilities.remove(i);
+				boundAll = false;
+			}
+		}
+		target.setAbilities(abilities);
+		return boundAll;
+	}
+
+}

--- a/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -5,6 +5,10 @@ import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.multiability.MultiAbilityManager;
 import com.projectkorra.projectkorra.object.Preset;
 
+
+
+
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -29,6 +33,7 @@ public class PresetCommand extends PKCommand {
 		super("preset", "/bending preset create|bind|list|delete [name]", "This command manages Presets, which are saved bindings. Use /bending preset list to view your existing presets, use /bending [create|delete] [name] to manage your presets, and use /bending bind [name] to bind an existing preset.", new String[] { "preset", "presets", "pre", "set", "p" });
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void execute(CommandSender sender, List<String> args) {
 		if (!isPlayer(sender) || !correctLength(sender, args.size(), 1, 3)) {
@@ -128,9 +133,11 @@ public class PresetCommand extends PKCommand {
 			}
 
 			BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
-			if (bPlayer == null)
+			if (bPlayer == null) {
 				return;
-			HashMap<Integer, String> abilities = bPlayer.getAbilities();
+			}
+			HashMap<Integer, String> abilities = (HashMap<Integer, String>) bPlayer.getAbilities().clone();
+			
 			Preset preset = new Preset(player.getUniqueId(), name, abilities);
 			preset.save(player);
 			sender.sendMessage(ChatColor.GREEN + "Created preset with the name: " + ChatColor.YELLOW + name);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -10,6 +10,7 @@ import com.projectkorra.projectkorra.util.ParticleEffect;
 import com.projectkorra.projectkorra.util.TempBlock;
 import com.projectkorra.projectkorra.waterbending.WaterMethods;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -105,14 +106,23 @@ public class EarthSmash {
 				return;
 			}
 
-			EarthSmash grabbedSmash = aimingAtSmashCheck(player, State.LIFTED);
+			EarthSmash grabbedSmash = aimingAtSmashCheck(player, null);
 			if (grabbedSmash == null) {
-				grabbedSmash = aimingAtSmashCheck(player, State.SHOT);
-			}
-			if (grabbedSmash != null) {
 				if (bplayer.isOnCooldown("EarthSmash")) {
 					return;
 				}
+				
+				grabbedSmash = aimingAtSmashCheck(player, State.SHOT);
+			}
+			if (grabbedSmash != null && grabbedSmash.state == State.LIFTED) {
+
+				grabbedSmash.state = State.GRABBED;
+				grabbedSmash.grabbedRange = grabbedSmash.loc.distance(player.getEyeLocation());
+				grabbedSmash.player = player;
+				return;
+			}
+			if (grabbedSmash != null && grabbedSmash.state == State.SHOT) {
+				
 				grabbedSmash.state = State.GRABBED;
 				grabbedSmash.grabbedRange = grabbedSmash.loc.distance(player.getEyeLocation());
 				grabbedSmash.player = player;

--- a/src/com/projectkorra/projectkorra/object/Preset.java
+++ b/src/com/projectkorra/projectkorra/object/Preset.java
@@ -6,7 +6,7 @@ import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.storage.DBConnection;
 
-import org.bukkit.Bukkit;
+
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -42,9 +42,9 @@ public class Preset {
 	static String updateQuery1 = "UPDATE pk_presets SET slot";
 	static String updateQuery2 = " = ? WHERE uuid = ? AND name = ?";
 
-	public UUID uuid;
-	public HashMap<Integer, String> abilities;
-	public String name;
+	private UUID uuid;
+	private HashMap<Integer, String> abilities;
+	private String name;
 
 	/**
 	 * Creates a new {@link Preset}
@@ -138,7 +138,8 @@ public class Preset {
 		if (!presets.containsKey(player.getUniqueId())) {
 			return false;
 		}
-		HashMap<Integer, String> abilities = preset.abilities;
+		@SuppressWarnings("unchecked")
+		HashMap<Integer, String> abilities = (HashMap<Integer, String>) preset.abilities.clone();
 		boolean boundAll = true;
 		for (int i = 1; i <= 9; i++) {
 			if (!GeneralMethods.canBend(player.getName(), abilities.get(i))) {
@@ -158,12 +159,14 @@ public class Preset {
 	 * @return true if the Preset exists, false otherwise
 	 */
 	public static boolean presetExists(Player player, String name) {
-		if (!presets.containsKey(player.getUniqueId()))
+		if (!presets.containsKey(player.getUniqueId())) {
 			return false;
+		}
 		boolean exists = false;
 		for (Preset preset : presets.get(player.getUniqueId())) {
-			if (preset.name.equalsIgnoreCase(name))
+			if (preset.name.equalsIgnoreCase(name)) {
 				exists = true;
+			}
 		}
 		return exists;
 	}
@@ -176,13 +179,16 @@ public class Preset {
 	 * @return The Preset, if it exists, or null otherwise
 	 */
 	public static Preset getPreset(Player player, String name) {
-		if (!presets.containsKey(player.getUniqueId()))
+		if (!presets.containsKey(player.getUniqueId())) {
 			return null;
+		}
 		for (Preset preset : presets.get(player.getUniqueId())) {
-			if (preset.name.equalsIgnoreCase(name))
+			if (preset.name.equalsIgnoreCase(name)) {
 				return preset;
+			}
 		}
 		return null;
+		
 	}
 	
 	public static void loadExternalPresets() {

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -35,6 +35,7 @@ permissions:
       bending.command.check: true
       bending.command.preset.bind.external: true
       bending.command.preset.bind.external.other: true
+      bending.command.copy.assign: true
       bending.admin.debug: true
       bending.admin.remove: true
   bending.player:
@@ -44,6 +45,7 @@ permissions:
       bending.command.bind: true
       bending.command.display: true
       bending.command.toggle: true
+      bending.command.copy: true
       bending.command.choose: true
       bending.command.version: true
       bending.command.help: true


### PR DESCRIPTION
Adds new /b copy [player] <player> command, allows you to copy the binds
of [player] onto yourself or <player>
Adds "bending.command.copy" node to use base command, default: true
Adds "bending.command.copy.assign" node to assign players binds to other
players, default: op

Fixes presets being cleared if you attempt to bind them with no elements
Fixes EarthSmash cooldown, now only effects shooting new earthsmashes
and raising new earthsmashes, not grabbing/redirecting