### PR TITLE
EarthTunnel - DropLootIfNotRevert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,11 @@ test/server/*.properties
 test/server/plugins/*/
 target/
 /dependency-reduced-pom.xml
+
+#################
+## IntelliJ Idea
+#################
+
+.idea/
+classes/
+projectkorra.iml

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1009,6 +1009,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthTunnel.Range", 10);
 			config.addDefault("Abilities.Earth.EarthTunnel.Radius", 0.25);
 			config.addDefault("Abilities.Earth.EarthTunnel.Revert", true);
+			config.addDefault("Abilities.Earth.EarthTunnel.DropLootIfNotRevert", false);
 			config.addDefault("Abilities.Earth.EarthTunnel.Interval", 30);
 
 			config.addDefault("Abilities.Earth.Extraction.Enabled", true);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
@@ -29,6 +29,7 @@ public class EarthTunnel extends EarthAbility {
 	private double range;
 	private double radiusIncrement;
 	private boolean revert;
+ 	private boolean dropLootIfNotRevert;
 	private Block block;
 	private Location origin;
 	private Location location;
@@ -44,6 +45,7 @@ public class EarthTunnel extends EarthAbility {
 		this.radius = getConfig().getDouble("Abilities.Earth.EarthTunnel.Radius");
 		this.interval = getConfig().getLong("Abilities.Earth.EarthTunnel.Interval");
 		this.revert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.Revert");
+		this.dropLootIfNotRevert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.DropLootIfNotRevert");
 		this.radiusIncrement = radius;
 		this.time = System.currentTimeMillis();
 
@@ -124,7 +126,11 @@ public class EarthTunnel extends EarthAbility {
 						}
 					}
 				} else {
-					block.setType(Material.AIR);
+					if (dropLootIfNotRevert) {
+						block.breakNaturally();
+					} else {
+						block.setType(Material.AIR);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Added the ability to choose whether or not EarthTunnel drops loot when revert for EarthTunnel is off. This commit also includes gitignores for IntellJ Idea.