### PR TITLE
AirScooter, AirBlast

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -32,6 +32,7 @@ import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.object.HorizontalVelocityTracker;
 import com.projectkorra.projectkorra.util.DamageHandler;
 import com.projectkorra.projectkorra.util.Flight;
+import com.projectkorra.projectkorra.util.TempBlock;
 
 public class AirBlast extends AirAbility {
 
@@ -400,9 +401,9 @@ public class AirBlast extends AirAbility {
 		if ((GeneralMethods.isSolid(block) || block.isLiquid()) && !affectedLevers.contains(block) && canCoolLava) {
 			if (block.getType() == Material.LAVA || block.getType() == Material.STATIONARY_LAVA) {
 				if (block.getData() == 0x0) {
-					block.setType(Material.OBSIDIAN);
+					new TempBlock(block, Material.OBSIDIAN, (byte) 0);
 				} else {
-					block.setType(Material.COBBLESTONE);
+					new TempBlock(block, Material.COBBLESTONE, (byte)0);
 				}
 			}
 			remove();

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -112,6 +112,12 @@ public class AirScooter extends AirAbility {
 			return;
 		}
 
+		if (player.isSneaking()) {
+			bPlayer.addCooldown(this);
+			remove();
+			return;
+		}
+
 		Vector velocity = player.getEyeLocation().getDirection().clone().normalize();
 		velocity = velocity.clone().normalize().multiply(speed);
 		/*


### PR DESCRIPTION
- Makes AirScooter disable itself on player sneak
- Changes AirBlast obsidian and cobblestone to tempblocks.

Links to Appropriate Issue Reports Addressed in this Pull Request:
- https://trello.com/c/nwkmFj3Z/723-make-pressing-sneak-while-using-airscooter-disable-the-ability
- https://trello.com/c/d6WoIjjb/844-when-airblast-cools-lava-the-obsidian-should-be-a-tempblock
