### PR TITLE
Update AirSwipe.java - Fix

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -244,7 +244,7 @@ public class AirSwipe extends AirAbility {
 	@SuppressWarnings("deprecation")
 	private boolean isBlockBreakable(Block block) {
 		Integer id = block.getTypeId();
-		if (Arrays.asList(BREAKABLES).contains(id) && !Illumination.getBlocks().containsKey(block)) {
+		if (Arrays.asList(BREAKABLES).contains(id) && !Illumination.isIlluminationTorch(block)) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
The breakable check here for this ability is bugged in a small way. It is trying to check if the block is a breakable type and is not a torch created by illumination, but this check to see if it is an illumination torch will always return false.

Illumination.getBlocks() currently returns a ConcurrentHashMap of key and value type <TempBlock,Player>... this method is trying to see if this map contains a Block, but this map only contains TempBlocks. This change fixes the issue, by using the Illumination.isIlluminationTorch(block) method instead, which works for regular blocks (rather than TempBlocks).

## Fixes
(second part of issue)
- Issue: https://github.com/ProjectKorra/ProjectKorra/issues/882