### PR TITLE
Various Fixes

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -467,13 +467,13 @@ public class GeneralMethods {
 		loc.setZ(loc.getZ() + Math.random() * (zOffset / 2 - -(zOffset / 2)));
 
 		if (type == ParticleEffect.RED_DUST || type == ParticleEffect.REDSTONE) {
-			ParticleEffect.RED_DUST.display(R, G, B, 0.004F, 0, loc, 257D);
+			ParticleEffect.RED_DUST.display(R, G, B, 0.004F, 0, loc, 255.0);
 		} else if (type == ParticleEffect.SPELL_MOB || type == ParticleEffect.MOB_SPELL) {
-			ParticleEffect.SPELL_MOB.display((float) 255 - R, (float) 255 - G, (float) 255 - B, 1, 0, loc, 257D);
+			ParticleEffect.SPELL_MOB.display((float) 255 - R, (float) 255 - G, (float) 255 - B, 1, 0, loc, 255.0);
 		} else if (type == ParticleEffect.SPELL_MOB_AMBIENT || type == ParticleEffect.MOB_SPELL_AMBIENT) {
-			ParticleEffect.SPELL_MOB_AMBIENT.display((float) 255 - R, (float) 255 - G, (float) 255 - B, 1, 0, loc, 257D);
+			ParticleEffect.SPELL_MOB_AMBIENT.display((float) 255 - R, (float) 255 - G, (float) 255 - B, 1, 0, loc, 255.0);
 		} else {
-			ParticleEffect.RED_DUST.display(0, 0, 0, 0.004F, 0, loc, 257D);
+			ParticleEffect.RED_DUST.display(0, 0, 0, 0.004F, 0, loc, 255.0D);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1088,22 +1088,20 @@ public class PKListener implements Listener {
 			return;
 		}
 
-//		else if (CoreAbility.hasAbility(player, WaterSpout.class) || CoreAbility.hasAbility(player, AirSpout.class) || CoreAbility.hasAbility(player, SandSpout.class)) {
-//			Vector vel = new Vector();
-//			vel.setX(event.getTo().getX() - event.getFrom().getX());
-//			vel.setY(event.getTo().getY() - event.getFrom().getY());
-//			vel.setZ(event.getTo().getZ() - event.getFrom().getZ());
-//			// You now know the old velocity. Set to match recommended velocity
-//			double currspeed = vel.length();
-//			double maxspeed = .15;
-//			if (currspeed > maxspeed) {
-//				// only if moving set a factor
-//				vel = vel.normalize().multiply(maxspeed);
-//				// apply the new velocity (MAY REQUIRE A SCHEDULED TASK
-//				// INSTEAD!)
-//				event.getPlayer().setVelocity(vel);
-//			}
-//		}
+		else if (CoreAbility.hasAbility(player, WaterSpout.class) || CoreAbility.hasAbility(player, AirSpout.class) || CoreAbility.hasAbility(player, SandSpout.class)) {
+			Vector vel = new Vector();
+			vel.setX(event.getTo().getX() - event.getFrom().getX());
+			vel.setZ(event.getTo().getZ() - event.getFrom().getZ());
+
+			double currspeed = vel.length();
+			double maxspeed = .2;
+			if (currspeed > maxspeed) {
+				// apply only if moving set a factor
+				vel = vel.normalize().multiply(maxspeed);
+				// apply the new velocity
+				event.getPlayer().setVelocity(vel);
+			}
+		}
 
 		else if (Bloodbending.isBloodbent(player)) {
 			double distance1, distance2;

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1573,7 +1573,7 @@ public class PKListener implements Listener {
 					new EarthGrab(player, true);
 				}
 				if (abil.equalsIgnoreCase("Tremorsense")) {
-					new Tremorsense(player);
+					new Tremorsense(player, true);
 				}
 				if (abil.equalsIgnoreCase("MetalClips")) {
 					MetalClips clips = CoreAbility.getAbility(player, MetalClips.class);

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -272,11 +272,11 @@ public abstract class EarthAbility extends ElementalAbility {
 
 		for (int x = 0; x < amount; x++) {
 			if (!red) {
-				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte) 0), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 257.0D);
-				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SANDSTONE, (byte) 0), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 257.0D);
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte) 0), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 255.0);
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SANDSTONE, (byte) 0), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 255.0);
 			} else if (red) {
-				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte) 1), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 257.0D);
-				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.RED_SANDSTONE, (byte) 0), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 257.0D);
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.SAND, (byte) 1), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 255.0);
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.RED_SANDSTONE, (byte) 0), new Vector(((Math.random() - 0.5) * xOffset), ((Math.random() - 0.5) * yOffset), ((Math.random() - 0.5) * zOffset)), speed, loc, 255.0);
 			}
 
 		}

--- a/src/com/projectkorra/projectkorra/command/HelpCommand.java
+++ b/src/com/projectkorra/projectkorra/command/HelpCommand.java
@@ -165,7 +165,7 @@ public class HelpCommand extends PKCommand {
 				abils.add(coreAbil.getName());
 			} else if (sender instanceof Player) {
 				BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(sender.getName());
-				if (bPlayer.canBind(coreAbil) || (coreAbil instanceof ComboAbility)) {
+				if (bPlayer.canBind(coreAbil) || ((coreAbil instanceof ComboAbility) && bPlayer.hasElement(coreAbil.getElement()))) {
 					abils.add(coreAbil.getName());
 				}
 			}

--- a/src/com/projectkorra/projectkorra/earthbending/SandSpout.java
+++ b/src/com/projectkorra/projectkorra/earthbending/SandSpout.java
@@ -26,6 +26,8 @@ public class SandSpout extends SandAbility {
 	private double damage;
 	private double height;
 	private double currentHeight;
+	private boolean couldFly;
+	private boolean wasFlying;
 	private Flight flight;
 	
 	public SandSpout(Player player) {
@@ -38,6 +40,9 @@ public class SandSpout extends SandAbility {
 		this.height = getConfig().getDouble("Abilities.Earth.SandSpout.Height");
 		this.blindnessTime = getConfig().getInt("Abilities.Earth.SandSpout.BlindnessTime");
 		this.damage = getConfig().getInt("Abilities.Earth.SandSpout.SpoutDamage");
+		
+		this.couldFly = player.getAllowFlight();
+		this.wasFlying = player.isFlying();
 		
 		SandSpout oldSandSpout = getAbility(player, SandSpout.class);
 		if (oldSandSpout != null) {
@@ -110,8 +115,8 @@ public class SandSpout extends SandAbility {
 	}
 
 	private void removeFlight() {
-		player.setAllowFlight(false);
-		player.setFlying(false);
+		player.setAllowFlight(couldFly);
+		player.setFlying(wasFlying);
 	}
 
 	private Block getGround() {

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -25,25 +25,30 @@ public class Tremorsense extends EarthAbility {
 	private long cooldown;
 	private Block block;
 	
-	public Tremorsense(Player player) {
+	public Tremorsense(Player player, boolean clicked) {
 		super(player);
-		
-		this.maxDepth = getConfig().getInt("Abilities.Earth.Tremorsense.MaxDepth");
-		this.radius = getConfig().getInt("Abilities.Earth.Tremorsense.Radius");
-		this.lightThreshold = (byte) getConfig().getInt("Abilities.Earth.Tremorsense.LightThreshold");
-		this.cooldown = getConfig().getLong("Abilities.Earth.Tremorsense.Cooldown");
 
 		if (!bPlayer.canBendIgnoreBinds(this)) {
 			return;
 		}
 		
+		setFields();
 		byte lightLevel = player.getLocation().getBlock().getLightLevel();
-
+		
 		if (lightLevel < this.lightThreshold && isEarthbendable(player.getLocation().getBlock().getRelative(BlockFace.DOWN))) {
-			bPlayer.addCooldown(this);
-			activate();
+			if(clicked) {
+				bPlayer.addCooldown(this);
+				activate();
+			}
 			start();
 		}
+	}
+	
+	private void setFields() {
+		this.maxDepth = getConfig().getInt("Abilities.Earth.Tremorsense.MaxDepth");
+		this.radius = getConfig().getInt("Abilities.Earth.Tremorsense.Radius");
+		this.lightThreshold = (byte) getConfig().getInt("Abilities.Earth.Tremorsense.LightThreshold");
+		this.cooldown = getConfig().getLong("Abilities.Earth.Tremorsense.Cooldown");
 	}
 
 	private void activate() {
@@ -133,7 +138,7 @@ public class Tremorsense extends EarthAbility {
 		for (Player player : server.getOnlinePlayers()) {
 			
 			if (canTremorSense(player) && !hasAbility(player, Tremorsense.class)) {
-				new Tremorsense(player);
+				new Tremorsense(player, false);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -181,7 +181,7 @@ public class FireBlastCharged extends FireAbility {
 					}
 				}
 				location.getWorld().playSound(location, Sound.ENTITY_GENERIC_EXPLODE, 5, 1);
-				ParticleEffect.EXPLOSION_HUGE.display(new Vector(0, 0, 0), 0, location, 256);
+				ParticleEffect.EXPLOSION_HUGE.display(new Vector(0, 0, 0), 0, location, 255.0D);
 			}
 		}
 

--- a/src/com/projectkorra/projectkorra/waterbending/IceBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/IceBlast.java
@@ -164,7 +164,7 @@ public class IceBlast extends IceAbility {
 		AirAbility.breakBreathbendingHold(entity);
 
 		for (int x = 0; x < 30; x++) {
-			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte) 0), new Vector(((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5)), .3f, location, 257.0D);
+			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte) 0), new Vector(((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5)), .3f, location, 255.0);
 		}
 	}
 
@@ -289,7 +289,7 @@ public class IceBlast extends IceAbility {
 			source = new TempBlock(sourceBlock, Material.PACKED_ICE, data);
 
 			for (int x = 0; x < 10; x++) {
-				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte) 0), new Vector(((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5)), .5f, location, 257.0D);
+				ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte) 0), new Vector(((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5)), .5f, location, 255.0);
 				ParticleEffect.SNOW_SHOVEL.display(location, (float) (Math.random() - 0.5), (float) (Math.random() - 0.5), (float) (Math.random() - 0.5), 0, 5);
 			}
 			if ((new Random()).nextInt(4) == 0) {
@@ -303,7 +303,7 @@ public class IceBlast extends IceAbility {
 
 	public void breakParticles(int amount) {
 		for (int x = 0; x < amount; x++) {
-			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte) 0), new Vector(((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5)), 2f, location, 257.0D);
+			ParticleEffect.ITEM_CRACK.display(new ParticleEffect.ItemData(Material.ICE, (byte) 0), new Vector(((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5), ((Math.random() - 0.5) * .5)), 2f, location, 255.0);
 			ParticleEffect.SNOW_SHOVEL.display(location, (float) Math.random(), (float) Math.random(), (float) Math.random(), 0, 2);
 		}
 		location.getWorld().playSound(location, Sound.BLOCK_GLASS_BREAK, 5, 1.3f);

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -385,13 +385,13 @@ public class OctopusForm extends WaterAbility {
 					tblock.setType(Material.WATER, FULL);
 				}
 				if (isWater(block) && !TempBlock.isTempBlock(block)) {
-					ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, block.getLocation().clone().add(0.5, 0.5, 0.5), 257D);
+					ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, block.getLocation().clone().add(0.5, 0.5, 0.5), 255.0);
 				} 
 				newBlocks.add(tblock);
 			}
 		} else if (isWaterbendable(player, block) || block.getType() == Material.FIRE || block.getType() == Material.AIR) {
 			if (isWater(block) && !TempBlock.isTempBlock(block)) {
-				ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, block.getLocation().clone().add(0.5, 0.5, 0.5), 257D);
+				ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, block.getLocation().clone().add(0.5, 0.5, 0.5), 255.0);
 			} 
 			newBlocks.add(new TempBlock(block, Material.STATIONARY_WATER, (byte) 8));
 		}

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -223,7 +223,7 @@ public class Torrent extends WaterAbility {
 					double dz = Math.sin(phi) * radius;
 					loc.add(dx, dy, dz);
 					if(GeneralMethods.isAdjacentToThreeOrMoreSources(loc.getBlock())) {
-						ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, loc.getBlock().getLocation().clone().add(.5,.5,.5), 257D);
+						ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, loc.getBlock().getLocation().clone().add(.5,.5,.5), 255.0);
 					}
 					loc.subtract(dx, dy, dz);
 				}
@@ -362,7 +362,7 @@ public class Torrent extends WaterAbility {
 			}
 			if (locBlock.getLocation().distanceSquared(targetLoc) > 1) {
 				if (isWater(locBlock)) {
-					ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, locBlock.getLocation().clone().add(.5,.5,.5), 257D);
+					ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, locBlock.getLocation().clone().add(.5,.5,.5), 255.0);
 				}
 				newBlocks.add(new TempBlock(locBlock, Material.STATIONARY_WATER, (byte) 8));
 			} else {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -380,7 +380,7 @@ public class WaterManipulation extends WaterAbility {
 		} else {
 			if (isWater(block) && !AFFECTED_BLOCKS.containsKey(block)) {
 				ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f,
-						5, block.getLocation().clone().add(.5, .5, .5), 257D);
+						5, block.getLocation().clone().add(.5, .5, .5), 255.0);
 			} 
 		}
 

--- a/src/com/projectkorra/projectkorra/waterbending/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterReturn.java
@@ -82,7 +82,7 @@ public class WaterReturn extends WaterAbility {
 			block = new TempBlock(newblock, Material.WATER, (byte) 0);
 		} else if (isTransparent(player, newblock)) {
 			if (isWater(newblock)) {
-				ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, newblock.getLocation().clone().add(.5,.5,.5), 257D);
+				ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f, 5, newblock.getLocation().clone().add(.5,.5,.5), 255.0);
 			}
 		} else {
 			remove();


### PR DESCRIPTION
Fixes `TremorSense` particles activating on movement and activation. Now only works with click.
Fixes particle distance. Particles now only appear within the radius slightly smaller than the entity render distance.
Fixes bending help auto tabbing displaying combos players didn't have access to.
Fixes `SandSpout` disabling flight on `remove()`