### PR TITLE
Generi-size PhaseChangeFreeze

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class PhaseChangeFreeze extends IceAbility {
 
-	private static final ConcurrentHashMap<Block, Byte> FROZEN_BLOCKS = new ConcurrentHashMap<>();
+	private static final Map<Block, Byte> FROZEN_BLOCKS = new ConcurrentHashMap<>();
 	private static final double REMOVE_RANGE = 50; // TODO: Make the remove range non static
 	
 	private static boolean overloading = false;

--- a/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
@@ -242,7 +242,7 @@ public class PhaseChangeFreeze extends IceAbility {
 		this.radius = radius;
 	}
 
-	public static ConcurrentHashMap<Block, Byte> getFrozenBlocks() {
+	public static Map<Block, Byte> getFrozenBlocks() {
 		return FROZEN_BLOCKS;
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/PhaseChangeFreeze.java
@@ -13,6 +13,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PhaseChangeFreeze extends IceAbility {


### PR DESCRIPTION
Makes the `ConcurrentHashMap<Block, Byte>` in `PhaseChangeFreeze` a Generic `Map<Block, Byte>` type in order to allow for Java 7 / Java 8 compatibility. 