### PR TITLE
Fix Error with /b bind, added Torrent ice revert effect

### DIFF
--- a/src/com/projectkorra/projectkorra/command/BindCommand.java
+++ b/src/com/projectkorra/projectkorra/command/BindCommand.java
@@ -60,7 +60,11 @@ public class BindCommand extends PKCommand {
 
 		// bending bind [ability] [#]
 		if (args.size() == 2) {
-			bind(sender, args.get(0), Integer.parseInt(args.get(1)));
+			try {
+				bind(sender, args.get(0), Integer.parseInt(args.get(1)));
+			} catch (NumberFormatException ex) {
+				sender.sendMessage(ChatColor.RED + wrongNumber);
+			}
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -120,7 +120,7 @@ public class Torrent extends WaterAbility {
 			if (isTransparent(player, block) && block.getType() != Material.ICE) {
 				TempBlock tblock = new TempBlock(block, Material.ICE, (byte) 0);
 				FROZEN_BLOCKS.put(tblock, player);
-				FROZEN_BLOCKS_DELAY.put(tblock, System.currentTimeMillis());
+				FROZEN_BLOCKS_DELAY.put(tblock, System.currentTimeMillis() + (new Random().nextInt((500 + 500) + 1) - 500));
 				playIcebendingSound(block.getLocation());
 			}
 		}


### PR DESCRIPTION
BindCommand

* Fixed error when specifying a slot which is not an integer.
    * Eg. /b b FireBlast t4geg
    * https://trello.com/c/bJOuadPV/602-when-binding-an-ability-if-you-do-not-specify-an-integer-for-the-3rd-argument-it-gives-this-error-eg-b-b-fireblast-test

__________

Torrent

* Added variation to the revert times to play an effect  like WaterArms' ice revert.

__________