### PR TITLE
Only fire an entitydamageevent with a CUSTOM cause

### DIFF
--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -52,10 +52,7 @@ public class DamageHandler {
 					Bukkit.getServer().getPluginManager().callEvent(event);
 				}
 				
-				DamageCause cause = DamageCause.CUSTOM;
-				if (ignoreArmor) {
-					cause = DamageCause.MAGIC;
-				}
+				DamageCause cause = DamageCause.CUSTOM;							
 				
 				EntityDamageByEntityEvent finalEvent = new EntityDamageByEntityEvent(source, entity, cause, damage);
 				Bukkit.getServer().getPluginManager().callEvent(finalEvent);


### PR DESCRIPTION
Otherwise, plugins will be tricked into believing an entity was damaged (twice), since calling entity#damage also fires a damage event... or perhaps this event shouldn't be called at all, because entity#damage makes a call anyways...

I'm not sure which is the best way to go about this; even for my needs, if I need to hook into PK to do what I want regarding knockback detection, I'd probably do that instead of messing around calling extra bukkit damage events.

If the idea is to set the `setLastDamageCause`, I guess you could listen and see if the damage event called with `entity#damage` is successful (or check entity's health after applying damage... if using entity#damage actually damages the entity in the same tick)...

~~Unrelated, I also wonder if this accounts for any damage reduction... https://github.com/ProjectKorra/ProjectKorra/pull/639/files#diff-c99d6dae7ef4217c6a24860b1abdff27R50~~ Looking at the handler, doesn't seem to matter, nevermind.
