### PR TITLE
use a damage event only for setting last damage cause

### DIFF
--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -58,13 +58,9 @@ public class DamageHandler {
 				}
 				
 				EntityDamageByEntityEvent finalEvent = new EntityDamageByEntityEvent(source, entity, cause, damage);
-				Bukkit.getServer().getPluginManager().callEvent(finalEvent);
-				if (!finalEvent.isCancelled()) {
-					damage = finalEvent.getDamage();
-					((LivingEntity) entity).damage(damage, source);
-					entity.setLastDamageCause(finalEvent);
-				}
-				
+				((LivingEntity) entity).damage(damage, source);
+				entity.setLastDamageCause(finalEvent);
+								
 				if (Bukkit.getPluginManager().isPluginEnabled("NoCheatPlus") && source != null) {
 					NCPExemptionManager.unexempt(source);
 				}


### PR DESCRIPTION
Firing this tricks other plugins into believing this entity was damaged.

In addition, Entity#damage also fires a damage event (and as such, applies the appropriate damage changes), so no need to fire a fake, duplicate one.

It doesn't seem `getLastDamageCause` is used anywhere in ProjectKorra, so I imagine this is for death message plugins.