### PR TITLE
Fixed bug #377

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/Tornado.java
+++ b/src/com/projectkorra/projectkorra/airbending/Tornado.java
@@ -1,7 +1,9 @@
 package com.projectkorra.projectkorra.airbending;
 
+import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.util.Flight;
@@ -12,7 +14,9 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -151,6 +155,14 @@ public class Tornado extends AirAbility {
 						if (entity instanceof Player) {
 							if (Commands.invincible.contains(((Player) entity).getName())) {
 								continue;
+							}
+							
+							Player trg = (Player) entity;
+							BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(trg);
+							if (player.canBend(CoreAbility.getAbility(AirSpout.class))) {
+								if (CoreAbility.getPlayers(AirSpout.class).contains(trg)) {
+									CoreAbility.getAbility(trg, AirSpout.class).remove();
+								}
 							}
 						}
 


### PR DESCRIPTION
Fixed issue #377 where AirSpout allows for infinite flying when touched by another player's tornado. This was copied off a closed pull request that was posted to the wrong branch.