### PR TITLE
Various Fixes (read desc) / Adds assign Preset

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -252,7 +252,10 @@ public class AirBlast implements ConfigLoadable {
 			entity.setFireTicks(0);
 			AirMethods.breakBreathbendingHold(entity);
 
-			if (damage > 0 && entity instanceof LivingEntity && !entity.equals(player) && !affectedentities.contains(entity)) {
+			if (source != null && (this.damage > 0 && entity instanceof LivingEntity && !entity.equals(player) && !affectedentities.contains(entity))) {
+				GeneralMethods.damageEntity(player, entity, damage, "AirBurst");
+				affectedentities.add(entity);
+			} else if (source == null && (damage > 0 && entity instanceof LivingEntity && !entity.equals(player) && !affectedentities.contains(entity))) {
 				GeneralMethods.damageEntity(player, entity, damage, "AirBlast");
 				affectedentities.add(entity);
 			}

--- a/src/com/projectkorra/projectkorra/airbending/AirBurst.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBurst.java
@@ -64,6 +64,8 @@ public class AirBurst implements ConfigLoadable {
 	}
 
 	public static void fallBurst(Player player) {
+		BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
+		
 		if (!GeneralMethods.canBend(player.getName(), "AirBurst")) {
 			return;
 		}
@@ -77,6 +79,9 @@ public class AirBurst implements ConfigLoadable {
 			return;
 		}
 		if (!GeneralMethods.getBoundAbility(player).equalsIgnoreCase("AirBurst")) {
+			return;
+		}
+		if (bPlayer.isOnCooldown("AirBurst")) {
 			return;
 		}
 

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -117,10 +117,6 @@ public class AirScooter implements ConfigLoadable {
 			remove();
 			return false;
 		}
-		if (!player.isOnline() || player.isDead() || !player.isFlying()) {
-			remove();
-			return false;
-		}
 
 		if (GeneralMethods.isRegionProtectedFromBuild(player, "AirScooter", player.getLocation())) {
 			remove();
@@ -189,9 +185,6 @@ public class AirScooter implements ConfigLoadable {
 
 	public void remove() {
 		instances.remove(player);
-		player.setFlying(false);
-		player.setAllowFlight(false);
-		player.setSprinting(false);
 	}
 
 	public static void removeAll() {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -178,6 +178,7 @@ public class ConfigManager {
 				config.addDefault("Properties.Water.NightFactor", 1.5);
 				config.addDefault("Properties.Water.FullMoonFactor", 2.0);
 				config.addDefault("Properties.Water.CanBendPackedIce", true);
+				config.addDefault("Properties.Water.CanBendFromSpout", false);
 				config.addDefault("Properties.Water.PlaySound", true);
 				config.addDefault("Properties.Water.NightMessage", "You feel the strength of the rising moon empowering your waterbending.");
 				config.addDefault("Properties.Water.DayMessage", "You feel the empowering of your waterbending subside as the moon sets.");

--- a/src/com/projectkorra/projectkorra/earthbending/Shockwave.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Shockwave.java
@@ -41,6 +41,7 @@ public class Shockwave {
 	}
 
 	public static void fallShockwave(Player player) {
+		BendingPlayer bPlayer = GeneralMethods.getBendingPlayer(player.getName());
 		if (!GeneralMethods.canBend(player.getName(), "Shockwave")) {
 			return;
 		}
@@ -51,7 +52,10 @@ public class Shockwave {
 		if (instances.containsKey(player) || player.getFallDistance() < threshold || !EarthMethods.isEarthbendable(player, player.getLocation().add(0, -1, 0).getBlock())) {
 			return;
 		}
-
+		if(bPlayer.isOnCooldown("Shockwave")) {
+			return;
+		}
+		
 		areaShockwave(player);
 	}
 

--- a/src/com/projectkorra/projectkorra/util/BlockSource.java
+++ b/src/com/projectkorra/projectkorra/util/BlockSource.java
@@ -1,9 +1,11 @@
 package com.projectkorra.projectkorra.util;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.earthbending.EarthMethods;
 import com.projectkorra.projectkorra.waterbending.WaterMethods;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -33,6 +35,7 @@ public class BlockSource {
 
 	public static List<Block> randomBlocks = new ArrayList<Block>();
 	private static HashMap<Player, HashMap<BlockSourceType, HashMap<ClickType, BlockSourceInformation>>> playerSources = new HashMap<Player, HashMap<BlockSourceType, HashMap<ClickType, BlockSourceInformation>>>();
+	private static final boolean spout = ProjectKorra.plugin.getConfig().getBoolean("Properties.Water.CanBendFromSpout");
 	// The player should never need to grab source blocks from farther than this.
 
 	/**
@@ -220,10 +223,14 @@ public class BlockSource {
 			// Check the block in front of the player's eyes, it may have been created by a
 			// WaterBottle.
 			sourceBlock = WaterMethods.getWaterSourceBlock(player, selectRange, water, ice, plant);
+			
 			}
 			if (auto && (sourceBlock == null || sourceBlock.getLocation().distance(player.getEyeLocation()) > autoRange)) {
 				sourceBlock = WaterMethods.getRandomWaterBlock(player, player.getLocation(), autoRange, water, ice, plant);
 			}
+		}
+		if(sourceBlock != null && TempBlock.isTempBlock(sourceBlock) && spout) {
+			return null;
 		}
 		return sourceBlock;
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Bloodbending.java
@@ -133,7 +133,7 @@ public class Bloodbending {
 			Vector vector = GeneralMethods.getDirection(location, GeneralMethods.getTargetedLocation(player, location.distance(target)));
 			vector.normalize();
 			entity.setVelocity(vector.multiply(factor));
-			new HorizontalVelocityTracker(entity, player, 200, "Bloodbending", Element.Air, SubElement.Bloodbending);
+			new HorizontalVelocityTracker(entity, player, 200, "Bloodbending", Element.Water, SubElement.Bloodbending);
 		}
 		remove(player);
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/IceSpike.java
+++ b/src/com/projectkorra/projectkorra/waterbending/IceSpike.java
@@ -230,7 +230,7 @@ public class IceSpike {
 
 	private void affect(LivingEntity entity) {
 		entity.setVelocity(thrown);
-		entity.damage(damage);
+		GeneralMethods.damageEntity(player, entity, damage, "IceSpike");
 		damaged.add(entity);
 		long slowCooldown = IceSpike2.slowCooldown;
 		int mod = 2;

--- a/src/com/projectkorra/projectkorra/waterbending/IceSpike2.java
+++ b/src/com/projectkorra/projectkorra/waterbending/IceSpike2.java
@@ -30,7 +30,6 @@ public class IceSpike2 {
 	private static double RANGE = ProjectKorra.plugin.getConfig().getLong("Abilities.Water.IceSpike.Projectile.Range");
 	private static double DAMAGE = ProjectKorra.plugin.getConfig().getLong("Abilities.Water.IceSpike.Projectile.Damage");
 	private static int selectRange = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.IceSpike.Projectile.SelectRange");
-	private static int autoSelectRange = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.IceSpike.Projectile.AutoSourcing.SelectRange");
 	private static boolean dynamic = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Water.IceSpike.Projectile.DynamicSourcing.Enabled");
 	private static long cooldown = ProjectKorra.plugin.getConfig().getLong("Abilities.Water.IceSpike.Cooldown");
 
@@ -65,7 +64,7 @@ public class IceSpike2 {
 		block(player);
 		range = WaterMethods.waterbendingNightAugment(defaultrange, player.getWorld());
 		this.player = player;
-		Block sourceblock = BlockSource.getWaterSourceBlock(player, autoSelectRange, selectRange, ClickType.SHIFT_DOWN, false, dynamic, false, true, WaterMethods.canIcebend(player), WaterMethods.canPlantbend(player));
+		Block sourceblock = BlockSource.getWaterSourceBlock(player, selectRange, selectRange, ClickType.SHIFT_DOWN, false, dynamic, false, true, WaterMethods.canIcebend(player), WaterMethods.canPlantbend(player));
 
 		if (sourceblock == null) {
 			new SpikeField(player);
@@ -312,12 +311,12 @@ public class IceSpike2 {
 				PotionEffect effect = new PotionEffect(PotionEffectType.SLOW, 70, mod);
 				new TempPotionEffect(entity, effect);
 				bPlayer.slow(slowCooldown);
-				entity.damage(damage, player);
+				GeneralMethods.damageEntity(player, entity, damage, "IceSpike");
 			}
 		} else {
 			PotionEffect effect = new PotionEffect(PotionEffectType.SLOW, 70, mod);
 			new TempPotionEffect(entity, effect);
-			entity.damage(damage, player);
+			GeneralMethods.damageEntity(player, entity, damage, "IceSpike");
 		}
 		AirMethods.breakBreathbendingHold(entity);
 

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
@@ -3,10 +3,13 @@ package com.projectkorra.projectkorra.waterbending;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.chiblocking.Paralyze;
+import com.projectkorra.projectkorra.util.BlockSource;
+import com.projectkorra.projectkorra.util.ClickType;
 import com.projectkorra.projectkorra.util.Flight;
 import com.projectkorra.projectkorra.util.ParticleEffect;
 import com.projectkorra.projectkorra.util.TempBlock;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Server;
@@ -28,6 +31,8 @@ public class WaterSpout {
 	private static final int HEIGHT = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.WaterSpout.Height");
 	private static final boolean PARTICLES = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Water.WaterSpout.Particles");
 	private static final boolean BLOCKS = ProjectKorra.plugin.getConfig().getBoolean("Abilities.Water.WaterSpout.BlockSpiral");
+	
+	private static int selectRange = ProjectKorra.plugin.getConfig().getInt("Abilities.Water.WaterSpout.Wave.SelectRange");
 
 	// private static final double threshold = .05;
 	// private static final byte half = 0x4;
@@ -55,16 +60,21 @@ public class WaterSpout {
 		this.player = player;
 		this.canBendOnPackedIce = ProjectKorra.plugin.getConfig().getBoolean("Properties.Water.CanBendPackedIce");
 		
-		WaterWave wwave = new WaterWave(player, WaterWave.AbilityType.CLICK);
-		if (WaterWave.instances.contains(wwave))
-			return;
+		Block block = BlockSource.getWaterSourceBlock(player, selectRange, selectRange, ClickType.LEFT_CLICK, false, false, false, true, WaterMethods.canIcebend(player), WaterMethods.canPlantbend(player));
+
+		if(block != null) {
+			WaterWave wwave = new WaterWave(player, block, WaterWave.AbilityType.CLICK);
+			if (WaterWave.instances.contains(wwave)) {
+				return;
+			}
+		}
 
 		Block topBlock = GeneralMethods.getTopBlock(player.getLocation(), 0, -50);
 		if (topBlock == null)
 			topBlock = player.getLocation().getBlock();
 		Material mat = topBlock.getType();
 		if (mat != Material.WATER && mat != Material.STATIONARY_WATER && mat != Material.ICE && mat != Material.PACKED_ICE && mat != Material.SNOW && mat != Material.SNOW_BLOCK)
-			return;
+			return; 
 		if (mat == Material.PACKED_ICE && !canBendOnPackedIce)
 			return;
 		new Flight(player);

--- a/src/com/projectkorra/projectkorra/waterbending/WaterWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterWave.java
@@ -10,6 +10,7 @@ import com.projectkorra.projectkorra.util.BlockSource;
 import com.projectkorra.projectkorra.util.ClickType;
 import com.projectkorra.projectkorra.util.TempBlock;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -50,6 +51,7 @@ public class WaterWave {
 	
 	private Player player;
 	private long time;
+	private Block block;
 	private AbilityType type;
 	private Location origin, currentLoc;
 	private Vector direction;
@@ -68,13 +70,14 @@ public class WaterWave {
 	private ArrayList<Entity> affectedEntities = new ArrayList<Entity>();
 	private ArrayList<BukkitRunnable> tasks = new ArrayList<BukkitRunnable>();
 
-	public WaterWave(Player player, AbilityType type) {
+	public WaterWave(Player player, Block block, AbilityType type) {
 		if (!ENABLED || GeneralMethods.getBendingPlayer(player.getName()).isOnCooldown("WaterWave"))
 			return;
 
 		this.player = player;
 		this.time = System.currentTimeMillis();
 		this.type = type;
+		this.block = block;
 		instances.add(this);
 
 		if (type == AbilityType.CLICK)
@@ -107,7 +110,6 @@ public class WaterWave {
 			if (origin == null) {
 				removeType(player, AbilityType.CLICK);
 
-				Block block = BlockSource.getWaterSourceBlock(player, selectRange, selectRange, ClickType.SHIFT_DOWN, false, false, true, true, WaterMethods.canIcebend(player), WaterMethods.canPlantbend(player));
 				if (block == null) {
 					if(instances.contains(this)) {
 						remove();
@@ -135,7 +137,7 @@ public class WaterWave {
 				remove();
 				return;
 			} else if (player.isSneaking()) {
-				new WaterWave(player, AbilityType.SHIFT);
+				new WaterWave(player, block, AbilityType.SHIFT);
 				return;
 			}
 			WaterMethods.playFocusWaterEffect(origin.getBlock());
@@ -166,7 +168,7 @@ public class WaterWave {
 			removeType(player, AbilityType.CLICK);
 			if (!player.isSneaking()) {
 				if (System.currentTimeMillis() - time > chargeTime) {
-					WaterWave wwave = new WaterWave(player, AbilityType.RELEASE);
+					WaterWave wwave = new WaterWave(player, block, AbilityType.RELEASE);
 					wwave.anim = AnimateState.SHRINK;
 					wwave.direction = direction;
 				}

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -33,8 +33,9 @@ permissions:
       bending.command.give: true
       bending.command.invincible: true
       bending.command.check: true
+      bending.command.preset.bind.assign: true
       bending.command.preset.bind.external: true
-      bending.command.preset.bind.external.other: true
+      bending.command.preset.bind.external.assign: true
       bending.command.copy.assign: true
       bending.admin.debug: true
       bending.admin.remove: true


### PR DESCRIPTION
Fixes AirBurst deathmessage
Fixes IceSpike deathmessage
Fixes Bloodbending deathmessage
Fixes AirScooter randomly ending
Fixes AirScooter taking players meant to fly out of fly mode
Fixes ShockWave/AirBurst cooldown not influencing fall induced
ShockWaves/AirBursts
Fixes WaterSpout sometimes not working

Adds "bending.command.preset.bind.assign" node which allows players to
assign their presets onto other players, default: op
Adds /b p b [preset] <player> capabilities for player presets
Adds "CanBendFromSpout" config option for Water, determines whether
players can use water from their spout to bend, default: false