### PR TITLE
CoreAbility Improvements and Bug Fixes

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -737,7 +737,7 @@ public class PKListener implements Listener {
 		} else {
 			for (Element element : Element.getMainElements()) {
 				if (bPlayer.hasElement(element)) {
-					color = ChatColor.valueOf(plugin.getConfig().getString("Properties.Chat.Colors." + element));
+					color = element.getColor();
 					break;
 				}
 			}

--- a/src/com/projectkorra/projectkorra/ability/util/AbilityLoader.java
+++ b/src/com/projectkorra/projectkorra/ability/util/AbilityLoader.java
@@ -79,7 +79,7 @@ public class AbilityLoader<T> implements Listener {
 					Class<?> clazz = null;
 					try {
 						clazz = Class.forName(className, true, loader);
-					} catch (Exception e) {
+					} catch (Exception | Error e) {
 						continue;
 					}
 
@@ -97,7 +97,7 @@ public class AbilityLoader<T> implements Listener {
 					plugin.getServer().getPluginManager().callEvent(event);
 				}
 		
-			} catch (Exception e) {
+			} catch (Exception | Error e) {
 				e.printStackTrace();
 				plugin.getLogger().log(Level.WARNING, "Unknown cause");
 				plugin.getLogger().log(Level.WARNING, "The JAR file " + file.getName() + " failed to load");

--- a/src/com/projectkorra/projectkorra/ability/util/ComboManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/ComboManager.java
@@ -1,7 +1,16 @@
 package com.projectkorra.projectkorra.ability.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element;
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
@@ -10,14 +19,6 @@ import com.projectkorra.projectkorra.chiblocking.ChiCombo;
 import com.projectkorra.projectkorra.firebending.FireCombo;
 import com.projectkorra.projectkorra.util.ClickType;
 import com.projectkorra.projectkorra.waterbending.WaterCombo;
-
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class ComboManager {
 	
@@ -271,9 +272,17 @@ public class ComboManager {
 	 */
 	public static ArrayList<String> getCombosForElement(Element element) {
 		ArrayList<String> list = new ArrayList<String>();
-		for (String comboab : DESCRIPTIONS.keySet()) {
-			CoreAbility coreAbil = CoreAbility.getAbility(COMBO_ABILITIES.get(comboab).getAbilities().get(0).getAbilityName());
-			if (coreAbil != null && coreAbil.getElement() == element) {
+		for (String comboab : COMBO_ABILITIES.keySet()) {
+			CoreAbility coreAbil = CoreAbility.getAbility(comboab);
+			if (coreAbil == null) {
+				continue;
+			}
+			
+			Element abilElement = coreAbil.getElement();
+			if (abilElement instanceof SubElement) {
+				abilElement = ((SubElement) abilElement).getParentElement();
+			}
+			if (abilElement == element) {
 				list.add(comboab);
 			}
 		}

--- a/src/com/projectkorra/projectkorra/airbending/AirFlight.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirFlight.java
@@ -104,6 +104,7 @@ public class AirFlight extends FlightAbility {
 		} else {
 			player.setVelocity(player.getEyeLocation().getDirection().normalize().multiply(speed));
 		}
+		firstProgressIteration = false;
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -46,10 +46,17 @@ public class DisplayCommand extends PKCommand {
 					sender.sendMessage(color + "There are no " + elementName + " combos avaliable.");
 					return;
 				}
-				for (String combomove : combos) {
-					if (!sender.hasPermission("bending.ability." + combomove))
+				for (String comboMove : combos) {
+					ChatColor comboColor = color;
+					if (!sender.hasPermission("bending.ability." + comboMove)) {
 						continue;
-					sender.sendMessage(color + combomove);
+					}
+					
+					CoreAbility coreAbil = CoreAbility.getAbility(comboMove);
+					if (coreAbil != null) {
+						comboColor = coreAbil.getElement().getColor();
+					}
+					sender.sendMessage(comboColor + comboMove);
 				}
 				return;
 			}
@@ -108,6 +115,9 @@ public class DisplayCommand extends PKCommand {
 			return;
 		}
 		for (CoreAbility ability : abilities) {
+			if (ability.isHiddenAbility()) {
+				continue;
+			}
 			if (sender instanceof Player) {
 				if (GeneralMethods.canView((Player) sender, ability.getName())) {
 					sender.sendMessage(ability.getElement().getColor() + ability.getName());

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -161,13 +161,6 @@ public class FireBlastCharged extends FireAbility {
 					yield = AvatarState.getValue(yield);
 				}
 				
-				if (!bPlayer.isAvatarState()) {
-					if (isDay(player.getWorld())) {
-						yield = (float) getDayFactor(yield);
-					}
-				} else {
-					yield = AvatarState.getValue(yield);
-				}
 				explosion.setYield((float) yield);
 				EXPLOSIONS.put(explosion, this);
 			} else {

--- a/src/com/projectkorra/projectkorra/firebending/FireCombo.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireCombo.java
@@ -1,19 +1,7 @@
 package com.projectkorra.projectkorra.firebending;
 
-import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.AirAbility;
-import com.projectkorra.projectkorra.ability.ComboAbility;
-import com.projectkorra.projectkorra.ability.ElementalAbility;
-import com.projectkorra.projectkorra.ability.FireAbility;
-import com.projectkorra.projectkorra.ability.WaterAbility;
-import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
-import com.projectkorra.projectkorra.avatar.AvatarState;
-import com.projectkorra.projectkorra.command.Commands;
-import com.projectkorra.projectkorra.util.ClickType;
-import com.projectkorra.projectkorra.util.ParticleEffect;
+import java.util.ArrayList;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -26,7 +14,18 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.ComboAbility;
+import com.projectkorra.projectkorra.ability.ElementalAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
+import com.projectkorra.projectkorra.ability.WaterAbility;
+import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
+import com.projectkorra.projectkorra.avatar.AvatarState;
+import com.projectkorra.projectkorra.command.Commands;
+import com.projectkorra.projectkorra.util.ClickType;
+import com.projectkorra.projectkorra.util.ParticleEffect;
 
 /*
  * TODO: Combo classes should eventually be rewritten so that each combo is treated
@@ -72,8 +71,6 @@ public class FireCombo extends FireAbility implements ComboAbility {
 	
 	public FireCombo(Player player, String ability) {
 		super(player);
-		Bukkit.broadcastMessage("Here 0");
-		
 		this.ability = ability;
 		
 		if (!bPlayer.canBendIgnoreBindsCooldowns(this)) {
@@ -211,7 +208,6 @@ public class FireCombo extends FireAbility implements ComboAbility {
 
 	@Override
 	public void progress() {
-		Bukkit.broadcastMessage("Progressing");
 		progressCounter++;
 		for (int i = 0; i < tasks.size(); i++) {
 			BukkitRunnable br = tasks.get(i);


### PR DESCRIPTION
AirFlight sneak (release) now causes AirFlight to be removed
Removed FireCombo debug messages
/b display was causing hiddenAbilities to be displayed if they extended AvatarAbility
AvatarState Charged FireBlast was exponentially bigger than it should have been
Old pre-refactor AddonAbilities were causing the plugin to crash while loading up