### PR TITLE
Small bug fixes + minor code change

### DIFF
--- a/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -198,7 +198,7 @@ public class PresetCommand extends PKCommand {
 		} else if (Arrays.asList(createaliases).contains(args.get(0)) && hasPermission(sender, "create")) { //bending preset create name
 			int limit = GeneralMethods.getMaxPresets(player);
 
-			if (Preset.presets.get(player) != null && Preset.presets.get(player).size() >= limit) {
+			if (Preset.presets.get(player.getUniqueId()) != null && Preset.presets.get(player.getUniqueId()).size() >= limit) {
 				GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + this.reachedMax);
 				return;
 			} else if (Preset.presetExists(player, name)) {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
@@ -248,8 +248,10 @@ public class WaterSpout extends WaterAbility {
 			if (GeneralMethods.isRegionProtectedFromBuild(this, blocki.getLocation())) {
 				return -1;
 			}
+			
+			TempBlock tempblock = TempBlock.get(blocki);
 
-			if (!blocks.contains(blocki)) {
+			if (TempBlock.get(blocki) == null || !blocks.contains(TempBlock.get(blocki))) {
 				if (isWater(blocki)) {
 					if (!TempBlock.isTempBlock(blocki)) {
 						revertBaseBlock();

--- a/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
@@ -176,6 +176,7 @@ public class WaterReturn extends WaterAbility {
 		}
 
 		ItemStack item = inventory.getItem(index);
+		if (item == null) return false;
 		if (item.getAmount() == 1) {
 			inventory.setItem(index, new ItemStack(Material.GLASS_BOTTLE));
 		} else {

--- a/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
@@ -148,7 +148,7 @@ public class WaterReturn extends WaterAbility {
 		if (inventory.contains(Material.POTION)) {
 			ItemStack item = inventory.getItem(inventory.first(Material.POTION));
 			PotionMeta meta = (PotionMeta) item.getItemMeta();
-			return meta.getBasePotionData().getType().equals(PotionType.WATER);
+			return meta.getBasePotionData().getType() == PotionType.WATER);
 		}
 		return false;
 	}
@@ -161,22 +161,13 @@ public class WaterReturn extends WaterAbility {
 			return false;
 		}
 
-		//Check that the first one found is actually a WATER bottle. We aren't implementing potion bending just yet ;)
-		if (!((PotionMeta) inventory.getItem(index).getItemMeta()).getBasePotionData().getType().equals(PotionType.WATER)) {
-			for (int i = 0; i < inventory.getSize(); i++) {
-				if (inventory.getItem(i) != null && inventory.getItem(i).getType() == Material.POTION) {
-					PotionMeta meta = (PotionMeta) inventory.getItem(i).getItemMeta();
-					if (meta.getBasePotionData().getType().equals(PotionType.WATER)) {
-						index = i;
-						break;
-					}
-				}
-			}
-			return false;
-		}
-
 		ItemStack item = inventory.getItem(index);
-		if (item == null) return false;
+		
+		//item could have been changed after inventory.first(Material.POTION) called
+		if (item == null || ((PotionMeta)item.getItemMeta()).getBasePotionData().getType() != PotionType.WATER) {
+		return false;
+		}
+		
 		if (item.getAmount() == 1) {
 			inventory.setItem(index, new ItemStack(Material.GLASS_BOTTLE));
 		} else {

--- a/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
@@ -153,14 +153,18 @@ public class WaterReturn extends WaterAbility {
 		return false;
 	}
 
-	public static void emptyWaterBottle(Player player) {
+	public static boolean emptyWaterBottle(Player player) {
 		PlayerInventory inventory = player.getInventory();
 		int index = inventory.first(Material.POTION);
+		
+		if (index == -1) {
+			return false;
+		}
 
 		//Check that the first one found is actually a WATER bottle. We aren't implementing potion bending just yet ;)
-		if (index != -1 && !((PotionMeta) inventory.getItem(index).getItemMeta()).getBasePotionData().getType().equals(PotionType.WATER)) {
+		if (!((PotionMeta) inventory.getItem(index).getItemMeta()).getBasePotionData().getType().equals(PotionType.WATER)) {
 			for (int i = 0; i < inventory.getSize(); i++) {
-				if (inventory.getItem(i).getType() == Material.POTION) {
+				if (inventory.getItem(i) != null && inventory.getItem(i).getType() == Material.POTION) {
 					PotionMeta meta = (PotionMeta) inventory.getItem(i).getItemMeta();
 					if (meta.getBasePotionData().getType().equals(PotionType.WATER)) {
 						index = i;
@@ -168,22 +172,22 @@ public class WaterReturn extends WaterAbility {
 					}
 				}
 			}
+			return false;
 		}
 
-		if (index != -1) {
-			ItemStack item = inventory.getItem(index);
-			if (item.getAmount() == 1) {
-				inventory.setItem(index, new ItemStack(Material.GLASS_BOTTLE));
-			} else {
-				item.setAmount(item.getAmount() - 1);
-				inventory.setItem(index, item);
-				HashMap<Integer, ItemStack> leftover = inventory.addItem(new ItemStack(Material.GLASS_BOTTLE));
+		ItemStack item = inventory.getItem(index);
+		if (item.getAmount() == 1) {
+			inventory.setItem(index, new ItemStack(Material.GLASS_BOTTLE));
+		} else {
+			item.setAmount(item.getAmount() - 1);
+			inventory.setItem(index, item);
+			HashMap<Integer, ItemStack> leftover = inventory.addItem(new ItemStack(Material.GLASS_BOTTLE));
 
-				for (int left : leftover.keySet()) {
-					player.getWorld().dropItemNaturally(player.getLocation(), leftover.get(left));
-				}
+			for (int left : leftover.keySet()) {
+				player.getWorld().dropItemNaturally(player.getLocation(), leftover.get(left));
 			}
 		}
+		return true;
 	}
 
 	public long getTime() {


### PR DESCRIPTION
These are mostly small bugfixes, where code isn't running how it seems to be intended, or wrong classtypes were used on checks (for example: checking if a list of TempBlocks contains a block), and some NullPointerException issues. Also, PresetCommand wasn't properly checking if the player has met their maximum presets yet (which is a significant bug).

Also, I've found it's really helpful if you make changes in your IDE first, as you will be able to see where the wrong classtype has been used incorrectly in collections when using contains(object).

##Fixes

- 1. Fixed PresetCommand not properly checking if the player has met their maximum presets (this check would never be raised), due to player being used instead of the player's UUID in a check
- 2. Fixed potions possibly being drained on rare occasions in WaterReturn#emptyWaterBottle, now even rarer
- 3. Fixed NullPointerExceptions in WaterReturn#emptyWaterBottle that occur almost every single time, and optimized code
- 4. Fixed WaterSpout reverting the base block briefly where this isn't intended, due to an improper check (Block instead of TempBlock)

##Changes

- Changed WaterReturn#emptyWaterBottle from void to boolean (returns whether or not the bottle was successfully removed), so that other classes or abilities can check if it wasn't removed where expected