### PR TITLE
Make DBConnection#init sync and remove async from bending player creation

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -266,12 +266,13 @@ public class GeneralMethods {
 	 * @throws SQLException
 	 */
 	public static void createBendingPlayer(final UUID uuid, final String player) {
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				createBendingPlayerAsynchronously(uuid, player);
-			}
-		}.runTaskAsynchronously(ProjectKorra.plugin);
+//		new BukkitRunnable() {
+//			@Override
+//			public void run() {
+//				createBendingPlayerAsynchronously(uuid, player);
+//			}
+//		}.runTaskAsynchronously(ProjectKorra.plugin);
+		createBendingPlayerAsynchronously(uuid, player); // "async"
 	}
 
 	private static void createBendingPlayerAsynchronously(final UUID uuid, final String player) {

--- a/src/com/projectkorra/projectkorra/storage/DBConnection.java
+++ b/src/com/projectkorra/projectkorra/storage/DBConnection.java
@@ -31,16 +31,16 @@ public class DBConnection {
 			if (!sql.tableExists("pk_players")) {
 				ProjectKorra.log.info("Creating pk_players table");
 				String query = "CREATE TABLE `pk_players` (" + "`uuid` varchar(36) NOT NULL," + "`player` varchar(16) NOT NULL," + "`element` varchar(255)," + "`subelement` varchar(255)," + "`permaremoved` varchar(5)," + "`slot1` varchar(255)," + "`slot2` varchar(255)," + "`slot3` varchar(255)," + "`slot4` varchar(255)," + "`slot5` varchar(255)," + "`slot6` varchar(255)," + "`slot7` varchar(255)," + "`slot8` varchar(255)," + "`slot9` varchar(255)," + " PRIMARY KEY (uuid));";
-				sql.modifyQuery(query);
+				sql.modifyQuery(query, false);
 			} else {				
 				try {
 					DatabaseMetaData md = sql.connection.getMetaData();
 					if (!md.getColumns(null, null, "pk_players", "subelement").next()) {
 						ProjectKorra.log.info("Updating Database with subelements...");
 						sql.getConnection().setAutoCommit(false);
-						sql.modifyQuery("ALTER TABLE `pk_players` ADD subelement varchar(255);");
+						sql.modifyQuery("ALTER TABLE `pk_players` ADD subelement varchar(255);", false);
 						sql.getConnection().commit();
-						sql.modifyQuery("UPDATE pk_players SET subelement = '-';");
+						sql.modifyQuery("UPDATE pk_players SET subelement = '-';", false);
 						sql.getConnection().setAutoCommit(true);
 						ProjectKorra.log.info("Database Updated.");
 					}
@@ -52,7 +52,7 @@ public class DBConnection {
 			if (!sql.tableExists("pk_presets")) {
 				ProjectKorra.log.info("Creating pk_presets table");
 				String query = "CREATE TABLE `pk_presets` (" + "`uuid` varchar(36) NOT NULL," + "`name` varchar(255) NOT NULL," + "`slot1` varchar(255)," + "`slot2` varchar(255)," + "`slot3` varchar(255)," + "`slot4` varchar(255)," + "`slot5` varchar(255)," + "`slot6` varchar(255)," + "`slot7` varchar(255)," + "`slot8` varchar(255)," + "`slot9` varchar(255)," + " PRIMARY KEY (uuid, name));";
-				sql.modifyQuery(query);
+				sql.modifyQuery(query, false);
 			} 
 		} else {
 			sql = new SQLite(ProjectKorra.log, "Establishing SQLite Connection.", "projectkorra.db", ProjectKorra.plugin.getDataFolder().getAbsolutePath());
@@ -66,16 +66,16 @@ public class DBConnection {
 			if (!sql.tableExists("pk_players")) {
 				ProjectKorra.log.info("Creating pk_players table.");
 				String query = "CREATE TABLE `pk_players` (" + "`uuid` TEXT(36) PRIMARY KEY," + "`player` TEXT(16)," + "`element` TEXT(255)," + "`subelement` TEXT(255)," + "`permaremoved` TEXT(5)," + "`slot1` TEXT(255)," + "`slot2` TEXT(255)," + "`slot3` TEXT(255)," + "`slot4` TEXT(255)," + "`slot5` TEXT(255)," + "`slot6` TEXT(255)," + "`slot7` TEXT(255)," + "`slot8` TEXT(255)," + "`slot9` TEXT(255));";
-				sql.modifyQuery(query);
+				sql.modifyQuery(query, false);
 			} else {
 				try {
 					DatabaseMetaData md = sql.connection.getMetaData();
 					if (!md.getColumns(null, null, "pk_players", "subelement").next()) {						
 						ProjectKorra.log.info("Updating Database with subelements...");
 						sql.getConnection().setAutoCommit(false);
-						sql.modifyQuery("ALTER TABLE `pk_players` ADD subelement TEXT(255);");
+						sql.modifyQuery("ALTER TABLE `pk_players` ADD subelement TEXT(255);", false);
 						sql.getConnection().commit();
-						sql.modifyQuery("UPDATE pk_players SET subelement = '-';");
+						sql.modifyQuery("UPDATE pk_players SET subelement = '-';", false);
 						sql.getConnection().setAutoCommit(true);
 						ProjectKorra.log.info("Database Updated.");
 					}
@@ -88,7 +88,7 @@ public class DBConnection {
 			if (!sql.tableExists("pk_presets")) {
 				ProjectKorra.log.info("Creating pk_presets table");
 				String query = "CREATE TABLE `pk_presets` (" + "`uuid` TEXT(36)," + "`name` TEXT(255)," + "`slot1` TEXT(255)," + "`slot2` TEXT(255)," + "`slot3` TEXT(255)," + "`slot4` TEXT(255)," + "`slot5` TEXT(255)," + "`slot6` TEXT(255)," + "`slot7` TEXT(255)," + "`slot8` TEXT(255)," + "`slot9` TEXT(255)," + "PRIMARY KEY (uuid, name));";
-				sql.modifyQuery(query);
+				sql.modifyQuery(query, false);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/src/com/projectkorra/projectkorra/storage/Database.java
@@ -93,7 +93,6 @@ public abstract class Database {
                 }
             }.runTaskAsynchronously(ProjectKorra.plugin);
         } else {
-            System.out.println("THIS SHOULD HAPPEN BEFORE THE ERROR");
             doQuery(query);
         }
     }
@@ -134,7 +133,7 @@ public abstract class Database {
         }
     }
 
-    private void doQuery(final String query) {
+    private synchronized void doQuery(final String query) {
         try {
             PreparedStatement stmt = connection.prepareStatement(query);
             stmt.execute();

--- a/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/src/com/projectkorra/projectkorra/storage/Database.java
@@ -93,6 +93,7 @@ public abstract class Database {
                 }
             }.runTaskAsynchronously(ProjectKorra.plugin);
         } else {
+            System.out.println("THIS SHOULD HAPPEN BEFORE THE ERROR");
             doQuery(query);
         }
     }

--- a/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/src/com/projectkorra/projectkorra/storage/Database.java
@@ -81,18 +81,20 @@ public abstract class Database {
      * @param query Query to run
      */
     public void modifyQuery(final String query) {
-    	new BukkitRunnable() {
-    		@Override
-    		public void run() {
-    			try {
-    				PreparedStatement stmt = connection.prepareStatement(query);
-    				stmt.execute();
-    				stmt.close();
-    			} catch (SQLException e) {
-    				e.printStackTrace();
-    			}
-    		}
-    	}.runTaskAsynchronously(ProjectKorra.plugin);
+    	modifyQuery(query, true);
+    }
+
+    public void modifyQuery(final String query, final boolean async) {
+        if (async) {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    doQuery(query);
+                }
+            }.runTaskAsynchronously(ProjectKorra.plugin);
+        } else {
+            doQuery(query);
+        }
     }
 
     /**
@@ -130,4 +132,15 @@ public abstract class Database {
             return false;
         }
     }
+
+    private void doQuery(final String query) {
+        try {
+            PreparedStatement stmt = connection.prepareStatement(query);
+            stmt.execute();
+            stmt.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/src/com/projectkorra/projectkorra/storage/Database.java
@@ -76,7 +76,7 @@ public abstract class Database {
     }
 
     /**
-     * Queries the Database, for queries which modify data.
+     * Queries the Database, for queries which modify data. Run async by default.
      *
      * @param query Query to run
      */
@@ -84,6 +84,12 @@ public abstract class Database {
     	modifyQuery(query, true);
     }
 
+    /**
+     * Queries the Databases, for queries which modify data.
+     *
+     * @param query Query to run
+     * @param async If to run asynchronously
+     */
     public void modifyQuery(final String query, final boolean async) {
         if (async) {
             new BukkitRunnable() {


### PR DESCRIPTION
Fixes an SQL error where the bending player is attempted to be created before DBConnection#init has completed