### PR TITLE
Include plugin.yml when building plugin

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -28,6 +28,7 @@
             <manifest>
                 <attribute name="Main-Class" value="${main-class}"/>
             </manifest>
+            <fileset file="${dir.src}/plugin.yml"/>
         </jar>
     </target>
 


### PR DESCRIPTION
Unless this was intended to be left out, the plugin, when built via ant, does not contain a plugin.yml file. This change will include the plugin.yml file when using `ant` to compile.