### PR TITLE
Add version to Addon help, fix AirScooter shift

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -204,7 +204,7 @@ public class PKListener implements Listener {
 		String abil = bPlayer.getBoundAbilityName();
 		CoreAbility ability = null;
 		
-		if (bPlayer.isElementToggled(Element.WATER)) {
+		if (bPlayer.isElementToggled(Element.WATER) && bPlayer.isToggled()) {
 			if (abil != null && abil.equalsIgnoreCase("Surge")) {
 				ability = CoreAbility.getAbility(SurgeWall.class);
 			} else if (abil != null && abil.equalsIgnoreCase("Torrent")) {
@@ -1281,11 +1281,6 @@ public class PKListener implements Listener {
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
 		if (event.isCancelled() || bPlayer == null) {
-			return;
-		}
-
-		if (CoreAbility.hasAbility(event.getPlayer(), AirScooter.class)) {
-			event.setCancelled(true);
 			return;
 		}
 

--- a/src/com/projectkorra/projectkorra/command/HelpCommand.java
+++ b/src/com/projectkorra/projectkorra/command/HelpCommand.java
@@ -152,6 +152,7 @@ public class HelpCommand extends PKCommand {
 				
 				AddonAbility abil = (AddonAbility) CoreAbility.getAbility(arg);
 				sender.sendMessage(color + "- By: " + ChatColor.WHITE + abil.getAuthor());
+				sender.sendMessage(color + "- Version: " + ChatColor.WHITE + abil.getVersion());
 			} else {
 				if (ability instanceof PassiveAbility) {
 					sender.sendMessage(color + (ChatColor.BOLD + ability.getName()) + ChatColor.WHITE + " (Passive)");
@@ -197,6 +198,7 @@ public class HelpCommand extends PKCommand {
 						
 						AddonAbility abil = (AddonAbility) CoreAbility.getAbility(arg);
 						sender.sendMessage(color + "- By: " + ChatColor.WHITE + abil.getAuthor());
+						sender.sendMessage(color + "- Version: " + ChatColor.WHITE + abil.getVersion());
 					} else {
 						sender.sendMessage(color + (ChatColor.BOLD + ability.getName()) + ChatColor.WHITE + " (Combo)");
 						sender.sendMessage(color + ComboManager.getDescriptions().get(combo));


### PR DESCRIPTION
## Fixes
* Fixes `AirScooter` cancelling on shift.
## Changes
* Adds the result of an Addon's `getVersion()` to its `/pk help` description.