### PR TITLE
typo for flight ability in plugin.yml permissions

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -78,8 +78,8 @@ permissions:
       bending.ability.Suffocate: true
       bending.ability.Tornado: true
       bending.ability.AirCombo: true
+      bending.ability.Flight: true
       bending.air.passive: true
-      bending.air.flight: true
   bending.water:
     default: true
     description: Grants access to most waterbending abilities.


### PR DESCRIPTION
Fixes:
- A typo for the permission node for the Flight ability for airbenders.
  - Flight is an ability. Also matched the formatting of uppercasing ability nodes.

Apparently the github web editor also likes adding a newline at the end of the file.