### PR TITLE
Change block set order when moving earth

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -480,8 +480,6 @@ public abstract class EarthAbility extends ElementalAbility {
 		info.setTime(System.currentTimeMillis());
 		MOVED_EARTH.put(target, info);
 
-		source.setType(Material.AIR);
-
 		if (info.getState().getType() == Material.SAND) {
 			if (info.getState().getRawData() == (byte) 0x1) {
 				target.setType(Material.RED_SANDSTONE);
@@ -494,6 +492,8 @@ public abstract class EarthAbility extends ElementalAbility {
 			target.setType(info.getState().getType());
 			target.setData(info.getState().getRawData());
 		}
+		
+		source.setType(Material.AIR);
 	}
 
 	public static void playEarthbendingSound(Location loc) {


### PR DESCRIPTION
- Set the source block to air after setting the target block to the new
  type. This will eliminate temporary holes, which minimizes major lighting
  updates.

This fixes a vulnerability that allows players to create massive lag by using Collapse/Shockwave. Using either of these abilities on a single layer plane up in the air will cause massive lighting updates, freezing the entire server.