### PR TITLE
Flight, Chi Stance & Chris' life

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1081,7 +1081,7 @@ public class PKListener implements Listener {
 		else if (AirFlight.isFlying(event.getPlayer())) {
 			if (AirFlight.isHovering(event.getPlayer())) {
 				Location loc = event.getFrom();
-				Location toLoc = player.getLocation();
+				Location toLoc = event.getTo();
 
 				if (loc.getX() != toLoc.getX() || loc.getY() != toLoc.getY() || loc.getZ() != toLoc.getZ()) {
 					event.setCancelled(true);

--- a/src/com/projectkorra/projectkorra/chiblocking/AcrobatStance.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/AcrobatStance.java
@@ -1,14 +1,14 @@
 package com.projectkorra.projectkorra.chiblocking;
 
-import com.projectkorra.projectkorra.Element;
-import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.ChiAbility;
-
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+
+import com.projectkorra.projectkorra.Element;
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.ChiAbility;
 
 public class AcrobatStance extends ChiAbility {
 	
@@ -30,11 +30,8 @@ public class AcrobatStance extends ChiAbility {
 		
 		ChiAbility stance = bPlayer.getStance();
 		if (stance != null) {
-			stance.remove();
 			if (stance instanceof AcrobatStance) {
-				bPlayer.setStance(null);
-				GeneralMethods.displayMovePreview(player, this);
-				player.playSound(player.getLocation(), Sound.ENTITY_ENDERDRAGON_SHOOT, 0.5F, 2F);
+				remove();
 				return;
 			}
 		}
@@ -57,6 +54,16 @@ public class AcrobatStance extends ChiAbility {
 		if (!player.hasPotionEffect(PotionEffectType.JUMP)) {
 			player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 60, jump, true));
 		}
+	}
+	
+	@Override
+	public void remove() {
+		super.remove();
+		bPlayer.setStance(null);
+		GeneralMethods.displayMovePreview(player, this);
+		player.playSound(player.getLocation(), Sound.ENTITY_ENDERDRAGON_SHOOT, 0.5F, 2F);
+		player.removePotionEffect(PotionEffectType.SPEED);
+		player.removePotionEffect(PotionEffectType.JUMP);
 	}
 	
 	@Override

--- a/src/com/projectkorra/projectkorra/chiblocking/WarriorStance.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/WarriorStance.java
@@ -25,11 +25,8 @@ public class WarriorStance extends ChiAbility {
 		
 		ChiAbility stance = bPlayer.getStance();
 		if (stance != null) {
-			stance.remove();
 			if (stance instanceof WarriorStance) {
-				bPlayer.setStance(null);
-				GeneralMethods.displayMovePreview(player, this);
-				player.playSound(player.getLocation(), Sound.ENTITY_ENDERDRAGON_SHOOT, 0.5F, 2F);
+				remove();
 				return;
 			}
 		}
@@ -52,6 +49,16 @@ public class WarriorStance extends ChiAbility {
 		if (!player.hasPotionEffect(PotionEffectType.INCREASE_DAMAGE)) {
 			player.addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, 60, strength, true));
 		}
+	}
+	
+	@Override
+	public void remove() {
+		super.remove();
+		bPlayer.setStance(null);
+		GeneralMethods.displayMovePreview(player, this);
+		player.playSound(player.getLocation(), Sound.ENTITY_ENDERDRAGON_SHOOT, 0.5F, 2F);
+		player.removePotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
+		player.removePotionEffect(PotionEffectType.INCREASE_DAMAGE);
 	}
 	
 	@Override

--- a/src/com/projectkorra/projectkorra/util/logging/LogFilter.java
+++ b/src/com/projectkorra/projectkorra/util/logging/LogFilter.java
@@ -59,7 +59,7 @@ public class LogFilter implements Filter {
 			return false;
 		}
 		
-		if(Bukkit.getServer().getPluginManager().isPluginEnabled(ProjectKorra.plugin.getName())) {
+		if (!Bukkit.getServer().getPluginManager().isPluginEnabled(ProjectKorra.plugin.getName())) {
 			return false;
 		}
 


### PR DESCRIPTION
Flight

* Fixed users being able to move around while hovering when they sprint.

____________

Acrobat & Warrior Stance

* When paralyzed, the effects from either stance would be removed, but move preview and sounds wouldn't update.
    * Disable effects now play on remove().
* When remove() is called, it now removes the potion effects so they don't remain for a few seconds.

____________

LogFilter

* Added a '!' to line 62

____________