### PR TITLE
Fixed AcrobatStance and Bloodbending errors

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -660,6 +660,9 @@ public class GeneralMethods {
 	
 	public static void displayMovePreview(Player player, int slot) {
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+		if (bPlayer == null) {
+			return;
+		}
 		String displayedMessage = bPlayer.getAbilities().get(slot);
 		CoreAbility ability = CoreAbility.getAbility(displayedMessage);
 		

--- a/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
@@ -1,6 +1,7 @@
 package com.projectkorra.projectkorra.waterbending.blood;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -93,9 +94,9 @@ public class Bloodbending extends BloodAbility {
 				entities = GeneralMethods.getEntitiesAroundPoint(location, 1.7);
 				if (entities.contains(player))
 					entities.remove(player);
-				for (Entity e : entities) {
-					if (!(e instanceof LivingEntity)) {
-						entities.remove(e);
+				for (Iterator<Entity> iterator = entities.iterator(); iterator.hasNext();) {
+					if (!(iterator.next() instanceof LivingEntity)) {
+						iterator.remove();
 					}
 				}
 				if (entities != null && !entities.isEmpty() && !entities.contains(player)) {


### PR DESCRIPTION
AcrobatStance NullPointerException
  * Caused by players disconnecting while having AcrobatStance active
  * Fixed by adding null check on bPlayer
  > * https://trello.com/c/wYVhu6IG/894-error-on-wip

Bloodbending ConcurrentModificationException
  * Caused by players unintentionally (or intentionally!) trying to bloodbend a non-LivingEntity
  * Fixed by using an Iterator to remove the non-LivingEntity from the entities ArrayList
  > * https://trello.com/c/58OTgYW7/896-another-another-error-on-wip