### PR TITLE
Update notification rooms for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ notifications:
   slack:
     rooms:
       - projectkorra:h9WFZqQ2o6fuCkI69ko28XgF#general
-      - projectkorra:h9WFZqQ2o6fuCkI69ko28XgF#development
+      - projectkorra:h9WFZqQ2o6fuCkI69ko28XgF#devs


### PR DESCRIPTION
Changed channel from #development which is now archived to #devs