### PR TITLE
Spelling error and warnings

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -241,6 +241,7 @@ public abstract class FireAbility extends ElementalAbility {
 	 * 
 	 * @param location The Location
 	 */
+	@SuppressWarnings("deprecation")
 	public static void revertTempFire(Location location) {
 		if (!TEMP_FIRE.containsKey(location)) {
 			return;

--- a/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -209,7 +209,6 @@ public abstract class WaterAbility extends ElementalAbility {
 	 * @param plantbending true if the player can bend plants.
 	 * @return a valid Water source block, or null if one could not be found.
 	 */
-	@SuppressWarnings("deprecation")
 	public static Block getWaterSourceBlock(Player player, double range, boolean plantbending) {
 		Location location = player.getEyeLocation();
 		Vector vector = location.getDirection().clone().normalize();

--- a/src/com/projectkorra/projectkorra/attribute/AttributeModifier.java
+++ b/src/com/projectkorra/projectkorra/attribute/AttributeModifier.java
@@ -9,8 +9,10 @@ import com.projectkorra.projectkorra.ability.WaterAbility;
 
 public class AttributeModifier {
 	
+	@SuppressWarnings("unused")
 	private String name;
 	private double modifier = 1.0D;
+	@SuppressWarnings("unused")
 	private Plugin plugin;
 	private AttributeModifierType type;
 	

--- a/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -60,7 +60,6 @@ public class PresetCommand extends PKCommand {
 		this.cantEditBinds = ConfigManager.languageConfig.get().getString("Commands.Preset.CantEditBinds");
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void execute(CommandSender sender, List<String> args) {
 		if (!isPlayer(sender) || !correctLength(sender, args.size(), 1, 3)) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -400,7 +400,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Chi.HighJump.Description", "HighJump gives the Chiblocker the ability to leap into the air. This ability is used for mobility, and is often used to dodge incoming attacks.");
 			config.addDefault("Abilities.Chi.HighJump.Instructions", "To use, simply left click while standing on the ground.");
 			config.addDefault("Abilities.Chi.Smokescreen.Description", "Smokescreen, if used correctly, can serve as a defensive and offensive ability for Chiblockers. When used, a smoke bomb is fired which will blind anyone within a small radius of the explosion, allowing you to either get away, or move in for the kill.");
-			config.addDefault("Abiltiies.Chi.Smokescreen.Instructions", "Left click and a smoke bomb will be fired in the direction you're looking.");
+			config.addDefault("Abilities.Chi.Smokescreen.Instructions", "Left click and a smoke bomb will be fired in the direction you're looking.");
 			config.addDefault("Abilities.Chi.WarriorStance.Description", "WariorStance is an advanced chiblocker technique that gives the chiblocker increased damage but makes them a tad more vulnerable. This ability is useful when finishing off weak targets.");
 			config.addDefault("Abilities.Chi.WarriorStance.Instructions", "Left click to activate the warrior stance mode. Additionally, left click to disable it.");
 			config.addDefault("Abilities.Chi.Paralyze.Description", "Paralyzes the target, making them unable to do anything for a short period of time as they will be paralyzed where they're stood. ");

--- a/src/com/projectkorra/projectkorra/util/BlockSource.java
+++ b/src/com/projectkorra/projectkorra/util/BlockSource.java
@@ -6,7 +6,6 @@ import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -16,6 +16,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
 
+@SuppressWarnings("deprecation")
 public class DamageHandler {
 
 	/**
@@ -26,7 +27,6 @@ public class DamageHandler {
 	 * @param entity The entity that is receiving the damage
 	 * @param damage The amount of damage to deal
 	 */
-	@SuppressWarnings("deprecation")
 	public static void damageEntity(Entity entity, Player source, double damage, Ability ability, boolean ignoreArmor) {
 		if (TempArmor.hasTempArmor((LivingEntity) entity)) {
 			ignoreArmor = true;


### PR DESCRIPTION
The error was in the "Abilities.Chi.Smokescreen.Instructions" path where "Abilities" was spelled "Abiltiies" making the Instructions appear at the bottom of the language.yml

## Fixes
    > * Fixed config path for Smokescreen Instructions in language.yml