### PR TITLE
Changes: Paralyze, WaterArms, AirBubble, Illumination

### DIFF
--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -46,6 +46,7 @@ public class BendingPlayer {
 	private boolean permaRemoved;
 	private boolean toggled;
 	private boolean tremorSense;
+	private boolean illumination;
 	private boolean chiBlocked;
 	private long slowTime;
 	private Player player;
@@ -78,6 +79,7 @@ public class BendingPlayer {
 		this.player = Bukkit.getPlayer(uuid);
 		this.toggled = true;
 		this.tremorSense = true;
+		this.illumination = true;
 		this.chiBlocked = false;
 		cooldowns = new ConcurrentHashMap<String, Long>();
 		toggledElements = new ConcurrentHashMap<Element, Boolean>();
@@ -611,6 +613,15 @@ public class BendingPlayer {
 	public boolean isTremorSensing() {
 		return this.tremorSense;
 	}
+	
+	/**
+	 * Checks if the {@link BendingPlayer} is using illumination.
+	 * 
+	 * @return true if player is using illumination
+	 */
+	public boolean isIlluminating() {
+		return this.illumination;
+	}
 
 	public void removeCooldown(CoreAbility ability) {
 		if (ability != null) {
@@ -713,6 +724,13 @@ public class BendingPlayer {
 	 */
 	public void toggleTremorSense() {
 		tremorSense = !tremorSense;
+	}
+	
+	/**
+	 * Toggles the {@link BendingPlayer}'s illumination.
+	 */
+	public void toggleIllumination() {
+		illumination = !illumination;
 	}
 
 	/**

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -565,18 +565,18 @@ public class GeneralMethods {
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 		
 		if (ConfigManager.defaultConfig.get().getBoolean("Properties.BendingPreview") == true) {
-		if (ability != null) {
-			if (bPlayer.isOnCooldown(ability)) {
-				displayedMessage = ability.getElement().getColor() + "" + ChatColor.STRIKETHROUGH + ability.getName();
+			if (ability != null) {
+				if (bPlayer.isOnCooldown(ability)) {
+					displayedMessage = ability.getElement().getColor() + "" + ChatColor.STRIKETHROUGH + ability.getName();
+				} else {
+					displayedMessage = ability.getElement().getColor() + ability.getName();
+				}
 			} else {
-				displayedMessage = ability.getElement().getColor() + ability.getName();
+				displayedMessage = "";
 			}
-		} else {
-			displayedMessage = "";
-		}
 		
-		ActionBar.sendActionBar(displayedMessage, player);
-	}
+			ActionBar.sendActionBar(displayedMessage, player);
+		}
 	}
 
 	public static List<Block> getBlocksAlongLine(Location ploc, Location tloc, World w) {

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1615,7 +1615,7 @@ public class PKListener implements Listener {
 					new HeatControlExtinguish(player);
 				}
 				if (abil.equalsIgnoreCase("Illumination")) {
-					new Illumination(player);
+					bPlayer.toggleIllumination();
 				}
 				if (abil.equalsIgnoreCase("FireBurst")) {
 					FireBurst.coneBurst(player);

--- a/src/com/projectkorra/projectkorra/airbending/AirBubble.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBubble.java
@@ -95,9 +95,6 @@ public class AirBubble extends AirAbility {
 			radius = waterRadius;
 		}
 		
-		if (bPlayer.hasElement(Element.WATER) && isNight(player.getWorld())) {
-			radius = WaterAbility.getNightFactor(waterRadius, player.getWorld());
-		}
 		if (airRadius > radius && bPlayer.hasElement(Element.AIR)) {
 			radius = airRadius;
 		}

--- a/src/com/projectkorra/projectkorra/chiblocking/Paralyze.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/Paralyze.java
@@ -1,22 +1,21 @@
 package com.projectkorra.projectkorra.chiblocking;
 
-import com.projectkorra.projectkorra.BendingPlayer;
-import com.projectkorra.projectkorra.ability.ChiAbility;
-import com.projectkorra.projectkorra.airbending.Suffocate;
-import com.projectkorra.projectkorra.command.Commands;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.ability.ChiAbility;
+import com.projectkorra.projectkorra.airbending.Suffocate;
+import com.projectkorra.projectkorra.command.Commands;
 
 public class Paralyze extends ChiAbility {
 
 	private static final Map<Entity, Long> ENTITIES = new ConcurrentHashMap<>();
-	private static final Map<Entity, Long> COOLDOWNS = new ConcurrentHashMap<>();
 
 	private long cooldown;
 	private Entity target;
@@ -33,14 +32,7 @@ public class Paralyze extends ChiAbility {
 	
 	@Override
 	public void progress() {
-		if (bPlayer.canBendIgnoreCooldowns(this)) {
-			if (COOLDOWNS.containsKey(target)) {
-				if (System.currentTimeMillis() < COOLDOWNS.get(target) + cooldown) {
-					return;
-				} else {
-					COOLDOWNS.remove(target);
-				}
-			}
+		if (bPlayer.canBend(this)) {
 			if (target instanceof Player) {
 				if (Commands.invincible.contains(((Player) target).getName())) {
 					remove();
@@ -48,7 +40,7 @@ public class Paralyze extends ChiAbility {
 				}
 			}
 			paralyze(target);
-			COOLDOWNS.put(target, System.currentTimeMillis());
+			bPlayer.addCooldown(this);
 		} else {
 			remove();
 		}
@@ -124,14 +116,6 @@ public class Paralyze extends ChiAbility {
 
 	public static Map<Entity, Long> getEntities() {
 		return ENTITIES;
-	}
-
-	public static Map<Entity, Long> getCooldowns() {
-		return COOLDOWNS;
-	}
-
-	public void setCooldown(long cooldown) {
-		this.cooldown = cooldown;
 	}
 	
 }

--- a/src/com/projectkorra/projectkorra/firebending/FirePassive.java
+++ b/src/com/projectkorra/projectkorra/firebending/FirePassive.java
@@ -1,12 +1,13 @@
 package com.projectkorra.projectkorra.firebending;
 
-import com.projectkorra.projectkorra.BendingPlayer;
-import com.projectkorra.projectkorra.Element;
-import com.projectkorra.projectkorra.command.Commands;
-import com.projectkorra.projectkorra.configuration.ConfigManager;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+
+import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.Element;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.command.Commands;
+import com.projectkorra.projectkorra.configuration.ConfigManager;
 
 public class FirePassive {
 
@@ -19,6 +20,10 @@ public class FirePassive {
 			if (bPlayer != null && bPlayer.canBendPassive(Element.FIRE)) {
 				if (player.getFireTicks() > 80) {
 					player.setFireTicks(80);
+				}
+				
+				if (CoreAbility.getAbility(player, Illumination.class) == null) {
+					new Illumination(player);
 				}
 			}
 		}

--- a/src/com/projectkorra/projectkorra/firebending/Illumination.java
+++ b/src/com/projectkorra/projectkorra/firebending/Illumination.java
@@ -31,6 +31,11 @@ public class Illumination extends FireAbility {
 			return;
 		}
 		
+		if (!bPlayer.isIlluminating()) {
+			remove();
+			return;
+		}
+		
 		this.range = getConfig().getDouble("Abilities.Fire.Illumination.Range");
 		this.cooldown = getConfig().getLong("Abilities.Fire.Illumination.Cooldown");
 		
@@ -51,6 +56,12 @@ public class Illumination extends FireAbility {
 			remove();
 			return;
 		}
+		
+		if (!bPlayer.isIlluminating()) {
+			remove();
+			return;
+		}
+		
 		set();
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterArmsWhip.java
@@ -221,7 +221,6 @@ public class WaterArmsWhip extends WaterAbility {
 
 		useArm();
 		dragEntity(end);
-		grapplePlayer(end);
 	}
 
 	private boolean canPlaceBlock(Block block) {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterPassive.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterPassive.java
@@ -53,6 +53,8 @@ public class WaterPassive {
 			if (bPlayer.canBendPassive(Element.WATER)) {
 				if (CoreAbility.hasAbility(player, WaterSpout.class) || CoreAbility.hasAbility(player, EarthArmor.class)) {
 					continue;
+				} else if (CoreAbility.getAbility(player, WaterArms.class) != null) {
+					continue;
 				} else if (coreAbil == null || (coreAbil != null && !coreAbil.isSneakAbility())) {
 					if (player.isSneaking() && WaterAbility.isWater(player.getLocation().getBlock())) {
 						player.setVelocity(player.getEyeLocation().getDirection().clone().normalize().multiply(swimSpeed));


### PR DESCRIPTION
Paralyze

* Paralyze cooldown system has been updated.
    - MovePreview now displays Paralyze while on cooldown correctly.

____________

WaterArms

* You can no longer FastSwim while having WaterArms enabled.

Water Arms (Grapple)

* Fix/Improvement to launching yourself in the air. May need more tweaking in the future (Loony says it's alright so I'm PRing it wasnt me blameloony ty)

____________

AirBubble

* AirBubble no longer gets WaterBubble's night factor.

____________

Illumination

* Illumination now works correctly as a passive ability. It is automatically enabled for all firebenders and can be toggled by clicking with the ability bound.

____________