### PR TITLE
Fixes, Added sticky feature to tremorsense

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -691,8 +691,8 @@ public class PKListener implements Listener {
 			}
 		}
 		
-		for (int i = 0; i < 4; i++) {
-			if (event.getSlot() == i && TempArmor.hasTempArmor((Player) event.getWhoClicked())) {
+		for (int i = 0; i < 4; i++) {	
+			if (event.getSlot() == 36 + i && TempArmor.hasTempArmor((Player) event.getWhoClicked())) {
 				event.setCancelled(true);
 			}
 		}
@@ -785,17 +785,13 @@ public class PKListener implements Listener {
 			if (bPlayer.hasElement(Element.AIR) && event.getCause() == DamageCause.FALL && bPlayer.canBendPassive(CoreAbility.getAbility(GracefulDescent.class)) && bPlayer.canUsePassive(CoreAbility.getAbility(GracefulDescent.class)) && CoreAbility.getAbility(GracefulDescent.class).isEnabled() && PassiveManager.hasPassive(player, CoreAbility.getAbility(GracefulDescent.class))) {
 				event.setDamage(0D);
 				event.setCancelled(true);
-			}
-
-			if (bPlayer.hasElement(Element.WATER) && event.getCause() == DamageCause.FALL && bPlayer.canBendPassive(CoreAbility.getAbility(HydroSink.class)) && bPlayer.canUsePassive(CoreAbility.getAbility(HydroSink.class)) && CoreAbility.getAbility(HydroSink.class).isEnabled() && PassiveManager.hasPassive(player, CoreAbility.getAbility(HydroSink.class))) {
-				if (HydroSink.applyNoFall(player)) {
+			} else if (bPlayer.hasElement(Element.EARTH) && event.getCause() == DamageCause.FALL && bPlayer.canBendPassive(CoreAbility.getAbility(DensityShift.class)) && bPlayer.canUsePassive(CoreAbility.getAbility(DensityShift.class)) && CoreAbility.getAbility(DensityShift.class).isEnabled() && PassiveManager.hasPassive(player, CoreAbility.getAbility(DensityShift.class))) {
+				if (DensityShift.softenLanding(player)) {
 					event.setDamage(0D);
 					event.setCancelled(true);
 				}
-			}
-
-			if (bPlayer.hasElement(Element.EARTH) && event.getCause() == DamageCause.FALL && bPlayer.canBendPassive(CoreAbility.getAbility(DensityShift.class)) && bPlayer.canUsePassive(CoreAbility.getAbility(DensityShift.class)) && CoreAbility.getAbility(DensityShift.class).isEnabled() && PassiveManager.hasPassive(player, CoreAbility.getAbility(DensityShift.class))) {
-				if (DensityShift.softenLanding(player)) {
+			} else if (bPlayer.hasElement(Element.WATER) && event.getCause() == DamageCause.FALL && bPlayer.canBendPassive(CoreAbility.getAbility(HydroSink.class)) && bPlayer.canUsePassive(CoreAbility.getAbility(HydroSink.class)) && CoreAbility.getAbility(HydroSink.class).isEnabled() && PassiveManager.hasPassive(player, CoreAbility.getAbility(HydroSink.class))) {
+				if (HydroSink.applyNoFall(player)) {
 					event.setDamage(0D);
 					event.setCancelled(true);
 				}

--- a/src/com/projectkorra/projectkorra/chiblocking/WarriorStance.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/WarriorStance.java
@@ -61,10 +61,12 @@ public class WarriorStance extends ChiAbility {
 		super.remove();
 		bPlayer.addCooldown(this);
 		bPlayer.setStance(null);
-		GeneralMethods.displayMovePreview(player);
-		player.playSound(player.getLocation(), Sound.ENTITY_ENDERDRAGON_SHOOT, 0.5F, 2F);
-		player.removePotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
-		player.removePotionEffect(PotionEffectType.INCREASE_DAMAGE);
+		if (player != null) {
+			GeneralMethods.displayMovePreview(player);
+			player.playSound(player.getLocation(), Sound.ENTITY_ENDERDRAGON_SHOOT, 0.5F, 2F);
+			player.removePotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
+			player.removePotionEffect(PotionEffectType.INCREASE_DAMAGE);
+		}
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1215,6 +1215,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.Tremorsense.Radius", 5);
 			config.addDefault("Abilities.Earth.Tremorsense.LightThreshold", 7);
 			config.addDefault("Abilities.Earth.Tremorsense.Cooldown", 1000);
+			config.addDefault("Abilities.Earth.Tremorsense.StickyRange", 3);
 			
 			config.addDefault("Abilities.Earth.EarthPillars.Enabled", true);
 			config.addDefault("Abilities.Earth.EarthPillars.Cooldown", 8000);

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class Tremorsense extends EarthAbility {
 
+	@Deprecated
 	private static final Map<Block, Player> BLOCKS = new ConcurrentHashMap<Block, Player>();
 
 	private byte lightThreshold;
@@ -24,6 +25,7 @@ public class Tremorsense extends EarthAbility {
 	private int radius;
 	private long cooldown;
 	private Block block;
+	private int stickyRange;
 
 	public Tremorsense(Player player, boolean clicked) {
 		super(player);
@@ -49,6 +51,7 @@ public class Tremorsense extends EarthAbility {
 		this.radius = getConfig().getInt("Abilities.Earth.Tremorsense.Radius");
 		this.lightThreshold = (byte) getConfig().getInt("Abilities.Earth.Tremorsense.LightThreshold");
 		this.cooldown = getConfig().getLong("Abilities.Earth.Tremorsense.Cooldown");
+		this.stickyRange = getConfig().getInt("Abilities.Earth.Tremorsense.StickyRange");
 	}
 
 	private void activate() {
@@ -106,7 +109,14 @@ public class Tremorsense extends EarthAbility {
 			remove();
 			return;
 		} else if (!isBendable) {
-			revertGlowBlock();
+			if (stickyRange > 0) {
+				if (standBlock.getLocation().distanceSquared(block.getLocation()) > stickyRange * stickyRange) {
+					revertGlowBlock();
+				}
+			} else {
+				revertGlowBlock();
+			}
+			
 			return;
 		}
 	}
@@ -153,6 +163,8 @@ public class Tremorsense extends EarthAbility {
 		return false;
 	}
 
+	@Deprecated
+	/**No longer used; will be removed in the next version.*/
 	public static Map<Block, Player> getBlocks() {
 		return BLOCKS;
 	}


### PR DESCRIPTION
• Added a "Sticky" feature to tremorsense (passive).
    • Now when an earthbender moves onto a block they can't bend, the light will remain on the last bendable block
    • After they go out of range (3 blocks; configurable), then the light goes out. Change to 0 to disable.
• Fixed WarrierStance NPE (from #830)
• Fixed being able to remove the EarthArmor armor items from their slots
• Fixed DensityShift softening your landing while you are an Airbender (and with optimizations to the if statements)