### PR TITLE
Fix collision manager bugs

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1618,6 +1618,8 @@ public class GeneralMethods {
 		Preset.loadExternalPresets();
 		new MultiAbilityManager();
 		new ComboManager();
+		// Stop the previous collision detection task before creating new manager.
+		ProjectKorra.collisionManager.stopCollisionDetection();
 		ProjectKorra.collisionManager = new CollisionManager();
 		ProjectKorra.collisionInitializer = new CollisionInitializer(ProjectKorra.collisionManager);
 		CoreAbility.registerAbilities();

--- a/src/com/projectkorra/projectkorra/ability/util/CollisionManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/CollisionManager.java
@@ -67,15 +67,20 @@ public class CollisionManager {
 	}
 
 	private void detectCollisions() {
-		List<CoreAbility> instances = new ArrayList<>();
+		int activeInstanceCount = 0;
+		
 		for (CoreAbility ability : CoreAbility.getAbilitiesByInstances()) {
 			if (!(ability instanceof PassiveAbility)) {
-				instances.add(ability);
+				if (++activeInstanceCount > 1) {
+					break;
+				}
 			}
 		}
-		if (instances.size() <= 1) {
+		
+		if (activeInstanceCount <= 1) {
 			return;
 		}
+		
 		HashMap<CoreAbility, List<Location>> locationsCache = new HashMap<>();
 
 		for (Collision collision : collisions) {
@@ -137,7 +142,7 @@ public class CollisionManager {
 							}
 
 							if (locationFirst.getWorld() != locationSecond.getWorld()) {
-								return;
+								continue;
 							}
 							double distSquared = locationFirst.distanceSquared(locationSecond);
 							if (distSquared <= requiredDistSquared) {


### PR DESCRIPTION
- Fix a bug where collision detection would be aborted if two abilities were in different worlds.
- Fix a bug where the old CollisionManager collision detection task wasn't aborted when creating a new manager.
- Improve performance by removing unnecessary work that's done before detecting collisions.

The detectCollisions method would return early if two abilities were in different worlds. This would cancel all collision detection for any other abilities that haven't been processed in the loop.

The CollisionManager would create new tasks every time the plugin is reloaded without stopping the previous one. This is both bad for performance and for addons that have configuration options for collisions.

The detectCollisions method was unnecessarily looping through all the active instances before detecting collisions. It only needs to know if any active instances exist, which can be done by early exiting after detecting two.