### PR TITLE
fix NPE when calling isTempBlock

### DIFF
--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -53,6 +53,8 @@ public class TempBlock {
 	}
 
 	public static boolean isTempBlock(Block block) {
+		if (instances.containsKey(block) == null)
+			return false;
 		return instances.containsKey(block);
 	}
 


### PR DESCRIPTION
Unsure if there's a better way to go about this, but this is the error that prompted me to look into this:

```
[05:54:50] [Server thread/ERROR]: Could not pass event EntityDamageByBlockEvent to ProjectKorra v1.8.0 BETA 10
org.bukkit.event.EventException
	at org.bukkit.plugin.EventExecutor$1.execute(EventExecutor.java:46) ~[patched_1.9.2.jar:git-Paper-727]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:78) ~[patched_1.9.2.jar:git-Paper-727]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[patched_1.9.2.jar:git-Paper-727]
	at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:517) [patched_1.9.2.jar:git-Paper-727]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:502) [patched_1.9.2.jar:git-Paper-727]
	at org.bukkit.craftbukkit.v1_9_R1.event.CraftEventFactory.callEvent(CraftEventFactory.java:89) [patched_1.9.2.jar:git-Paper-727]
	at org.bukkit.craftbukkit.v1_9_R1.event.CraftEventFactory.handleEntityDamageEvent(CraftEventFactory.java:487) [patched_1.9.2.jar:git-Paper-727]
	at org.bukkit.craftbukkit.v1_9_R1.event.CraftEventFactory.handleNonLivingEntityDamageEvent(CraftEventFactory.java:621) [patched_1.9.2.jar:git-Paper-727]
	at org.bukkit.craftbukkit.v1_9_R1.event.CraftEventFactory.handleNonLivingEntityDamageEvent(CraftEventFactory.java:607) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.EntityItem.damageEntity(EntityItem.java:235) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.Entity.burnFromLava(Entity.java:419) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.Entity.U(Entity.java:390) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.Entity.m(Entity.java:304) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.EntityItem.m(EntityItem.java:63) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.World.entityJoinedWorld(World.java:1728) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.World.g(World.java:1703) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.World.tickEntities(World.java:1528) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.WorldServer.tickEntities(WorldServer.java:636) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.MinecraftServer.D(MinecraftServer.java:885) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.DedicatedServer.D(DedicatedServer.java:404) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.MinecraftServer.C(MinecraftServer.java:723) [patched_1.9.2.jar:git-Paper-727]
	at net.minecraft.server.v1_9_R1.MinecraftServer.run(MinecraftServer.java:622) [patched_1.9.2.jar:git-Paper-727]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_91]
Caused by: java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(Unknown Source) ~[?:1.8.0_91]
	at java.util.concurrent.ConcurrentHashMap.containsKey(Unknown Source) ~[?:1.8.0_91]
	at com.projectkorra.projectkorra.util.TempBlock.isTempBlock(Unknown Source) ~[?:?]
	at com.projectkorra.projectkorra.PKListener.onEntityDamageByBlock(Unknown Source) ~[?:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor1173.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$1.execute(EventExecutor.java:44) ~[patched_1.9.2.jar:git-Paper-727]
	... 22 more
```