### PR TITLE
Fixed WaterReturn permission & MetalClips duplication

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -428,9 +428,7 @@ public class MetalClips extends MetalAbility {
 								formArmor();
 							} else {
 								TARGET_TO_ABILITY.get(targetEntity).remove();
-								targetEntity = (LivingEntity) e;
-								TARGET_TO_ABILITY.put(targetEntity, this);
-								formArmor();
+								player.getWorld().dropItemNaturally(e.getLocation(), new ItemStack(Material.IRON_INGOT, 1));
 							}
 						} else {
 							DamageHandler.damageEntity(e, player, damage, this);

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -113,6 +113,7 @@ permissions:
       bending.ability.WaterArms.Grab: true
       bending.ability.WaterArms.Freeze: true
       bending.ability.WaterArms.Spear: true
+      bending.ability.WaterReturn: true
   bending.earth:
     default: true
     description: Grants access to all Earthbending abilities.


### PR DESCRIPTION
WaterReturn

* bending.ability.WaterReturn is now in bending.player in plugin.yml to fix permission problems with bottlebending.

_______________

MetalClips

* If you have already shot a metal clip at someone and then hit someone else with one it will remove the ability instance, fixing duplicated armour.

_______________