### PR TITLE
Insert new players into database atomically

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -303,8 +303,9 @@ public class GeneralMethods {
 		ResultSet rs2 = DBConnection.sql.readQuery("SELECT * FROM pk_players WHERE uuid = '" + uuid.toString() + "'");
 		try {
 			if (!rs2.next()) { // Data doesn't exist, we want a completely new player.
+				DBConnection.sql.modifyQuery("INSERT INTO pk_players (uuid, player, slot1, slot2, slot3, slot4, slot5, slot6, slot7, slot8, slot9) VALUES ('" + 
+				    uuid.toString() + "', '" + player + "', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null')");
 				new BendingPlayer(uuid, player, new ArrayList<Element>(), new ArrayList<SubElement>(), new HashMap<Integer, String>(), false);
-				DBConnection.sql.modifyQuery("INSERT INTO pk_players (uuid, player) VALUES ('" + uuid.toString() + "', '" + player + "')");
 				ProjectKorra.log.info("Created new BendingPlayer for " + player);
 			} else {
 				// The player has at least played before.


### PR DESCRIPTION
Links to Appropriate Issue Reports Addressed in this Pull Request:
- https://trello.com/c/dP0WWu8t/781-elements-for-a-player-returning-null-in-the-database-causes-plugin-to-break

Abilities aren't allowed to be null because ConcurrentHashMaps are used everywhere, which throw an exception when a null value is added. The default insert would set the slots to null in the database. The only reason why new player abilities would be changed from null to 'null' in the database is because onPlayerJoin calls GeneralMethods.removeUnusableAbilities 5 ticks later. If a player would leave before that's called then their database values would be null instead of 'null', and it would cause ConcurrentHashMap to throw an exception.

Before this pull request, player insertion and all the set slot inserts would all be called asynchronously. It's possible for the set slots to occur before the player insert is run. This would result in a half initialized database row. I ran a test of logging in 20 clients at the same time and immediately disconnecting them. This is the result of the row's being inserted: http://i.imgur.com/RL5bgm8.png

After the pull request, player insertion includes setting the slots to 'null', so it's always fully initialized. I ran the same test as before and every row was fully initialized: http://i.imgur.com/A6aCRXG.png

This pull request doesn't address the design decision of using 'null' as null values in the database.