### PR TITLE
Fix ParticleEffect in version 1.10

### DIFF
--- a/src/com/projectkorra/projectkorra/util/ParticleEffect.java
+++ b/src/com/projectkorra/projectkorra/util/ParticleEffect.java
@@ -1148,7 +1148,7 @@ public enum ParticleEffect {
 				return;
 			}
 			try {
-				version = Integer.parseInt(Character.toString(PackageType.getServerVersion().charAt(3)));
+				version = Integer.parseInt(PackageType.getServerVersion().substring(PackageType.getServerVersion().lastIndexOf('.') + 1));
 				if (version > 7) {
 					enumParticle = PackageType.MINECRAFT_SERVER.getClass("EnumParticle");
 				}


### PR DESCRIPTION
The new 1.10 version looks like version 0 to the version check in ParticleEffect. Instead of just grabbing the last char, grab the last part of the string (after the .) and parseInt that. Then the numeric version compares will return the right class.