### PR TITLE
1.9/1.10 Tweaks

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -690,10 +690,7 @@ public class PKListener implements Listener {
 				return;
 			}
 
-			StringBuilder sb = new StringBuilder();
-			sb.append(ability.getElement().getColor());
-			sb.append(event.getAbility().getName());
-			BENDING_PLAYER_DEATH.put((Player) event.getEntity(), sb.toString());
+			BENDING_PLAYER_DEATH.put((Player) event.getEntity(), ability.getElement().getColor() + ability.getName());
 			final Player player = (Player) event.getEntity();
 
 			new BukkitRunnable() {
@@ -848,7 +845,7 @@ public class PKListener implements Listener {
 				if (sourceBPlayer.canBendPassive(Element.CHI)) {
 					if (e.getCause() == DamageCause.ENTITY_ATTACK && e.getDamage() == 1) {
 						if (sourceBPlayer.getBoundAbility() instanceof ChiAbility) {
-							if (GeneralMethods.isWeapon(sourcePlayer.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
+							if (GeneralMethods.isWeapon(sourcePlayer.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
 								return;
 							}
 							if (sourceBPlayer.isElementToggled(Element.CHI) == true) {
@@ -864,7 +861,7 @@ public class PKListener implements Listener {
 					}
 				}
 				if (sourceBPlayer.canBendPassive(Element.CHI)) {
-					if (GeneralMethods.isWeapon(sourcePlayer.getItemInHand().getType()) && !ProjectKorra.plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
+					if (GeneralMethods.isWeapon(sourcePlayer.getInventory().getItemInMainHand().getType()) && !ProjectKorra.plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
 						return;
 					}
 					if (e.getCause() == DamageCause.ENTITY_ATTACK && sourceBPlayer.isElementToggled(Element.CHI) == true) {
@@ -959,13 +956,12 @@ public class PKListener implements Listener {
 			}
 		}
 
-
 		if (event.getEntity().getKiller() != null) {
 			if (BENDING_PLAYER_DEATH.containsKey(event.getEntity())) {
 				String message = ConfigManager.languageConfig.get().getString("DeathMessages.Default");
 				String ability = BENDING_PLAYER_DEATH.get(event.getEntity());
 				String tempAbility = ChatColor.stripColor(ability).replaceAll(" ", "");
-				CoreAbility coreAbil = CoreAbility.getAbility(ability);
+				CoreAbility coreAbil = CoreAbility.getAbility(tempAbility);
 				Element element = null;
 				boolean isAvatarAbility = false;
 
@@ -1266,7 +1262,7 @@ public class PKListener implements Listener {
 				return;
 			}
 			if (coreAbil instanceof AirAbility && bPlayer.isElementToggled(Element.AIR) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Air.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Air.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("Tornado")) {
@@ -1299,7 +1295,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof WaterAbility && bPlayer.isElementToggled(Element.WATER) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Water.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Water.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("Bloodbending")) {
@@ -1332,7 +1328,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof EarthAbility && bPlayer.isElementToggled(Element.EARTH) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Earth.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Earth.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("EarthBlast")) {
@@ -1381,7 +1377,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof FireAbility && bPlayer.isElementToggled(Element.FIRE) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Fire.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Fire.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("Blaze")) {
@@ -1461,7 +1457,7 @@ public class PKListener implements Listener {
 		} else if (GeneralMethods.isInteractable(player.getTargetBlock((Set<Material>) null, 5))) {
 			event.setCancelled(true);
 			return;
-		} else if (player.getItemInHand().getType() == Material.FISHING_ROD) {
+		} else if (player.getInventory().getItemInMainHand().getType() == Material.FISHING_ROD) {
 			return;
 		}
 
@@ -1479,7 +1475,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof AirAbility && bPlayer.isElementToggled(Element.AIR) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Air.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Air.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("AirBlast")) {
@@ -1516,7 +1512,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof WaterAbility && bPlayer.isElementToggled(Element.WATER) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Water.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Water.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("Bloodbending")) {
@@ -1552,7 +1548,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof EarthAbility && bPlayer.isElementToggled(Element.EARTH) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Earth.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Earth.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("Catapult")) {
@@ -1607,7 +1603,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof FireAbility && bPlayer.isElementToggled(Element.FIRE) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Fire.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Fire.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("Blaze")) {
@@ -1645,7 +1641,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof ChiAbility && bPlayer.isElementToggled(Element.CHI) == true) {
-				if (GeneralMethods.isWeapon(player.getItemInHand().getType()) && !plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
+				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && !plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
 					return;
 				}
 				if (abil.equalsIgnoreCase("HighJump")) {

--- a/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/MetalClips.java
@@ -286,7 +286,7 @@ public class MetalClips extends MetalAbility {
 			}
 			for (Entity entity : GeneralMethods.getEntitiesAroundPoint(player.getLocation(), magnetRange)) {
 				Vector vector = GeneralMethods.getDirection(entity.getLocation(), player.getLocation());
-				ItemStack itemInHand = player.getInventory().getItemInHand();
+				ItemStack itemInHand = player.getInventory().getItemInMainHand();
 				
 				if (entity instanceof Player && canLoot && itemInHand.getType() == Material.IRON_INGOT && itemInHand.getItemMeta().getDisplayName().equalsIgnoreCase("Magnet")) {
 					Player targetPlayer = (Player) entity;
@@ -320,9 +320,9 @@ public class MetalClips extends MetalAbility {
 					}
 
 					targetPlayer.getInventory().setArmorContents(armor);
-					if (Arrays.asList(METAL_ITEMS).contains(targetPlayer.getInventory().getItemInHand().getType())) {
-						targetPlayer.getWorld().dropItem(targetPlayer.getLocation(), targetPlayer.getEquipment().getItemInHand());
-						targetPlayer.getEquipment().setItemInHand(new ItemStack(Material.AIR, 1));
+					if (Arrays.asList(METAL_ITEMS).contains(targetPlayer.getInventory().getItemInMainHand().getType())) {
+						targetPlayer.getWorld().dropItem(targetPlayer.getLocation(), targetPlayer.getEquipment().getItemInMainHand());
+						targetPlayer.getEquipment().setItemInMainHand(new ItemStack(Material.AIR, 1));
 					}
 				}
 
@@ -343,9 +343,9 @@ public class MetalClips extends MetalAbility {
 
 					livingEntity.getEquipment().setArmorContents(armor);
 
-					if (Arrays.asList(METAL_ITEMS).contains(livingEntity.getEquipment().getItemInHand().getType())) {
-						livingEntity.getWorld().dropItem(livingEntity.getLocation(), livingEntity.getEquipment().getItemInHand());
-						livingEntity.getEquipment().setItemInHand(new ItemStack(Material.AIR, 1));
+					if (Arrays.asList(METAL_ITEMS).contains(livingEntity.getEquipment().getItemInMainHand().getType())) {
+						livingEntity.getWorld().dropItem(livingEntity.getLocation(), livingEntity.getEquipment().getItemInMainHand());
+						livingEntity.getEquipment().setItemInMainHand(new ItemStack(Material.AIR, 1));
 					}
 				}
 

--- a/src/com/projectkorra/projectkorra/firebending/HeatControlCook.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControlCook.java
@@ -25,7 +25,7 @@ public class HeatControlCook extends FireAbility {
 		
 		this.time = System.currentTimeMillis();
 		this.cookTime = getConfig().getLong("Abilities.Fire.HeatControl.Cook.CookTime");
-		this.item = player.getItemInHand();
+		this.item = player.getInventory().getItemInMainHand();
 		
 		if (isCookable(item.getType())) {
 			start();
@@ -89,9 +89,9 @@ public class HeatControlCook extends FireAbility {
 		if (!bPlayer.canBendIgnoreCooldowns(this)) {
 			remove();
 			return;
-		} else if (!item.equals(player.getItemInHand())) {
+		} else if (!item.equals(player.getInventory().getItemInMainHand())) {
 			time = System.currentTimeMillis();
-			item = player.getItemInHand();
+			item = player.getInventory().getItemInMainHand();
 		}
 
 		if (!isCookable(item.getType())) {

--- a/src/com/projectkorra/projectkorra/firebending/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/Lightning.java
@@ -122,8 +122,8 @@ public class Lightning extends LightningAbility {
 	 * @param lent The LivingEntity that is being damaged
 	 */
 	public void electrocute(LivingEntity lent) {
-		lent.getWorld().playSound(lent.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0);
-		player.getWorld().playSound(player.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0);
+		lent.getWorld().playSound(lent.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0.01F);
+		player.getWorld().playSound(player.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0.01F);
 		DamageHandler.damageEntity(lent, damage, this);
 		
 		if (Math.random() < stunChance) {
@@ -532,8 +532,8 @@ public class Lightning extends LightningAbility {
 						affectedEntities.add(entity);
 						LivingEntity lent = (LivingEntity) entity;
 						if (lent instanceof Player) {
-							lent.getWorld().playSound(lent.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0);
-							player.getWorld().playSound(player.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0);
+							lent.getWorld().playSound(lent.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0.01F);
+							player.getWorld().playSound(player.getLocation(), Sound.ENTITY_CREEPER_HURT, 1, 0.01F);
 							Player p = (Player) lent;
 							Lightning light = getAbility(p, Lightning.class);
 							if (light != null && light.state == State.START) {

--- a/src/com/projectkorra/projectkorra/util/ParticleEffect.java
+++ b/src/com/projectkorra/projectkorra/util/ParticleEffect.java
@@ -925,7 +925,7 @@ public enum ParticleEffect {
 	public static abstract class ParticleData {
 		private final Material material;
 		private final byte data;
-		private final int[] packetData;
+		private int[] packetData;
 
 		/**
 		 * Construct a new particle data
@@ -975,6 +975,15 @@ public enum ParticleEffect {
 		public String getPacketDataString() {
 			return "_" + packetData[0] + "_" + packetData[1];
 		}
+		
+		/**Sets the packet data. Should be an integer array. For ITEM_CRACK
+		 *  and BLOCK_DUST, it should be [id, meta] but for BLOCK_CRACK it 
+		 *  should be [id + (meta * 4096)] 
+		 * 
+		 * @param data The packet data.*/
+		public void setPacketData(int[] data) {
+			packetData = data;
+		}
 	}
 
 	/**
@@ -1018,11 +1027,14 @@ public enum ParticleEffect {
 		 * @throws IllegalArgumentException If the material is not a block
 		 * @see ParticleData#ParticleData(Material, byte)
 		 */
+		@SuppressWarnings("deprecation")
 		public BlockData(Material material, byte data) throws IllegalArgumentException {
 			super(material, data);
 			if (!material.isBlock()) {
 				throw new IllegalArgumentException("The material is not a block");
 			}
+			
+			this.setPacketData(new int[] {material.getId() + (data * 4096)});
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterReturn.java
@@ -11,6 +11,8 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionType;
 import org.bukkit.util.Vector;
 
 import java.util.HashMap;
@@ -142,12 +144,30 @@ public class WaterReturn extends WaterAbility {
 			return false;
 		}
 		PlayerInventory inventory = player.getInventory();
-		return (inventory.contains(new ItemStack(Material.POTION), 1));
+		if (inventory.contains(Material.POTION)) {
+			ItemStack item = inventory.getItem(inventory.first(Material.POTION));
+			PotionMeta meta = (PotionMeta) item.getItemMeta();
+			return meta.getBasePotionData().getType().equals(PotionType.WATER);
+		}
+		return false;
 	}
 
 	public static void emptyWaterBottle(Player player) {
 		PlayerInventory inventory = player.getInventory();
-		int index = inventory.first(new ItemStack(Material.POTION));
+		int index = inventory.first(Material.POTION);
+		
+		//Check that the first one found is actually a WATER bottle. We aren't implementing potion bending just yet ;)
+		if (index != -1 && !((PotionMeta)inventory.getItem(index).getItemMeta()).getBasePotionData().getType().equals(PotionType.WATER)) {
+			for (int i = 0; i < inventory.getSize(); i++) {
+				if (inventory.getItem(i).getType() == Material.POTION) {
+					PotionMeta meta = (PotionMeta) inventory.getItem(i).getItemMeta();
+					if (meta.getBasePotionData().getType().equals(PotionType.WATER)) {
+						index = i;
+						break;
+					}
+				}
+			}
+		}
 		
 		if (index != -1) {
 			ItemStack item = inventory.getItem(index);


### PR DESCRIPTION
• Fixed all deprecated player.getItemInHand methods
• Death messages not working at all (only the default bending death
message would show)
• Fixed BLOCK_CRACK particles being unable to spawn block particles with
metadata
• Fixed bottlebending breaking in 1.9/1.10

Thanks to jedk1 for bottlebending fix as it was orignally his.