### PR TITLE
Fixed addon passive abilities

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -566,6 +566,10 @@ public abstract class CoreAbility implements Ability {
 					if (coreAbil.getElement() instanceof SubElement) {
 						PassiveManager.getPassivesByElement().get(((SubElement) coreAbil.getElement()).getParentElement()).add(name);
 					}
+					if (!PassiveManager.getPassiveClasses().containsKey(coreAbil)) {
+						PassiveManager.getPassiveClasses().put((PassiveAbility) coreAbil, coreAbil.getClass());
+					}
+					PassiveManager.getPassiveClasses().put((PassiveAbility) coreAbil, coreAbil.getClass());
 				}
 			}
 			catch (Exception | Error e) {
@@ -637,6 +641,9 @@ public abstract class CoreAbility implements Ability {
 					PassiveManager.getPassivesByElement().get(coreAbil.getElement()).add(name);
 					if (coreAbil.getElement() instanceof SubElement) {
 						PassiveManager.getPassivesByElement().get(((SubElement) coreAbil.getElement()).getParentElement()).add(name);
+					}
+					if (!PassiveManager.getPassiveClasses().containsKey(coreAbil)) {
+						PassiveManager.getPassiveClasses().put((PassiveAbility) coreAbil, coreAbil.getClass());
 					}
 				}
 			}

--- a/src/com/projectkorra/projectkorra/ability/util/PassiveManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/PassiveManager.java
@@ -19,6 +19,7 @@ public class PassiveManager {
 
 	private static final Map<String, CoreAbility> PASSIVES = new HashMap<>();
 	private static final Map<Element, Set<String>> PASSIVES_BY_ELEMENT = new HashMap<>(); // Parent elements INCLUDE subelement passives.
+	private static final Map<PassiveAbility, Class<? extends CoreAbility>> PASSIVE_CLASSES = new HashMap<>();
 
 	public static void registerPassives(Player player) {
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
@@ -40,28 +41,15 @@ public class PassiveManager {
 				} else if (!((PassiveAbility) ability).isInstantiable()) {
 					continue;
 				}
-				Class<?> clazz = null;
 				try {
-					clazz = Class.forName(ability.getClass().getName());
+					Class<? extends CoreAbility> clazz = PASSIVE_CLASSES.get((PassiveAbility) ability);
+					Constructor<?> constructor = clazz.getConstructor(Player.class);
+					Object object = constructor.newInstance(new Object[] { player });
+					((CoreAbility) object).start();
 				}
-				catch (ClassNotFoundException e) {
+				catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
 					e.printStackTrace();
 				}
-				Constructor<?> constructor = null;
-				try {
-					constructor = clazz.getConstructor(Player.class);
-				}
-				catch (NoSuchMethodException | SecurityException e) {
-					e.printStackTrace();
-				}
-				Object object = null;
-				try {
-					object = constructor.newInstance(new Object[] { player });
-				}
-				catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-					e.printStackTrace();
-				}
-				((CoreAbility) object).start();
 			}
 		}
 	}
@@ -106,6 +94,10 @@ public class PassiveManager {
 
 	public static Map<Element, Set<String>> getPassivesByElement() {
 		return PASSIVES_BY_ELEMENT;
+	}
+
+	public static Map<PassiveAbility, Class<? extends CoreAbility>> getPassiveClasses() {
+		return PASSIVE_CLASSES;
 	}
 
 }


### PR DESCRIPTION
Fixed Addon Passive abilities throwing an exception when registering the ability.
* `Class<?> clazz = Class.forName(ability.getClass().getName());` would not work with addons because it is an external jar file.
* Fixed by storing the ability classes in PassiveManager#PASSIVE_CLASSES, which is then pulled when registering the instance.