### PR TITLE
Some NCP compatibility

### DIFF
--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -45,6 +45,10 @@ public class DamageHandler {
 				damage = damageEvent.getDamage();
 				if (Bukkit.getPluginManager().isPluginEnabled("NoCheatPlus") && source != null) {
 					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_REACH);
+					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_DIRECTION);
+					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_NOSWING);
+					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_SPEED);
+					NCPExemptionManager.exemptPermanently(source, CheckType.COMBINED_IMPROBABLE);
 				}
 
 				if (((LivingEntity) entity).getHealth() - damage <= 0 && !entity.isDead()) {


### PR DESCRIPTION
Closes #314, closes #320, closes #321

Exempts various PvP-related checks in NCP when an entity receives damage from a bending ability (since the way PK deals damage due to an ability is similar to melee attack instead of as a projectile):

- Direction: A player can use an ability (e.g. earthblast, watermanipulation) and then decide to look elsewhere (check fails as player isn't looking at entity being attacked).
- NoSwing: Especially evident on abilities that require no left-clicking (e.g. suffocation).
- Speed and Improbable: Usually for AoE attacks (e.g. fireburst, earthsmash) cause this, since the player can damage multiple entities around themself at the same time.