### PR TITLE
Fix EarthTunnel not ignoring grass

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
@@ -61,7 +61,7 @@ public class EarthTunnel extends EarthAbility {
 		}
 		this.angle = 0;
 
-		if (!bPlayer.canBend(this) || !EarthAbility.isEarthbendable(player, block)) {
+		if (!bPlayer.canBend(this) || (!EarthAbility.isEarthbendable(player, block) && !EarthAbility.isTransparent(player, "EarthTunnel", block))) {
 			return;
 		}
 		if (bPlayer.isAvatarState()) {


### PR DESCRIPTION
## Fixes
* Fixed Earth tunnel so that it will work through tall grass and other transparent blocks.
