### PR TITLE
Spout Max Height, RaiseEarth Config Options

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirSpout.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSpout.java
@@ -39,6 +39,11 @@ public class AirSpout extends AirAbility {
 		this.interval = getConfig().getLong("Abilities.Air.AirSpout.Interval");
 		this.height = getConfig().getDouble("Abilities.Air.AirSpout.Height");
 
+		double heightRemoveThreshold = 2;
+		if (!isWithinMaxSpoutHeight(heightRemoveThreshold)) {
+			return;
+		}
+		
 		new Flight(player);
 		start();
 		bPlayer.addCooldown(this);
@@ -69,6 +74,18 @@ public class AirSpout extends AirAbility {
 		player.setAllowFlight(true);
 		player.setFlying(true);
 	}
+	
+	private boolean isWithinMaxSpoutHeight(double threshold) {
+		Block ground = getGround();
+		if (ground == null) {
+			return false;
+		}
+		double playerHeight = player.getLocation().getY();
+		if (playerHeight > ground.getLocation().getY() + height + threshold) {
+			return false;
+		}
+		return true;
+	}
 
 	private Block getGround() {
 		Block standingblock = player.getLocation().getBlock();
@@ -84,6 +101,12 @@ public class AirSpout extends AirAbility {
 	@Override
 	public void progress() {
 		if (player.isDead() || !player.isOnline() || !bPlayer.canBendIgnoreBindsCooldowns(this)) {
+			remove();
+			return;
+		}
+		
+		double heightRemoveThreshold = 2;
+		if (!isWithinMaxSpoutHeight(heightRemoveThreshold)) {
 			remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/earthbending/RaiseEarthWall.java
+++ b/src/com/projectkorra/projectkorra/earthbending/RaiseEarthWall.java
@@ -38,12 +38,14 @@ public class RaiseEarthWall extends EarthAbility {
 
 		Vector direction = player.getEyeLocation().getDirection().normalize();
 		double ox, oy, oz;
+		direction.setY(0);
 		ox = -direction.getZ();
 		oy = 0;
 		oz = direction.getX();
-
+		
 		Vector orth = new Vector(ox, oy, oz);
 		orth = orth.normalize();
+		orth = getDegreeRoundedVector(orth, 0.25);
 
 		Block sblock = BlockSource.getEarthSourceBlock(player, selectRange, ClickType.SHIFT_DOWN);
 		
@@ -56,8 +58,9 @@ public class RaiseEarthWall extends EarthAbility {
 		World world = location.getWorld();
 		boolean shouldAddCooldown = false;
 
-		for (int i = -width / 2; i <= width / 2; i++) {
-			Block block = world.getBlockAt(location.clone().add(orth.clone().multiply((double) i)));
+		for (int i = 0; i < width; i++) {
+			double adjustedI = i - width / 2.0;
+			Block block = world.getBlockAt(location.clone().add(orth.clone().multiply(adjustedI)));
 
 			if (isTransparent(block)) {
 				for (int j = 1; j < height; j++) {
@@ -88,6 +91,30 @@ public class RaiseEarthWall extends EarthAbility {
 		if (shouldAddCooldown) {
 			bPlayer.addCooldown("RaiseEarthWall", cooldown);
 		}
+	}
+	
+	private static Vector getDegreeRoundedVector(Vector vec, double degreeIncrement) {
+		if (vec == null) {
+			return null;
+		}
+		vec = vec.normalize();
+		double[] dims = {vec.getX(), vec.getY(), vec.getZ()};
+		
+		for (int i = 0; i < dims.length; i++) {
+			double dim = dims[i];
+			int sign = dim >= 0 ? 1 : -1;
+			int dimDivIncr = (int)(dim / degreeIncrement);
+			
+			double lowerBound = dimDivIncr * degreeIncrement;
+			double upperBound = (dimDivIncr + (1 * sign))  * degreeIncrement;
+			
+			if (Math.abs(dim - lowerBound) < Math.abs(dim - upperBound)) {
+				dims[i] = lowerBound;
+			} else {
+				dims[i] = upperBound;
+			}
+		}
+		return new Vector(dims[0], dims[1], dims[2]);
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -53,7 +53,7 @@ public class TempBlock {
 	}
 
 	public static boolean isTempBlock(Block block) {
-		return instances.containsKey(block);
+		return block != null ? instances.containsKey(block) : false;
 	}
 
 	public static boolean isTouchingTempBlock(Block block) {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
@@ -67,7 +67,12 @@ public class WaterSpout extends WaterAbility {
 		} else if (topBlock.getType() == Material.PACKED_ICE && !canBendOnPackedIce) {
 			return;
 		}
-
+		
+		double heightRemoveThreshold = 2;
+		if (!isWithinMaxSpoutHeight(topBlock.getLocation(), heightRemoveThreshold)) {
+			return;
+		}
+		
 		new Flight(player);
 		player.setAllowFlight(true);
 		start();
@@ -124,6 +129,12 @@ public class WaterSpout extends WaterAbility {
 
 			if (height != -1) {
 				location = base.getLocation();
+				double heightRemoveThreshold = 2;
+				if (!isWithinMaxSpoutHeight(location, heightRemoveThreshold)) {
+					remove();
+					return;
+				}
+				
 				for (int i = 1; i <= height; i++) {
 					block = location.clone().add(0, i, 0).getBlock();
 					
@@ -160,12 +171,24 @@ public class WaterSpout extends WaterAbility {
 		player.setAllowFlight(canFly);
 		player.setFlying(hadFly);
 	}
-
+	
 	public void revertBaseBlock() {
 		if (baseBlock != null) {
 			baseBlock.revertBlock();
 			baseBlock = null;
 		}
+	}
+	
+	private boolean isWithinMaxSpoutHeight(Location baseBlockLocation, double threshold) {
+		if (baseBlockLocation == null) {
+			return false;
+		}
+		double playerHeight = player.getLocation().getY();
+		double maxHeight = isNight(player.getWorld()) ? getNightFactor(height) : height;
+		if (playerHeight > baseBlockLocation.getY() + maxHeight + threshold) {
+			return false;
+		}
+		return true;
 	}
 
 	public void rotateParticles(Block block) {


### PR DESCRIPTION
- Fixed a NullPointerException in OctopusForm
- Updated WaterSpout and AirSpout so that a user cannot use the ability if they are higher than the maximum height
- Made improvements to RaiseEarth so that it better reflects the "width" config option