### PR TITLE
- AirBurst no longer triggers doors/buttons/levers

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -104,6 +104,10 @@ public class AirBlast extends AirAbility {
 		this.pushFactor *= modifiedPushFactor;
 		this.affectedLevers = new ArrayList<>();
 		this.affectedEntities = new ArrayList<>();
+		//prevent the airburst related airblasts from triggering doors/levers/buttons
+		this.canOpenDoors = false;
+		this.canPressButtons = false;
+		this.canFlickLevers = false;
 		start();
 	}
 


### PR DESCRIPTION
The many airblasts that are generated from airburst were causing sound glitches by triggering doors levers and buttons at extremely fast rates