### PR TITLE
Fixed Tremorsense, WaterArms AllowPlantSource config

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -719,7 +719,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.WaterArms.Arms.MaxAlternateUsage", 50);
 			config.addDefault("Abilities.Water.WaterArms.Arms.MaxIceShots", 8);
 			config.addDefault("Abilities.Water.WaterArms.Arms.Cooldown", 20000);
-			config.addDefault("Abilities.Water.WaterArms.Arms.AllowPlantSource", false);
+			config.addDefault("Abilities.Water.WaterArms.Arms.AllowPlantSource", true);
 
 			config.addDefault("Abilities.Water.WaterArms.Arms.Lightning.Enabled", true);
 			config.addDefault("Abilities.Water.WaterArms.Arms.Lightning.Damage", Double.valueOf(10.0));

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -33,7 +33,7 @@ public class Tremorsense extends EarthAbility {
 		this.lightThreshold = (byte) getConfig().getInt("Abilities.Earth.Tremorsense.LightThreshold");
 		this.cooldown = getConfig().getLong("Abilities.Earth.Tremorsense.Cooldown");
 
-		if (!bPlayer.canBend(this)) {
+		if (!bPlayer.canBendIgnoreBinds(this)) {
 			return;
 		}
 		
@@ -134,7 +134,7 @@ public class Tremorsense extends EarthAbility {
 			BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 			
 			if (bPlayer != null && !hasAbility(player, Tremorsense.class) 
-					&& bPlayer.canBend(getAbility("Tremorsense"))) {
+					&& bPlayer.canBendIgnoreBinds(getAbility("Tremorsense"))) {
 				new Tremorsense(player);
 			}
 		}


### PR DESCRIPTION
Tremorsense

* Ignores if they have Tremorsense bound. The passive is now enabled by default, and can still be toggled by binding it and using sneak.

________________

WaterArms

* Default config value for "AllowPlantSource" has been set to true. Plants can now be used as a source for WaterArms by default.

________________