### PR TITLE
Bug fixes

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -258,7 +258,7 @@ public class AirSwipe extends AirAbility {
 	}
 
 	public void progress() {
-		if (!bPlayer.canBendIgnoreCooldowns(this)) {
+		if (!bPlayer.canBendIgnoreBindsCooldowns(this)) {
 			remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -631,7 +631,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.IceBlast.Damage", 3);
 			config.addDefault("Abilities.Water.IceBlast.Range", 20);
 			config.addDefault("Abilities.Water.IceBlast.DeflectRange", 3);
-			config.addDefault("Abilities.Water.IceBlast.CollisionRadius", 2);
+			config.addDefault("Abilities.Water.IceBlast.CollisionRadius", 1.5);
 			config.addDefault("Abilities.Water.IceBlast.Interval", 20);
 			config.addDefault("Abilities.Water.IceBlast.Cooldown", 1500);
 
@@ -651,7 +651,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.IceSpike.Field.Cooldown", 2000);
 			config.addDefault("Abilities.Water.IceSpike.Blast.Range", 20);
 			config.addDefault("Abilities.Water.IceSpike.Blast.Damage", 1);
-			config.addDefault("Abilities.Water.IceSpike.Blast.CollisionRadius", 2);
+			config.addDefault("Abilities.Water.IceSpike.Blast.CollisionRadius", 1.5);
 			config.addDefault("Abilities.Water.IceSpike.Blast.DeflectRange", 3);
 			config.addDefault("Abilities.Water.IceSpike.Blast.Cooldown", 500);
 			config.addDefault("Abilities.Water.IceSpike.Blast.SlowCooldown", 5000);
@@ -776,7 +776,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.WaterManipulation.Damage", 3.0);
 			config.addDefault("Abilities.Water.WaterManipulation.Range", 25);
 			config.addDefault("Abilities.Water.WaterManipulation.SelectRange", 16);
-			config.addDefault("Abilities.Water.WaterManipulation.CollisionRadius", 2);
+			config.addDefault("Abilities.Water.WaterManipulation.CollisionRadius", 1.5);
 			config.addDefault("Abilities.Water.WaterManipulation.DeflectRange", 3);
 			config.addDefault("Abilities.Water.WaterManipulation.Speed", 35);
 			config.addDefault("Abilities.Water.WaterManipulation.Push", 0.3);
@@ -845,7 +845,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthBlast.Push", 0.3);
 			config.addDefault("Abilities.Earth.EarthBlast.Cooldown", 500);
 			config.addDefault("Abilities.Earth.EarthBlast.DeflectRange", 3);
-			config.addDefault("Abilities.Earth.EarthBlast.CollisionRadius", 2);
+			config.addDefault("Abilities.Earth.EarthBlast.CollisionRadius", 1.5);
 
 			config.addDefault("Abilities.Earth.EarthGrab.Enabled", true);
 			config.addDefault("Abilities.Earth.EarthGrab.SelectRange", 20);
@@ -975,7 +975,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.FireBlast.Enabled", true);
 			config.addDefault("Abilities.Fire.FireBlast.Speed", 20);
 			config.addDefault("Abilities.Fire.FireBlast.Range", 20);
-			config.addDefault("Abilities.Fire.FireBlast.CollisionRadius", 2);
+			config.addDefault("Abilities.Fire.FireBlast.CollisionRadius", 1.5);
 			config.addDefault("Abilities.Fire.FireBlast.Push", 0.3);
 			config.addDefault("Abilities.Fire.FireBlast.Damage", 3);
 			config.addDefault("Abilities.Fire.FireBlast.Cooldown", 1500);
@@ -984,7 +984,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.FireBlast.SmokeParticleRadius", 0.3);
 			config.addDefault("Abilities.Fire.FireBlast.FlameParticleRadius", 0.275);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.ChargeTime", 3000);
-			config.addDefault("Abilities.Fire.FireBlast.Charged.CollisionRadius", 3);
+			config.addDefault("Abilities.Fire.FireBlast.Charged.CollisionRadius", 2);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.Damage", 4);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.DamageRadius", 4);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.DamageBlocks", true);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -631,7 +631,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.IceBlast.Damage", 3);
 			config.addDefault("Abilities.Water.IceBlast.Range", 20);
 			config.addDefault("Abilities.Water.IceBlast.DeflectRange", 3);
-			config.addDefault("Abilities.Water.IceBlast.CollisionRadius", 0.5);
+			config.addDefault("Abilities.Water.IceBlast.CollisionRadius", 2);
 			config.addDefault("Abilities.Water.IceBlast.Interval", 20);
 			config.addDefault("Abilities.Water.IceBlast.Cooldown", 1500);
 
@@ -651,7 +651,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.IceSpike.Field.Cooldown", 2000);
 			config.addDefault("Abilities.Water.IceSpike.Blast.Range", 20);
 			config.addDefault("Abilities.Water.IceSpike.Blast.Damage", 1);
-			config.addDefault("Abilities.Water.IceSpike.Blast.CollisionRadius", 0.5);
+			config.addDefault("Abilities.Water.IceSpike.Blast.CollisionRadius", 2);
 			config.addDefault("Abilities.Water.IceSpike.Blast.DeflectRange", 3);
 			config.addDefault("Abilities.Water.IceSpike.Blast.Cooldown", 500);
 			config.addDefault("Abilities.Water.IceSpike.Blast.SlowCooldown", 5000);
@@ -776,7 +776,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.WaterManipulation.Damage", 3.0);
 			config.addDefault("Abilities.Water.WaterManipulation.Range", 25);
 			config.addDefault("Abilities.Water.WaterManipulation.SelectRange", 16);
-			config.addDefault("Abilities.Water.WaterManipulation.CollisionRadius", 0.5);
+			config.addDefault("Abilities.Water.WaterManipulation.CollisionRadius", 2);
 			config.addDefault("Abilities.Water.WaterManipulation.DeflectRange", 3);
 			config.addDefault("Abilities.Water.WaterManipulation.Speed", 35);
 			config.addDefault("Abilities.Water.WaterManipulation.Push", 0.3);
@@ -845,7 +845,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthBlast.Push", 0.3);
 			config.addDefault("Abilities.Earth.EarthBlast.Cooldown", 500);
 			config.addDefault("Abilities.Earth.EarthBlast.DeflectRange", 3);
-			config.addDefault("Abilities.Earth.EarthBlast.CollisionRadius", 0.5);
+			config.addDefault("Abilities.Earth.EarthBlast.CollisionRadius", 2);
 
 			config.addDefault("Abilities.Earth.EarthGrab.Enabled", true);
 			config.addDefault("Abilities.Earth.EarthGrab.SelectRange", 20);
@@ -975,7 +975,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.FireBlast.Enabled", true);
 			config.addDefault("Abilities.Fire.FireBlast.Speed", 20);
 			config.addDefault("Abilities.Fire.FireBlast.Range", 20);
-			config.addDefault("Abilities.Fire.FireBlast.CollisionRadius", 0.5);
+			config.addDefault("Abilities.Fire.FireBlast.CollisionRadius", 2);
 			config.addDefault("Abilities.Fire.FireBlast.Push", 0.3);
 			config.addDefault("Abilities.Fire.FireBlast.Damage", 3);
 			config.addDefault("Abilities.Fire.FireBlast.Cooldown", 1500);
@@ -984,7 +984,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.FireBlast.SmokeParticleRadius", 0.3);
 			config.addDefault("Abilities.Fire.FireBlast.FlameParticleRadius", 0.275);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.ChargeTime", 3000);
-			config.addDefault("Abilities.Fire.FireBlast.Charged.CollisionRadius", 2);
+			config.addDefault("Abilities.Fire.FireBlast.Charged.CollisionRadius", 3);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.Damage", 4);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.DamageRadius", 4);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.DamageBlocks", true);

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -158,7 +158,7 @@ public class FireBlast extends FireAbility {
 
 	@Override
 	public void progress() {
-		if (!bPlayer.canBendIgnoreCooldowns(this)
+		if (!bPlayer.canBendIgnoreBindsCooldowns(this)
 				|| GeneralMethods.isRegionProtectedFromBuild(this, location)) {
 			remove();
 			return;

--- a/src/com/projectkorra/projectkorra/waterbending/HealingWaters.java
+++ b/src/com/projectkorra/projectkorra/waterbending/HealingWaters.java
@@ -208,7 +208,7 @@ public class HealingWaters extends HealingAbility {
 	
 	private void applyHealing(LivingEntity livingEntity) {
 		if (livingEntity.getHealth() < livingEntity.getMaxHealth()) {
-			livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, duration, 1));
+			livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, duration, power));
 			AirAbility.breakBreathbendingHold(livingEntity);
 			healing = true;
 			healingSelf = false;


### PR DESCRIPTION
ConfigManager

* For all abilities with a `CollisionRadius` config option, it can been increased from 0.5 to 1.5.
    * This fixes problems with abilities passing straight through people & the collision not being registered.
        * https://trello.com/c/Vdq6uDwY/595-increase-collisionradius-config-option

_____________

FireBlast & AirSwipe

* Changed `canBendIgnoreCooldowns` in progress to `canBendIgnoreBindsCooldowns`. 
    * This prevents the ability instance being removed when a player switches slot, even if the blast/swipe is still progressing.
        * https://trello.com/c/kEtRcIFY/574-fireblast-and-airswipe-are-removed-if-you-go-off-the-slot-in-the-latest-core-version

_____________

HealingWaters

* `Power` config option is now applied when healing other users.
    * https://trello.com/c/aLywvQTe/597-fix-healingwaters-not-giving-appropriate-power-level-when-healing-others

_____________