### PR TITLE
Updated addCooldown() Method

### DIFF
--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -110,6 +110,8 @@ public class BendingPlayer {
 	 * @param cooldown The cooldown time
 	 */
 	public void addCooldown(String ability, long cooldown) {
+		if(cooldown <= 0)
+			return;
 		PlayerCooldownChangeEvent event = new PlayerCooldownChangeEvent(Bukkit.getPlayer(uuid), ability, cooldown, Result.ADDED);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 		if (!event.isCancelled()) {


### PR DESCRIPTION

## Fixes
* Prevents cooldownChangeEvent from being fired on moves with a zero cooldown.
    
