### PR TITLE
Added option for Torrent revert & fixed Bloodbending NPE

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -715,6 +715,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.Torrent.Wave.GrowSpeed", 0.5);
 			config.addDefault("Abilities.Water.Torrent.Wave.Interval", 30);
 			config.addDefault("Abilities.Water.Torrent.Wave.Cooldown", 0);
+			config.addDefault("Abilities.Water.Torrent.Wave.Revert", true);
+			config.addDefault("Abilities.Water.Torrent.Wave.RevertTime", 60000);
 
 			config.addDefault("Abilities.Water.Plantbending.RegrowTime", 180000);
 

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -709,14 +709,14 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.Torrent.MaxUpwardForce", 0.2);
 			config.addDefault("Abilities.Water.Torrent.Interval", 30);
 			config.addDefault("Abilities.Water.Torrent.Cooldown", 0);
+			config.addDefault("Abilities.Water.Torrent.Revert", true);
+			config.addDefault("Abilities.Water.Torrent.RevertTime", 60000);
 			config.addDefault("Abilities.Water.Torrent.Wave.Radius", 12);
 			config.addDefault("Abilities.Water.Torrent.Wave.Knockback", 1.5);
 			config.addDefault("Abilities.Water.Torrent.Wave.Height", 1);
 			config.addDefault("Abilities.Water.Torrent.Wave.GrowSpeed", 0.5);
 			config.addDefault("Abilities.Water.Torrent.Wave.Interval", 30);
 			config.addDefault("Abilities.Water.Torrent.Wave.Cooldown", 0);
-			config.addDefault("Abilities.Water.Torrent.Wave.Revert", true);
-			config.addDefault("Abilities.Water.Torrent.Wave.RevertTime", 60000);
 
 			config.addDefault("Abilities.Water.Plantbending.RegrowTime", 180000);
 

--- a/src/com/projectkorra/projectkorra/waterbending/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Bloodbending.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Creature;
@@ -88,7 +89,7 @@ public class Bloodbending extends BloodAbility {
 		} else {
 			//Location location = GeneralMethods.getTargetedLocation(player, 6, getTransparentMaterial());
 			//List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(location, 1.5);
-			List<Entity> entities = new ArrayList<Entity>();
+			List<Entity> entities = new CopyOnWriteArrayList<Entity>();
 			for (int i = 0; i < range; i++) {
 				Location location = GeneralMethods.getTargetedLocation(player, i, getTransparentMaterial());
 				entities = GeneralMethods.getEntitiesAroundPoint(location, 1.7);


### PR DESCRIPTION
Torrent

* Added `Revert` config option. Set to false to disable reverting.
* Added `RevertTime` config option. Set to the delay in milliseconds for reverting Torrent ice. Only works if `Revert` is set to true.

https://trello.com/c/CcTB1Fuq/582-torrent-s-ice-revert-doesn-t-work-ice-stays-forever

_________________

Bloodbending

* Fixed `ConcurrentModificationException`

https://trello.com/c/vLLl8d3m/579-bloodbending-error

_________________