### PR TITLE
dont break all bending if a move errors

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -222,8 +222,17 @@ public abstract class CoreAbility implements Ability {
 						continue;
 					}
 				}
-				abil.progress();
-				Bukkit.getServer().getPluginManager().callEvent(new AbilityProgressEvent(abil));
+				try{
+					abil.progress();
+					Bukkit.getServer().getPluginManager().callEvent(new AbilityProgressEvent(abil));
+				} catch(Exception e) {
+					e.printStackTrace();
+					try{
+						abil.remove();
+					} catch(Exception re) {
+						re.printStackTrace();
+					}
+				}
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -222,14 +222,14 @@ public abstract class CoreAbility implements Ability {
 						continue;
 					}
 				}
-				try{
+				try {
 					abil.progress();
 					Bukkit.getServer().getPluginManager().callEvent(new AbilityProgressEvent(abil));
-				} catch(Exception e) {
+				} catch (Exception e) {
 					e.printStackTrace();
-					try{
+					try {
 						abil.remove();
-					} catch(Exception re) {
+					} catch (Exception re) {
 						re.printStackTrace();
 					}
 				}


### PR DESCRIPTION
Links to Appropriate Issue Reports Addressed in this Pull Request:
- none

Release Notes for this Pull Request:
- if a move errors, print the error then attempt to call the remove method for it
- this allows other moves that didnt error to continue, preventing one move from breaking the whole server of players bending
