### PR TITLE
update for 1.12.1

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -40,11 +40,10 @@ public abstract class ElementalAbility extends CoreAbility {
 		return TRANSPARENT_MATERIAL;
 	}
 
-	public static HashSet<Byte> getTransparentMaterialSet() {
-		HashSet<Byte> set = new HashSet<Byte>();
-		for (int i : TRANSPARENT_MATERIAL) {
-			set.add((byte) i);
-		}
+	public static HashSet<Material> getTransparentMaterialSet() {
+		HashSet<Material> set = new HashSet<Material>();
+		for (int i : TRANSPARENT_MATERIAL)
+			set.add(Material.getMaterial(i));
 		return set;
 	}
 


### PR DESCRIPTION
Update form() method to use <Material> instead of <Byte> for 1.12.1


Release Notes for this Pull Request:
- Get Target block returns material instead of byte in 1.12.1 