### PR TITLE
Improve MetalClips

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1577,8 +1577,8 @@ public class PKListener implements Listener {
 						new MetalClips(player, 0);
 					} else if (clips.getMetalClipsCount() < (player.hasPermission("bending.ability.MetalClips.4clips") ? 4 : 3)) {
 						clips.shootMetal();
-					} else if (MetalClips.isControllingEntity(player)) {
-						clips.launch();
+					} else if (clips.getMetalClipsCount() == 4 && clips.isCanUse4Clips()) {
+						clips.crush();
 					}
 				}
 				if (abil.equalsIgnoreCase("LavaSurge")) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -906,11 +906,12 @@ public class ConfigManager {
 
 			config.addDefault("Abilities.Earth.MetalClips.Enabled", true);			
 			config.addDefault("Abilities.Earth.MetalClips.Damage", 2);
-			config.addDefault("Abilities.Earth.MetalClips.DamageInterval", 500);
 			config.addDefault("Abilities.Earth.MetalClips.Range", 10);
 			config.addDefault("Abilities.Earth.MetalClips.MagnetRange", 20);
 			config.addDefault("Abilities.Earth.MetalClips.MagnetPower", 0.6);
-			config.addDefault("Abilities.Earth.MetalClips.Cooldown", 1000);
+			config.addDefault("Abilities.Earth.MetalClips.Cooldown", 6000);
+			config.addDefault("Abilities.Earth.MetalClips.CrushCooldown", 2000);
+			config.addDefault("Abilities.Earth.MetalClips.ShootCooldown", 1500);
 			config.addDefault("Abilities.Earth.MetalClips.Duration", 10000);
 			config.addDefault("Abilities.Earth.MetalClips.ThrowEnabled", false);
 

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -906,6 +906,7 @@ public class ConfigManager {
 
 			config.addDefault("Abilities.Earth.MetalClips.Enabled", true);			
 			config.addDefault("Abilities.Earth.MetalClips.Damage", 2);
+			config.addDefault("Abilities.Earth.MetalClips.CrushDamage", 1);
 			config.addDefault("Abilities.Earth.MetalClips.Range", 10);
 			config.addDefault("Abilities.Earth.MetalClips.MagnetRange", 20);
 			config.addDefault("Abilities.Earth.MetalClips.MagnetPower", 0.6);

--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -39,10 +39,10 @@ public class MetalClips extends MetalAbility {
 	private boolean isMagnetized;
 	private boolean canUse4Clips;
 	private boolean canLoot;
+	private boolean hasSnuck;
 	private int metalClipsCount;
 	private int abilityType;
 	private int armorTime;
-	private int crushDamage;
 	private int magnetRange;
 	private long armorStartTime;
 	private long cooldown;
@@ -50,6 +50,8 @@ public class MetalClips extends MetalAbility {
 	private long crushCooldown;
 	private double magnetPower;
 	private double range;
+	private double crushDamage;
+	private double damage;
 	private LivingEntity targetEntity;
 	private ItemStack[] oldArmor;
 	private List<Item> trackedIngots;
@@ -68,9 +70,10 @@ public class MetalClips extends MetalAbility {
 		this.cooldown = getConfig().getLong("Abilities.Earth.MetalClips.Cooldown");
 		this.shootCooldown = getConfig().getLong("Abilities.Earth.MetalClips.ShootCooldown");
 		this.crushCooldown = getConfig().getLong("Abilities.Earth.MetalClips.CrushCooldown");
-		this.crushDamage = getConfig().getInt("Abilities.Earth.MetalClips.Damage");
 		this.magnetRange = getConfig().getInt("Abilities.Earth.MetalClips.MagnetRange");
 		this.magnetPower = getConfig().getDouble("Abilities.Earth.MetalClips.MagnetPower");
+		this.crushDamage = getConfig().getDouble("Abilities.Earth.MetalClips.CrushDamage");
+		this.damage = getConfig().getDouble("Abilities.Earth.MetalClips.Damage");
 		this.canThrow = (getConfig().getBoolean("Abilities.Earth.MetalClips.ThrowEnabled") && player.hasPermission("bending.ability.metalclips.throw"));
 		this.trackedIngots = new ArrayList<>();		
 		
@@ -258,11 +261,15 @@ public class MetalClips extends MetalAbility {
 				return;
 			}
 		}
+		
+		if (player.isSneaking()) {
+			hasSnuck = true;
+		}
 
 		if (!player.isSneaking()) {
 			isControlling = false;
 			isMagnetized = false;
-			if (metalClipsCount < 4) {
+			if (metalClipsCount < 4 && hasSnuck) {
 				launch();
 			}
 		}
@@ -421,7 +428,7 @@ public class MetalClips extends MetalAbility {
 								formArmor();
 							}
 						} else {
-							DamageHandler.damageEntity(e, 5, this);
+							DamageHandler.damageEntity(e, player, damage, this);
 							ii.getWorld().dropItem(ii.getLocation(), ii.getItemStack());
 							remove();
 						}
@@ -604,11 +611,11 @@ public class MetalClips extends MetalAbility {
 		this.armorTime = armorTime;
 	}
 
-	public int getCrushDamage() {
+	public double getCrushDamage() {
 		return crushDamage;
 	}
 
-	public void setCrushDamage(int crushDamage) {
+	public void setCrushDamage(double crushDamage) {
 		this.crushDamage = crushDamage;
 	}
 

--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -414,10 +414,19 @@ public class MetalClips extends MetalAbility {
 
 				for (Entity e : GeneralMethods.getEntitiesAroundPoint(ii.getLocation(), 2)) {
 					if (e instanceof LivingEntity && e.getEntityId() != player.getEntityId()) {
-						if (e instanceof Player || e instanceof Zombie || e instanceof Skeleton) {
-							targetEntity = (LivingEntity) e;
-							TARGET_TO_ABILITY.put(targetEntity, this);
-							formArmor();
+						if ((e instanceof Player || e instanceof Zombie || e instanceof Skeleton)) {
+							if (targetEntity == null) {
+								targetEntity = (LivingEntity) e;
+								TARGET_TO_ABILITY.put(targetEntity, this);
+								formArmor();
+							} else if (targetEntity == e) {
+								formArmor();
+							} else {
+								TARGET_TO_ABILITY.get(targetEntity).remove();
+								targetEntity = (LivingEntity) e;
+								TARGET_TO_ABILITY.put(targetEntity, this);
+								formArmor();
+							}
 						} else {
 							DamageHandler.damageEntity(e, 5, this);
 							ii.getWorld().dropItem(ii.getLocation(), ii.getItemStack());
@@ -425,6 +434,7 @@ public class MetalClips extends MetalAbility {
 						}
 
 						ii.remove();
+						break;
 					}
 				}
 			}

--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -42,13 +42,12 @@ public class MetalClips extends MetalAbility {
 	private int metalClipsCount;
 	private int abilityType;
 	private int armorTime;
-	private int crushInterval;
 	private int crushDamage;
 	private int magnetRange;
 	private long armorStartTime;
-	private long time;
 	private long cooldown;
-	private double lastDistanceCheck;
+	private long shootCooldown;
+	private long crushCooldown;
 	private double magnetPower;
 	private double range;
 	private LivingEntity targetEntity;
@@ -65,9 +64,10 @@ public class MetalClips extends MetalAbility {
 		this.canLoot = player.hasPermission("bending.ability.MetalClips.loot");
 		this.canUse4Clips = player.hasPermission("bending.ability.MetalClips.4clips");
 		this.armorTime = getConfig().getInt("Abilities.Earth.MetalClips.Duration");
-		this.crushInterval = getConfig().getInt("Abilities.Earth.MetalClips.DamageInterval");;
 		this.range = getConfig().getDouble("Abilities.Earth.MetalClips.Range");
-		this.cooldown = getConfig().getInt("Abilities.Earth.MetalClips.Cooldown");
+		this.cooldown = getConfig().getLong("Abilities.Earth.MetalClips.Cooldown");
+		this.shootCooldown = getConfig().getLong("Abilities.Earth.MetalClips.ShootCooldown");
+		this.crushCooldown = getConfig().getLong("Abilities.Earth.MetalClips.CrushCooldown");
 		this.crushDamage = getConfig().getInt("Abilities.Earth.MetalClips.Damage");
 		this.magnetRange = getConfig().getInt("Abilities.Earth.MetalClips.MagnetRange");
 		this.magnetPower = getConfig().getDouble("Abilities.Earth.MetalClips.MagnetPower");
@@ -136,6 +136,10 @@ public class MetalClips extends MetalAbility {
 	}
 
 	public void shootMetal() {
+		if (bPlayer.isOnCooldown("MetalClips Shoot")) {
+			return;
+		}
+		bPlayer.addCooldown("MetalClips Shoot", shootCooldown);
 		ItemStack is = new ItemStack(Material.IRON_INGOT, 1);
 
 		if (!player.getInventory().containsAtLeast(is, 1)) {
@@ -156,8 +160,6 @@ public class MetalClips extends MetalAbility {
 		item.setVelocity(vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
 		trackedIngots.add(item);
 		player.getInventory().removeItem(is);
-
-		bPlayer.addCooldown(this);
 	}
 
 	public void formArmor() {
@@ -199,11 +201,6 @@ public class MetalClips extends MetalAbility {
 			ENTITY_CLIPS_COUNT.put(targetEntity, metalClipsCount);
 			targetEntity.getEquipment().setArmorContents(metalarmor);
 		}
-
-		if (metalClipsCount == 4) {
-			time = System.currentTimeMillis();
-			lastDistanceCheck = player.getLocation().distance(targetEntity.getLocation());
-		}
 		armorStartTime = System.currentTimeMillis();
 		isBeingWorn = true;
 	}
@@ -236,8 +233,16 @@ public class MetalClips extends MetalAbility {
 		dz = target.getZ() - location.getZ();
 		Vector vector = new Vector(dx, dy, dz);
 		vector.normalize();
-		targetEntity.setVelocity(vector.multiply(2));
+		targetEntity.setVelocity(vector.multiply(metalClipsCount/2).normalize());
 		remove();
+	}
+	
+	public void crush() {
+		if (bPlayer.isOnCooldown("MetalClips Crush")) {
+			return;
+		}
+		bPlayer.addCooldown("MetalClips Crush", crushCooldown);
+		DamageHandler.damageEntity(targetEntity, player, crushDamage, this);
 	}
 
 	@Override
@@ -257,6 +262,9 @@ public class MetalClips extends MetalAbility {
 		if (!player.isSneaking()) {
 			isControlling = false;
 			isMagnetized = false;
+			if (metalClipsCount < 4) {
+				launch();
+			}
 		}
 
 		if (isMagnetized) {
@@ -382,21 +390,6 @@ public class MetalClips extends MetalAbility {
 
 				targetEntity.setFallDistance(0);
 			}
-
-			if (metalClipsCount == 4 && canUse4Clips) {
-				double distance = player.getLocation().distance(targetEntity.getLocation());
-				if (distance < lastDistanceCheck - 0.3) {
-					double height = targetEntity.getLocation().getY();
-					if (height > player.getEyeLocation().getY()) {
-						lastDistanceCheck = distance;
-
-						if (System.currentTimeMillis() > time + crushInterval) {
-							time = System.currentTimeMillis();
-							DamageHandler.damageEntity(targetEntity, (crushDamage + (crushDamage * 1.2)), this);
-						}
-					}
-				}
-			}
 		}
 
 		for (int i = 0; i < trackedIngots.size(); i++) {
@@ -467,6 +460,10 @@ public class MetalClips extends MetalAbility {
 			ENTITY_CLIPS_COUNT.remove(targetEntity);
 			TARGET_TO_ABILITY.remove(targetEntity);
 		}
+		
+		if (player != null && player.isOnline()) {
+			bPlayer.addCooldown(this);
+		}
 	}
 
 	public static boolean isControlled(LivingEntity player) {
@@ -515,6 +512,14 @@ public class MetalClips extends MetalAbility {
 	@Override
 	public long getCooldown() {
 		return cooldown;
+	}
+	
+	public long getShootCooldown() {
+		return shootCooldown;
+	}
+	
+	public long getCrushCooldown() {
+		return crushCooldown;
 	}
 	
 	@Override
@@ -599,14 +604,6 @@ public class MetalClips extends MetalAbility {
 		this.armorTime = armorTime;
 	}
 
-	public int getCrushInterval() {
-		return crushInterval;
-	}
-
-	public void setCrushInterval(int crushInterval) {
-		this.crushInterval = crushInterval;
-	}
-
 	public int getCrushDamage() {
 		return crushDamage;
 	}
@@ -629,22 +626,6 @@ public class MetalClips extends MetalAbility {
 
 	public void setArmorStartTime(long armorStartTime) {
 		this.armorStartTime = armorStartTime;
-	}
-
-	public long getTime() {
-		return time;
-	}
-
-	public void setTime(long time) {
-		this.time = time;
-	}
-
-	public double getLastDistanceCheck() {
-		return lastDistanceCheck;
-	}
-
-	public void setLastDistanceCheck(double lastDistanceCheck) {
-		this.lastDistanceCheck = lastDistanceCheck;
 	}
 
 	public double getMagnetPower() {

--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -414,7 +414,7 @@ public class MetalClips extends MetalAbility {
 
 				for (Entity e : GeneralMethods.getEntitiesAroundPoint(ii.getLocation(), 2)) {
 					if (e instanceof LivingEntity && e.getEntityId() != player.getEntityId()) {
-						if ((e instanceof Player || e instanceof Zombie || e instanceof Skeleton) && targetEntity == null) {
+						if (e instanceof Player || e instanceof Zombie || e instanceof Skeleton) {
 							targetEntity = (LivingEntity) e;
 							TARGET_TO_ABILITY.put(targetEntity, this);
 							formArmor();


### PR DESCRIPTION
- Fixed bug where shooting at a block spawned two clips
- Added ShootCooldown and CrushCooldown
- ShootCooldown only applies to shooting clips, default of 1500 (1.5 seconds)
- Changed how crushing works: (current system is unreliable)
- - Removed old style and variables
- + When controlling an entity with 4 clips, the controller can click to
cause the armor to "crush" and damage the entity.
- + Has own cooldown, default of 2000 (2 seconds)
- + Added CrushDamage option
- Changed launching:
- + Works with all clip amounts except 4
- + When the user releases sneak, the entity will be launched at varying
power depending on how many clips were attached.
- Changed ability cooldown to activate only after the ability is
finished.
- Edited default cooldown, now 6000 (6 seconds)
- Edited damage for non-armor wearing entities, uses Damage config option

Yes I tested these fixes. (You're welcome Loony)