### PR TITLE
Fixed bug with MetalClips and misc errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,4 +237,5 @@ target/
 
 .idea/
 classes/
+out/
 projectkorra.iml

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -470,7 +470,7 @@ public class PKListener implements Listener {
 			FireDamageTimer.dealFlameDamage(entity);
 		}
 		
-		if (TempArmor.hasTempArmor((LivingEntity)entity)) {
+		if (entity instanceof LivingEntity && TempArmor.hasTempArmor((LivingEntity)entity)) {
 			event.setDamage(DamageModifier.ARMOR, 0);
 		}
 

--- a/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -435,7 +435,7 @@ public class MetalClips extends MetalAbility {
 							}
 						} else {
 							DamageHandler.damageEntity(e, player, damage, this);
-							dropIngots(e.getLocation());
+							dropIngots(e.getLocation(), ii.getItemStack().getAmount());
 							remove();
 						}
 
@@ -450,7 +450,11 @@ public class MetalClips extends MetalAbility {
 	}
 	
 	public void dropIngots(Location loc) {
-		Item i = player.getWorld().dropItem(loc, new ItemStack(Material.IRON_INGOT, metalClipsCount == 0 ? 1 : metalClipsCount));
+		dropIngots(loc, metalClipsCount == 0 ? 1 : metalClipsCount);
+	}
+
+	public void dropIngots(Location loc, int amount) {
+		Item i = player.getWorld().dropItem(loc, new ItemStack(Material.IRON_INGOT, amount));
 		i.setPickupDelay(61);
 	}
 

--- a/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -339,7 +339,7 @@ public class MetalClips extends MetalAbility {
 					Item iron = (Item) entity;
 
 					if (Arrays.asList(METAL_ITEMS).contains(iron.getItemStack().getType())) {
-						iron.setVelocity(vector.normalize().multiply(magnetPower));
+						iron.setVelocity(vector.normalize().multiply(magnetPower).add(new Vector(0, 0.2, 0)));
 					}
 				}
 			}


### PR DESCRIPTION
## This pull-request covers the following changes
> **Note**: more information is contained in the description of each commit.
### Errors and bugs corrected
* A `ClassCastException` in `PKListener.java:onEntityDamageEvent()` would occur when a non-Living Entity took damage.
* Ingots on the ground would disappear when their `ItemStack` merged with MetalClips', and the latter is removed upon colliding with an Entity.
### Improvements made
* A small vertical push was given to items affected by the *magnetize* functionality of MetalClips, so that they no longer get stuck when being pulled upwards.
### Other changes
* Added a `gitignore` entry to omit IntelliJ's out/ directory, which contains compiled code.

> **Note**: more information is contained in the description of each commit.