### PR TITLE
Various Fixes

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -896,7 +896,7 @@ public class PKListener implements Listener {
 				if (sourceBPlayer.canBendPassive(Element.CHI)) {
 					if (e.getCause() == DamageCause.ENTITY_ATTACK && e.getDamage() == 1) {
 						if (sourceBPlayer.getBoundAbility() instanceof ChiAbility) {
-							if (GeneralMethods.isWeapon(sourcePlayer.getInventory().getItemInMainHand().getType())
+							if (sourceBPlayer.getBoundAbility() != null && sourcePlayer.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(sourcePlayer.getInventory().getItemInMainHand().getType())
 									&& !plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
 								return;
 							}
@@ -921,7 +921,7 @@ public class PKListener implements Listener {
 					}
 				}
 				if (sourceBPlayer.canBendPassive(Element.CHI)) {
-					if (GeneralMethods.isWeapon(sourcePlayer.getInventory().getItemInMainHand().getType())
+					if (sourcePlayer.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(sourcePlayer.getInventory().getItemInMainHand().getType())
 							&& !ProjectKorra.plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
 						return;
 					}
@@ -1025,7 +1025,7 @@ public class PKListener implements Listener {
 			}.runTaskLater(plugin, 5);
 
 			if (event.getHand() == EquipmentSlot.HAND) {
-				if (!GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
+				if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && !GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
 					if (event.getClickedBlock() != null) {
 						ComboManager.addComboAbility(player, ClickType.RIGHT_CLICK_BLOCK);
 					} else {
@@ -1053,7 +1053,7 @@ public class PKListener implements Listener {
 		Player player = event.getPlayer();
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 		
-		if (!GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
+		if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && !GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
 			ComboManager.addComboAbility(player, ClickType.RIGHT_CLICK_ENTITY);
 		}
 
@@ -1263,7 +1263,7 @@ public class PKListener implements Listener {
 			return;
 		}
 		
-		if (!GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
+		if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && !GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
 			if (player.isSneaking()) {
 				ComboManager.addComboAbility(player, ClickType.SHIFT_UP);
 			} else {
@@ -1308,7 +1308,7 @@ public class PKListener implements Listener {
 				return;
 			}
 			if (coreAbil instanceof AirAbility && bPlayer.isElementToggled(Element.AIR) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Air.CanBendWithWeapons")) {
 					return;
 				}
@@ -1335,7 +1335,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof WaterAbility && bPlayer.isElementToggled(Element.WATER) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Water.CanBendWithWeapons")) {
 					return;
 				}
@@ -1369,7 +1369,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof EarthAbility && bPlayer.isElementToggled(Element.EARTH) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Earth.CanBendWithWeapons")) {
 					return;
 				}
@@ -1410,7 +1410,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof FireAbility && bPlayer.isElementToggled(Element.FIRE) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Fire.CanBendWithWeapons")) {
 					return;
 				}
@@ -1467,7 +1467,7 @@ public class PKListener implements Listener {
 
 		Entity target = GeneralMethods.getTargetedEntity(player, 3);
 		
-		if(!GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
+		if(bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && !GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType()) && GeneralMethods.getElementsWithNoWeaponBending().contains(bPlayer.getBoundAbility().getElement())) {
 			if (target != null && !(target.equals(player)) && target instanceof LivingEntity) {
 				ComboManager.addComboAbility(player, ClickType.LEFT_CLICK_ENTITY);
 
@@ -1506,7 +1506,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof AirAbility && bPlayer.isElementToggled(Element.AIR) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Air.CanBendWithWeapons")) {
 					return;
 				}
@@ -1539,7 +1539,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof WaterAbility && bPlayer.isElementToggled(Element.WATER) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Water.CanBendWithWeapons")) {
 					return;
 				}
@@ -1572,7 +1572,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof EarthAbility && bPlayer.isElementToggled(Element.EARTH) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Earth.CanBendWithWeapons")) {
 					return;
 				}
@@ -1620,7 +1620,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof FireAbility && bPlayer.isElementToggled(Element.FIRE) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Fire.CanBendWithWeapons")) {
 					return;
 				}
@@ -1651,7 +1651,7 @@ public class PKListener implements Listener {
 			}
 
 			if (coreAbil instanceof ChiAbility && bPlayer.isElementToggled(Element.CHI) == true) {
-				if (GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
+				if (bPlayer.getBoundAbility() != null && player.getInventory().getItemInMainHand() != null && GeneralMethods.isWeapon(player.getInventory().getItemInMainHand().getType())
 						&& !plugin.getConfig().getBoolean("Properties.Chi.CanBendWithWeapons")) {
 					return;
 				}

--- a/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -137,7 +137,7 @@ public class HeatControl extends FireAbility {
 			this.solidifyMaxRadius = getConfig().getDouble("Abilities.Fire.HeatControl.Solidify.MaxRadius");
 			this.solidifyRange = getConfig().getDouble("Abilities.Fire.HeatControl.Solidify.Range");
 			this.solidifyRevert = getConfig().getBoolean("Abilities.Fire.HeatControl.Solidify.Revert");
-			this.solidifyRevertTime = getConfig().getLong("Abilities.Fire.HeatControl.Solidify.RevertTime");
+			this.solidifyRevertTime = 10000;//getConfig().getLong("Abilities.Fire.HeatControl.Solidify.RevertTime");
 			this.randy = new Random();
 		}
 	}

--- a/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -137,7 +137,7 @@ public class HeatControl extends FireAbility {
 			this.solidifyMaxRadius = getConfig().getDouble("Abilities.Fire.HeatControl.Solidify.MaxRadius");
 			this.solidifyRange = getConfig().getDouble("Abilities.Fire.HeatControl.Solidify.Range");
 			this.solidifyRevert = getConfig().getBoolean("Abilities.Fire.HeatControl.Solidify.Revert");
-			this.solidifyRevertTime = 10000;//getConfig().getLong("Abilities.Fire.HeatControl.Solidify.RevertTime");
+			this.solidifyRevertTime = getConfig().getLong("Abilities.Fire.HeatControl.Solidify.RevertTime");
 			this.randy = new Random();
 		}
 	}

--- a/src/com/projectkorra/projectkorra/util/BlockSource.java
+++ b/src/com/projectkorra/projectkorra/util/BlockSource.java
@@ -7,6 +7,7 @@ import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
@@ -36,7 +37,7 @@ public class BlockSource {
 	private static FileConfiguration config = ConfigManager.defaultConfig.get();
 	// The player should never need to grab source blocks from farther than this.
 	private static double MAX_RANGE = config.getDouble("Abilities.Water.WaterManipulation.SelectRange");
-	private static boolean tempblock = config.getBoolean("Properties.Water.CanBendFromBentBlocks");
+	//private static boolean tempblock = config.getBoolean("Properties.Water.CanBendFromBentBlocks");
 
 	/**
 	 * Updates all of the player's sources.
@@ -57,7 +58,7 @@ public class BlockSource {
 		
 		if (coreAbil instanceof WaterAbility) {
 			Block waterBlock = WaterAbility.getWaterSourceBlock(player, MAX_RANGE, true);
-			if (waterBlock != null) {
+			if (waterBlock != null && !TempBlock.isTempBlock(waterBlock)) {
 				putSource(player, waterBlock, BlockSourceType.WATER, clickType);
 				if (WaterAbility.isPlant(waterBlock)) {
 					putSource(player, waterBlock, BlockSourceType.PLANT, clickType);
@@ -260,10 +261,10 @@ public class BlockSource {
 		if (allowSnow && sourceBlock == null) {
 			sourceBlock = getSourceBlock(player, range, BlockSourceType.SNOW, clickType);
 		}
-		if(sourceBlock != null && TempBlock.isTempBlock(sourceBlock) && !tempblock) {
-			return null;
+		if(sourceBlock != null && !sourceBlock.getType().equals(Material.AIR) && (WaterAbility.isWater(sourceBlock) || WaterAbility.isPlant(sourceBlock) || WaterAbility.isSnow(sourceBlock) || WaterAbility.isIce(sourceBlock)) && !TempBlock.isTempBlock(sourceBlock)) {
+			return sourceBlock;
 		}
-		return sourceBlock;
+		return null;
 	}
 
 	/**

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -82,6 +82,9 @@ public class TempBlock {
 		for (Block block : instances.keySet()) {
 			revertBlock(block, Material.AIR);
 		}
+		for (TempBlock tempblock : REVERT_QUEUE) {
+			tempblock.revertBlock();
+		}
 	}
 
 	public static void removeBlock(Block block) {

--- a/src/com/projectkorra/projectkorra/waterbending/PhaseChange.java
+++ b/src/com/projectkorra/projectkorra/waterbending/PhaseChange.java
@@ -419,9 +419,12 @@ public class PhaseChange extends IceAbility {
 			Player p = PLAYER_BY_BLOCK.get(tb);
 			PhaseChange pc = getAbility(p, PhaseChange.class);
 			PLAYER_BY_BLOCK.remove(tb);
-			pc.getFrozenBlocks().remove(tb);
-			tb.revertBlock();
-			return true;
+			if (pc.getFrozenBlocks() != null) {
+				pc.getFrozenBlocks().remove(tb);
+				tb.revertBlock();
+				return true;
+			}
+			return false;
 		}
 	}
 	

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -345,7 +345,6 @@ public class WaterManipulation extends WaterAbility {
 		}
 	}
 
-	@SuppressWarnings("deprecation")
 	private static void addWater(Block block) {
 		if (!isWater(block)) {
 			if (!AFFECTED_BLOCKS.containsKey(block)) {
@@ -354,8 +353,7 @@ public class WaterManipulation extends WaterAbility {
 			if (PhaseChange.getFrozenBlocksAsBlock().contains(block)) {
 				PhaseChange.getFrozenBlocksAsBlock().remove(block);
 			}
-			block.setType(Material.STATIONARY_WATER);
-			block.setData((byte) 0);
+			new TempBlock(block, Material.WATER, (byte)0);
 		} else {
 			if (isWater(block) && !AFFECTED_BLOCKS.containsKey(block)) {
 				ParticleEffect.WATER_BUBBLE.display((float) Math.random(), (float) Math.random(), (float) Math.random(), 0f,


### PR DESCRIPTION
Fixes `WaterManipulation` being able to select `TempBlocks` as a source.
`HeatControl` will no longer leave overridden perm stone or cobblestone. These now revert correctly on revert / after a revert time.
Fixes `NPE` in `PKListener`.
Fixes `NPE` in `PhaseChange`.