### PR TITLE
Fix WaterWave and WaterSpout behavior & DamageHandler error

### DIFF
--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -18,8 +18,10 @@ import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AvatarAbility;
 import com.projectkorra.projectkorra.ability.ChiAbility;
+import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
+import com.projectkorra.projectkorra.ability.PassiveAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.avatar.AvatarState;
 import com.projectkorra.projectkorra.chiblocking.Paralyze;
@@ -301,6 +303,8 @@ public class BendingPlayer {
 			return false;
 		} else if (!hasElement(ability.getElement()) && !(ability instanceof AvatarAbility && !((AvatarAbility) ability).requireAvatar())) {
 			return false;
+		} else if (ability instanceof ComboAbility || ability instanceof PassiveAbility) {
+			return false;
 		} else if (ability.getElement() instanceof SubElement) {
 			SubElement subElement = (SubElement) ability.getElement();
 			if (!hasElement(subElement.getParentElement())) {
@@ -315,6 +319,7 @@ public class BendingPlayer {
 					if (subElement.equals(SpiritElement.DARK) && sPlayer.isLightSpirit()) {
 						return false;
 					}
+					
 					if (subElement.equals(SpiritElement.LIGHT) && sPlayer.isDarkSpirit()) {
 						return false;
 					}

--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -18,10 +18,8 @@ import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AvatarAbility;
 import com.projectkorra.projectkorra.ability.ChiAbility;
-import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
-import com.projectkorra.projectkorra.ability.PassiveAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.avatar.AvatarState;
 import com.projectkorra.projectkorra.chiblocking.Paralyze;
@@ -198,7 +196,7 @@ public class BendingPlayer {
 			return false;
 		} else if (!ignoreCooldowns && isOnCooldown(ability.getName())) {
 			return false;
-		} else if (!ignoreBinds && !ability.getName().equals(getBoundAbilityName())) {
+		} else if (!ignoreBinds && (!ability.getName().equals(getBoundAbilityName()) && !ability.getName().contains(getBoundAbilityName()))) {
 			return false;
 		} else if (disabledWorlds != null && disabledWorlds.contains(player.getWorld().getName())) {
 			return false;
@@ -302,8 +300,6 @@ public class BendingPlayer {
 		} else if (!player.hasPermission("bending.ability." + ability.getName())) {
 			return false;
 		} else if (!hasElement(ability.getElement()) && !(ability instanceof AvatarAbility && !((AvatarAbility) ability).requireAvatar())) {
-			return false;
-		} else if (ability instanceof ComboAbility || ability instanceof PassiveAbility) {
 			return false;
 		} else if (ability.getElement() instanceof SubElement) {
 			SubElement subElement = (SubElement) ability.getElement();

--- a/src/com/projectkorra/projectkorra/command/BindCommand.java
+++ b/src/com/projectkorra/projectkorra/command/BindCommand.java
@@ -123,7 +123,7 @@ public class BindCommand extends PKCommand {
 		if (args.size() == 0) {
 			if (bPlayer != null) {
 				for (CoreAbility coreAbil : CoreAbility.getAbilities()) {
-					if (!coreAbil.isHiddenAbility() && bPlayer.canBind(coreAbil)) {
+					if (!coreAbil.isHiddenAbility() && bPlayer.canBind(coreAbil) && !(coreAbil instanceof CoreAbility && coreAbil instanceof ComboAbility)) {
 						abilities.add(coreAbil.getName());
 					}
 				}

--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -261,10 +261,8 @@ public class DisplayCommand extends PKCommand {
 		List<CoreAbility> abilities = CoreAbility.getAbilitiesByElement(element);
 
 		if (abilities.isEmpty()) {
-			sender.sendMessage(ChatColor.RED + invalidArgument);
-			return;
-		} else if (abilities.isEmpty()) {
 			sender.sendMessage(ChatColor.YELLOW + noAbilitiesAvailable.replace("{element}", element.getColor() + element.getName() + ChatColor.YELLOW));
+			return;
 		}
 
 		HashSet<String> abilitiesSent = new HashSet<String>(); //Some abilities have the same name. This prevents this from showing anything.

--- a/src/com/projectkorra/projectkorra/command/WhoCommand.java
+++ b/src/com/projectkorra/projectkorra/command/WhoCommand.java
@@ -196,7 +196,7 @@ public class WhoCommand extends PKCommand {
 
 		bPlayer = BendingPlayer.getBendingPlayer(player);
 		if (bPlayer != null) {
-			sender.sendMessage(ChatColor.BOLD + player.getName() + (!player.isOnline() ? ChatColor.RESET + " (Offline)" : ""));
+			sender.sendMessage(player.getName() + (!player.isOnline() ? ChatColor.RESET + " (Offline)" : ""));
 			if (bPlayer.hasElement(Element.AIR)) {
 				if (bPlayer.isElementToggled(Element.AIR)) {
 					sender.sendMessage(Element.AIR.getColor() + "- Airbender");

--- a/src/com/projectkorra/projectkorra/command/WhoCommand.java
+++ b/src/com/projectkorra/projectkorra/command/WhoCommand.java
@@ -196,7 +196,7 @@ public class WhoCommand extends PKCommand {
 
 		bPlayer = BendingPlayer.getBendingPlayer(player);
 		if (bPlayer != null) {
-			sender.sendMessage(player.getName() + (!player.isOnline() ? ChatColor.RESET + " (Offline)" : "") + " - ");
+			sender.sendMessage(ChatColor.BOLD + player.getName() + (!player.isOnline() ? ChatColor.RESET + " (Offline)" : ""));
 			if (bPlayer.hasElement(Element.AIR)) {
 				if (bPlayer.isElementToggled(Element.AIR)) {
 					sender.sendMessage(Element.AIR.getColor() + "- Airbender");
@@ -357,7 +357,7 @@ public class WhoCommand extends PKCommand {
 				sender.sendMessage(staff.get(uuid.toString()));
 			}
 			
-			if (player_.hasPermission("bending.donator")) {
+			if (player_.hasPermission("bending.donor")) {
 				// Requires Servers to define `server-name` in their server.properties file. Example: server-name=My Server
 				sender.sendMessage(Element.AVATAR.getColor() + ProjectKorra.plugin.getServer().getServerName() + " Donor");
 			}

--- a/src/com/projectkorra/projectkorra/earthbending/CollapseWall.java
+++ b/src/com/projectkorra/projectkorra/earthbending/CollapseWall.java
@@ -88,7 +88,7 @@ public class CollapseWall extends EarthAbility {
 
 	@Override
 	public String getName() {
-		return "Collapse";
+		return "CollapseWall";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/earthbending/CollapseWall.java
+++ b/src/com/projectkorra/projectkorra/earthbending/CollapseWall.java
@@ -114,6 +114,11 @@ public class CollapseWall extends EarthAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public int getSelectRange() {
 		return selectRange;

--- a/src/com/projectkorra/projectkorra/earthbending/RaiseEarthWall.java
+++ b/src/com/projectkorra/projectkorra/earthbending/RaiseEarthWall.java
@@ -144,6 +144,11 @@ public class RaiseEarthWall extends EarthAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public int getRange() {
 		return selectRange;

--- a/src/com/projectkorra/projectkorra/earthbending/RaiseEarthWall.java
+++ b/src/com/projectkorra/projectkorra/earthbending/RaiseEarthWall.java
@@ -118,7 +118,7 @@ public class RaiseEarthWall extends EarthAbility {
 
 	@Override
 	public String getName() {
-		return "RaiseEarth";
+		return "RaiseEarthWall";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/earthbending/Ripple.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Ripple.java
@@ -305,7 +305,7 @@ public class Ripple extends EarthAbility {
 
 	@Override
 	public String getName() {
-		return "Shockwave";
+		return "Ripple";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/earthbending/Ripple.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Ripple.java
@@ -327,6 +327,11 @@ public class Ripple extends EarthAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	@Override
 	public ArrayList<Location> getLocations() {

--- a/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
@@ -171,7 +171,7 @@ public class BlazeArc extends FireAbility {
 
 	@Override
 	public String getName() {
-		return "Blaze";
+		return "BlazeArc";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
@@ -196,6 +196,11 @@ public class BlazeArc extends FireAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public long getTime() {
 		return time;

--- a/src/com/projectkorra/projectkorra/firebending/BlazeRing.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeRing.java
@@ -52,7 +52,7 @@ public class BlazeRing extends FireAbility {
 
 	@Override
 	public String getName() {
-		return "Blaze";
+		return "BlazeRing";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/firebending/BlazeRing.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeRing.java
@@ -78,6 +78,11 @@ public class BlazeRing extends FireAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public int getRange() {
 		return range;

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -319,6 +319,11 @@ public class FireBlastCharged extends FireAbility {
 	}
 
 	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
+	
+	@Override
 	public boolean isCollidable() {
 		return this.launched;
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -295,7 +295,7 @@ public class FireBlastCharged extends FireAbility {
 
 	@Override
 	public String getName() {
-		return "FireBlast";
+		return "FireBlastCharged";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -63,7 +63,9 @@ public class DamageHandler {
 				((LivingEntity) entity).damage(damage, source);
 				entity.setLastDamageCause(finalEvent);
 				if (ignoreArmor) {
-					finalEvent.setDamage(DamageModifier.ARMOR, 0);
+				    if (finalEvent.isApplicable(DamageModifier.ARMOR)) {
+				        finalEvent.setDamage(DamageModifier.ARMOR, 0);
+				    }
 				}
 
 				if (Bukkit.getPluginManager().isPluginEnabled("NoCheatPlus") && source != null) {

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -218,7 +218,7 @@ public class SurgeWall extends WaterAbility {
 
 		if (System.currentTimeMillis() - time >= interval) {
 			time = System.currentTimeMillis();
-			boolean matchesName = bPlayer.getBoundAbilityName().equalsIgnoreCase(getName());
+			boolean matchesName = getName().contains(bPlayer.getBoundAbilityName());
 
 			if (!progressing && !matchesName) {
 				remove();
@@ -456,7 +456,7 @@ public class SurgeWall extends WaterAbility {
 
 	@Override
 	public String getName() {
-		return "Surge";
+		return "SurgeWall";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -483,6 +483,11 @@ public class SurgeWall extends WaterAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	@Override
 	public List<Location> getLocations() {

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -249,7 +249,7 @@ public class SurgeWave extends WaterAbility {
 
 		if (System.currentTimeMillis() - time >= interval) {
 			time = System.currentTimeMillis();
-			if (!progressing && !bPlayer.getBoundAbilityName().equalsIgnoreCase(getName())) {
+			if (!progressing && !bPlayer.getBoundAbilityName().contains(getName())) {
 				remove();
 				return;
 			} else if (!progressing) {

--- a/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
@@ -217,6 +217,11 @@ public class TorrentWave extends WaterAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	@Override
 	public List<Location> getLocations() {

--- a/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
@@ -195,7 +195,7 @@ public class TorrentWave extends WaterAbility {
 
 	@Override
 	public String getName() {
-		return "Torrent";
+		return "TorrentWave";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -131,12 +131,17 @@ public class WaterSpoutWave extends WaterAbility {
 			remove();
 			return;
 		}
+		
+		if (CoreAbility.hasAbility(player, WaterSpout.class)) {
+			WaterSpout waterSpout = CoreAbility.getAbility(player, WaterSpout.class);
+			waterSpout.remove();
+		}
 
 		if (type != AbilityType.RELEASE) {
 			if (!player.hasPermission("bending.ability.WaterSpout.Wave")) {
 				remove();
 				return;
-			} else if (!bPlayer.getBoundAbilityName().equalsIgnoreCase(getName())) {
+			} else if (!getName().contains(bPlayer.getBoundAbilityName())) {
 				remove();
 				return;
 			}
@@ -484,7 +489,7 @@ public class WaterSpoutWave extends WaterAbility {
 
 	@Override
 	public String getName() {
-		return "WaterSpout";
+		return "WaterSpoutWave";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -506,6 +506,11 @@ public class WaterSpoutWave extends WaterAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	@Override
 	public boolean isCollidable() {

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -438,6 +438,11 @@ public class IceSpikeBlast extends IceAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	@Override
 	public boolean isCollidable() {

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -140,7 +140,7 @@ public class IceSpikeBlast extends IceAbility {
 				remove();
 			}
 			return;
-		} else if (!bPlayer.getBoundAbilityName().equals(getName()) && prepared) {
+		} else if (!getName().contains(bPlayer.getBoundAbilityName()) && prepared) {
 			remove();
 			return;
 		}
@@ -411,7 +411,7 @@ public class IceSpikeBlast extends IceAbility {
 
 	@Override
 	public String getName() {
-		return "IceSpike";
+		return "IceSpikeBlast";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
@@ -274,7 +274,7 @@ public class IceSpikePillar extends IceAbility {
 
 	@Override
 	public String getName() {
-		return "IceSpike";
+		return "IceSpikePillar";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
@@ -286,6 +286,11 @@ public class IceSpikePillar extends IceAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public int getHeight() {
 		return height;

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillarField.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillarField.java
@@ -16,6 +16,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.IceAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
+import com.projectkorra.projectkorra.util.TempBlock;
 
 public class IceSpikePillarField extends IceAbility {
 
@@ -58,7 +59,7 @@ public class IceSpikePillarField extends IceAbility {
 
 					if (WaterAbility.isIcebendable(player, testBlock.getType(), false) && testBlock.getRelative(BlockFace.UP).getType() == Material.AIR 
 							&& !(testBlock.getX() == player.getEyeLocation().getBlock().getX() && testBlock.getZ() == player.getEyeLocation().getBlock().getZ())
-							&& WaterAbility.isBendableWaterTempBlock(testBlock)) {
+							|| (TempBlock.isTempBlock(testBlock) && WaterAbility.isBendableWaterTempBlock(testBlock))) {
 						iceBlocks.add(testBlock);
 						for (int i = 0; i < iceBlocks.size() / 2 + 1; i++) {
 							Random rand = new Random();
@@ -100,6 +101,7 @@ public class IceSpikePillarField extends IceAbility {
 			}
 
 			if (targetBlock.getRelative(BlockFace.UP).getType() != Material.ICE) {
+				
 				IceSpikePillar pillar = new IceSpikePillar(player, targetBlock.getLocation(), (int) damage, thrownForce, cooldown);
 				pillar.inField = true;
 				bPlayer.addCooldown("IceSpikePillarField", cooldown);

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
@@ -183,6 +183,11 @@ public class WaterArmsFreeze extends IceAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public boolean isCancelled() {
 		return cancelled;

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
@@ -161,7 +161,7 @@ public class WaterArmsFreeze extends IceAbility {
 
 	@Override
 	public String getName() {
-		return "WaterArms";
+		return "WaterArmsFreeze";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
@@ -271,7 +271,7 @@ public class WaterArmsSpear extends WaterAbility {
 
 	@Override
 	public String getName() {
-		return "WaterArms";
+		return "WaterArmsSpear";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
@@ -297,6 +297,11 @@ public class WaterArmsSpear extends WaterAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public boolean isHitEntity() {
 		return hitEntity;

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -446,6 +446,11 @@ public class WaterArmsWhip extends WaterAbility {
 	public boolean isHarmlessAbility() {
 		return false;
 	}
+	
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
 
 	public boolean isReverting() {
 		return reverting;

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -424,7 +424,7 @@ public class WaterArmsWhip extends WaterAbility {
 
 	@Override
 	public String getName() {
-		return "WaterArms";
+		return "WaterArmsWhip";
 	}
 
 	@Override

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -242,6 +242,6 @@ permissions:
     children:
       bending.ability.FastSwim: true
       bending.ability.Hydrosink: true
-  bending.donator:
+  bending.donor:
     default: false
-    description: Grants the Donator tag.
+    description: Grants the Donor tag.


### PR DESCRIPTION
## Fixes
* Fixes multiple instances of the same `CoreAbility` being present in auto tabbing due to certain move functionalities being split up between files.
    > * https://trello.com/c/sw6cw7BT/833-moves-with-multiple-functionalities-split-up-among-multiple-classes-create-multiple-occurrences-of-a-single-move-in-pk-help-and
* Fixes passives and passives showing up in `/pk bind <Ability>` auto tabbing.
    > * https://trello.com/c/STJ0AR1f/834-combos-and-passives-appear-in-pk-bind-auto-tabbing
* Fixes `WaterWave` and `WaterSpout` cohesive movement.
    > * https://trello.com/c/ZEAAW9fU/807-waterwave-any-spout-does-not-allow-for-the-cohesive-movement-of-waterwave
* Fixes `DamageHandler` applying `DamageModifier.ARMOR` where it is not applicable.
    > * https://trello.com/c/JrC35la8/828-damaging-creatures-without-armor-throws-an-error-in-damagehandler