### PR TITLE
Disable movement while hovering in AirFlight

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/flight/AirFlight.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/AirFlight.java
@@ -91,12 +91,14 @@ public class AirFlight extends FlightAbility {
 				player.setVelocity(new Vector(0, 0, 0));
 				player.setAllowFlight(true);
 				player.setFlying(true);
+				player.setFlySpeed(0);
 			}
 		} else {
 			if (HOVERING.containsKey(playername)) {
 				PlayerFlyData pfd = HOVERING.get(playername);
 				player.setAllowFlight(pfd.canFly());
 				player.setFlying(pfd.isFlying());
+				player.setFlySpeed(0.1f);
 				HOVERING.remove(playername);
 			}
 		}


### PR DESCRIPTION
Movement while hovering in Flight already seems to be prevented, might as well tell the client not to move at all then.

Might want to consider saving and restoring the `flySpeed` value. 0.1f is the default `flySpeed`.
