### PR TITLE
Generi-size PhaseChangeFreeze

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class PhaseChangeFreeze extends IceAbility {
 
-	private static final ConcurrentHashMap<Block, Byte> FROZEN_BLOCKS = new ConcurrentHashMap<>();
+	private static final Map<Block, Byte> FROZEN_BLOCKS = new ConcurrentHashMap<>();
 	private static final double REMOVE_RANGE = 50; // TODO: Make the remove range non static
 	
 	private static boolean overloading = false;


### PR DESCRIPTION
Makes the `ConcurrentHashMap<Block, Byte>` in `PhaseChangeFreeze` generic to allow for Java 7 / Java 8 compatibility.