### PR TITLE
Don't blindly check cancel status for all damage

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -732,11 +732,8 @@ public class PKListener implements Listener {
 		event.setFormat(format);
 	}
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.NORMAL)
 	public void onPlayerDamage(EntityDamageEvent event) {
-		if (event.isCancelled()) {
-			return;
-		}
 
 		if (event.getEntity() instanceof Player) {
 			Player player = (Player) event.getEntity();


### PR DESCRIPTION
If fall damage is disabled via another plugin like WorldGuard, abilities like Shockwave can't function upon landing. Plus, there's already a lot of checks for event.isCancelled, so don't see a reason to do a check for the entire event.