### PR TITLE
Updated ProjectKorra.java to remove NPE on disable

### DIFF
--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -174,7 +174,7 @@ public class ProjectKorra extends JavaPlugin {
 			DBConnection.sql.close();
 		}
 		
-		handler.close();
+		// handler.close();
 	}
 
 	public static CollisionManager getCollisionManager() {


### PR DESCRIPTION
On the newest version of Korra there is an NPE thrown on disable. This is caused by "handler" not being defined in the code. It seems all code relating to "hander" is commented out, so I did the same with the variable in the onDisable().
