### PR TITLE
Metal Clips fixes

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -912,7 +912,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.MetalClips.MagnetPower", 0.6);
 			config.addDefault("Abilities.Earth.MetalClips.Cooldown", 6000);
 			config.addDefault("Abilities.Earth.MetalClips.CrushCooldown", 2000);
-			config.addDefault("Abilities.Earth.MetalClips.ShootCooldown", 1500);
+			config.addDefault("Abilities.Earth.MetalClips.ShootCooldown", 0);
 			config.addDefault("Abilities.Earth.MetalClips.Duration", 10000);
 			config.addDefault("Abilities.Earth.MetalClips.ThrowEnabled", true);
 

--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -459,9 +459,6 @@ public class MetalClips extends MetalAbility {
 	@Override
 	public void remove() {
 		super.remove();
-		for (Item i : trackedIngots) {
-			i.remove();
-		}
 		
 		resetArmor();
 		trackedIngots.clear();


### PR DESCRIPTION
-Metal Clips no longer deletes iron ingots upon instance removal.
-Metal Clips shoot cooldown now 0 by default