### PR TITLE
Added Cooldown & MaxDuration to Flight

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirFlight.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirFlight.java
@@ -19,11 +19,13 @@ public class AirFlight extends FlightAbility {
 	private static final Map<String, Integer> HITS = new ConcurrentHashMap<>();
 	private static final Map<String, PlayerFlyData> HOVERING = new ConcurrentHashMap<>();
 	
+	private long cooldown;
 	private boolean firstProgressIteration;
 	private int maxHitsBeforeRemoval;
 	private double speed;
 	private Flight flight;
 	private double hoverY;
+	private double maxDuration;
 
 	public AirFlight(Player player) {
 		super(player);
@@ -31,8 +33,10 @@ public class AirFlight extends FlightAbility {
 		if (CoreAbility.getAbility(player, AirFlight.class) != null)
 			return;
 			
+		this.cooldown = getConfig().getInt("Abilities.Air.Flight.Cooldown");
 		this.maxHitsBeforeRemoval = getConfig().getInt("Abilities.Air.Flight.MaxHits");
 		this.speed = getConfig().getDouble("Abilities.Air.Flight.Speed");
+		this.maxDuration = getConfig().getDouble("Abilities.Air.Flight.MaxDuration");
 		this.firstProgressIteration = true;
 		hoverY = player.getLocation().getBlockY();
 		start();
@@ -106,6 +110,10 @@ public class AirFlight extends FlightAbility {
 		} else if (player.getLocation().subtract(0, 0.5, 0).getBlock().getType() != Material.AIR) {
 			remove();
 			return;
+		} else if (System.currentTimeMillis() - getStartTime() > maxDuration && maxDuration > 0) {
+			bPlayer.addCooldown(this);
+			remove();
+			return;
 		}
 
 		player.setAllowFlight(true);
@@ -158,7 +166,7 @@ public class AirFlight extends FlightAbility {
 
 	@Override
 	public long getCooldown() {
-		return 0;
+		return cooldown;
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -612,8 +612,10 @@ public class ConfigManager {
 
 			config.addDefault("Abilities.Air.Flight.Enabled", true);
 			config.addDefault("Abilities.Air.Flight.HoverEnabled", true);
+			config.addDefault("Abilities.Air.Flight.Cooldown", 5000);
 			config.addDefault("Abilities.Air.Flight.Speed", 1);
 			config.addDefault("Abilities.Air.Flight.MaxHits", 4);
+			config.addDefault("Abilities.Air.Flight.MaxDuration", 0);
 
 			config.addDefault("Abilities.Air.Suffocate.Enabled", true);
 			config.addDefault("Abilities.Air.Suffocate.ChargeTime", 500);


### PR DESCRIPTION
https://trello.com/c/DO48r2co/669-add-maxduration-config-value-to-flight-to-limit-how-long-users-can-use-the-ability-for

https://trello.com/c/G8E1tv4V/670-add-cooldown-config-value-for-flight-if-maxduration-is-hit