### PR TITLE
Fixed EarthTunnel bug

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
@@ -30,7 +30,7 @@ public class EarthTunnel extends EarthAbility {
 	private double range;
 	private double radiusIncrement;
 	private boolean revert;
- 	private boolean dropLootIfNotRevert;
+	private boolean dropLootIfNotRevert;
 	private Block block;
 	private Location origin;
 	private Location location;
@@ -48,7 +48,7 @@ public class EarthTunnel extends EarthAbility {
 		this.interval = getConfig().getLong("Abilities.Earth.EarthTunnel.Interval");
 		this.revert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.Revert");
 		this.dropLootIfNotRevert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.DropLootIfNotRevert");
-		
+
 		this.time = System.currentTimeMillis();
 
 		this.location = player.getEyeLocation().clone();
@@ -69,7 +69,7 @@ public class EarthTunnel extends EarthAbility {
 		}
 
 		this.radiusIncrement = radius;
-		
+
 		start();
 	}
 

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -26,7 +26,7 @@ public class TempBlock {
 	});
 
 	private Block block;
-	private Material newtype;
+//	private Material newtype;
 	private byte newdata;
 	private BlockState state;
 	private long revertTime;
@@ -37,14 +37,14 @@ public class TempBlock {
 	public TempBlock(Block block, Material newtype, byte newdata) {
 		this.block = block;
 		this.newdata = newdata;
-		this.newtype = newtype;
+//		this.newtype = newtype;
 		if (instances.containsKey(block)) {
 			TempBlock temp = instances.get(block);
-			if (newtype != temp.newtype) {
+			if (newtype != temp.block.getType()) {
 				temp.block.setType(newtype);
-				temp.newtype = newtype;
+//				temp.newtype = newtype;
 			}
-			if (newdata != temp.newdata) {
+			if (newdata != temp.block.getData()) {
 				temp.block.setData(newdata);
 				temp.newdata = newdata;
 			}
@@ -164,7 +164,7 @@ public class TempBlock {
 
 	@SuppressWarnings("deprecation")
 	public void setType(Material material, byte data) {
-		newtype = material;
+//		newtype = material;
 		newdata = data;
 		block.setType(material);
 		block.setData(data);


### PR DESCRIPTION
## Fixes
* EarthTunnel bug
    > * https://trello.com/c/O1zvQT0N/831-earthtunnel-cant-be-used-on-gravel-sand-red-sand-blocks-that-are-fell
This bug was caused by blocks with gravity (sand, gravel, etc) falling into already existing TempBlocks and attempting to use EarthTunnel on these blocks. Previously it would result in nothing happening, and the block would be stuck.
This issue was caused by TempBlock not correctly checking the material type (and data!) of the already existing TempBlock when attempting to create a new instance on a pre-existing TempBlock.
This was fixed by instead of checking if `newtype` and `newdata` on the old and new TempBlock are different, it checks the actual type of the block by using `temp.block.getType()`, to get the actual values. This is because the already created TempBlock has the same type as what is trying to be set (air), and so the code to set the type again never is called.
____________