### PR TITLE
Call the final damage event

### DIFF
--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -58,6 +58,7 @@ public class DamageHandler {
 				}
 				
 				EntityDamageByEntityEvent finalEvent = new EntityDamageByEntityEvent(source, entity, cause, damage);
+				Bukkit.getServer().getPluginManager().callEvent(finalEvent);
 				if (!finalEvent.isCancelled()) {
 					damage = finalEvent.getDamage();
 					((LivingEntity) entity).damage(damage, source);


### PR DESCRIPTION
I'm assuming this was a typo? 

As an aside (and also why I found this), I'm currently working on a "NoKnockback" feature in my plugin, but trying to avoid canceling knockback due to bending abilities. Also, it seems that Entity.damage(damage, source) will call its own EntityDamageByEntity event, as if the player melee'd the entity (with `ENTITY_ATTACK` as the cause, etc.). Not sure if this is avoidable, but at least if you either call this custom damage event or if I hook into ProjectKorra and watch the other event, I can have it ignore other damage events within that tick for that player I suppose.