### PR TITLE
Update for 1.12.1

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWall.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWall.java
@@ -288,7 +288,7 @@ public class LavaSurgeWall extends LavaAbility {
 		if (!hasAbility(player, LavaSurgeWall.class)) {
 			new LavaSurgeWave(player);
 			return;
-		} else if (isLavabendable(player, player.getTargetBlock((HashSet<Byte>) null, SURGE_WAVE_RANGE))) {
+		} else if (isLavabendable(player, player.getTargetBlock((HashSet<Material>) null, SURGE_WAVE_RANGE))) {
 			new LavaSurgeWave(player);
 			return;
 		}


### PR DESCRIPTION
Update form() method to use <Material> instead of <Byte> for 1.12.1


Release Notes for this Pull Request:
- Get Target block returns material instead of byte in 1.12.1 