### PR TITLE
Method clarification & improvements + AirSwipe fix

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -257,8 +257,8 @@ public class PKListener implements Listener {
 			}
 
 			if (!event.isCancelled()) {
-				if (Illumination.isIlluminationTorch(block)) {
-					TempBlock temp = TempBlock.get(block);
+				if (Illumination.isIlluminationTorch(toblock)) {
+					TempBlock temp = TempBlock.get(toblock);
 					if (temp != null) temp.revertBlock();
 				}
 			}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -228,7 +228,7 @@ public class PKListener implements Listener {
 			}
 		} else if (SurgeWall.getWallBlocks().containsKey(block)) {
 			event.setCancelled(true);
-		} else if (TempBlock.isTempBlock(block) && Illumination.getBlocks().containsKey(TempBlock.get(block))) {
+		} else if (Illumination.isIlluminationTorch(block)) {
 			event.setCancelled(true);
 		} else if (!SurgeWave.canThaw(block)) {
 			SurgeWave.thaw(block);
@@ -257,8 +257,9 @@ public class PKListener implements Listener {
 			}
 
 			if (!event.isCancelled()) {
-				if (TempBlock.isTempBlock(toblock) && Illumination.getBlocks().containsKey(TempBlock.get(toblock))) {
-					toblock.setType(Material.AIR);
+				if (Illumination.isIlluminationTorch(block)) {
+					TempBlock temp = TempBlock.get(block);
+					if (temp != null) temp.revertBlock();
 				}
 			}
 		}
@@ -309,7 +310,7 @@ public class PKListener implements Listener {
 			return;
 		}
 
-		event.setCancelled(TempBlock.isTempBlock(block) && Illumination.getBlocks().containsKey(TempBlock.get(block)));
+		event.setCancelled(Illumination.isIlluminationTorch(block));
 		if (!event.isCancelled()) {
 			event.setCancelled(!WaterManipulation.canPhysicsChange(block));
 		}
@@ -339,7 +340,7 @@ public class PKListener implements Listener {
 	public void onBlockPhysics(BlockPhysicsEvent event) {
 		Block block = event.getBlock();
 
-		if (!WaterManipulation.canPhysicsChange(block) || !EarthPassive.canPhysicsChange(block) || (TempBlock.isTempBlock(block) && Illumination.getBlocks().containsKey(TempBlock.get(block))) || EarthAbility.getPreventPhysicsBlocks().contains(block)) {
+		if (!WaterManipulation.canPhysicsChange(block) || !EarthPassive.canPhysicsChange(block) || Illumination.isIlluminationTorch(block) || EarthAbility.getPreventPhysicsBlocks().contains(block)) {
 			event.setCancelled(true);
 		}
 

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -244,7 +244,7 @@ public class AirSwipe extends AirAbility {
 	@SuppressWarnings("deprecation")
 	private boolean isBlockBreakable(Block block) {
 		Integer id = block.getTypeId();
-		if (Arrays.asList(BREAKABLES).contains(id) && !Illumination.getBlocks().containsKey(block)) {
+		if (Arrays.asList(BREAKABLES).contains(id) && !Illumination.isIlluminationTorch(block)) {
 			return true;
 		}
 		return false;

--- a/src/com/projectkorra/projectkorra/firebending/Illumination.java
+++ b/src/com/projectkorra/projectkorra/firebending/Illumination.java
@@ -180,6 +180,14 @@ public class Illumination extends FireAbility {
 		this.block = block;
 	}
 
+	/**
+	 *@deprecated In favor of Illumination#isIlluminationTorch(block).
+	 *This method may be removed in the future, but regardless should only be used for purposes
+	 *other than checking if a block is a torch created by Illumination.
+	 
+	 *@return A map of TempBlocks created by Illumination
+	 */
+	@Deprecated
 	public static Map<TempBlock, Player> getBlocks() {
 		return BLOCKS;
 	}
@@ -190,12 +198,13 @@ public class Illumination extends FireAbility {
 	 * @param block The block being tested
 	 */
 	public static boolean isIlluminationTorch(Block block) {
-		for (TempBlock b : BLOCKS.keySet()) {
-			if (b.getBlock().equals(block)) {
-				return true;
-			}
+		if (block == null || block.getType() != Material.TORCH) {
+			return false;
 		}
-		return false;
+		
+		TempBlock temp = TempBlock.get(block);
+		
+		return temp != null && BLOCKS.containsKey(temp);
 	}
 
 	public void setCooldown(long cooldown) {

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -32,11 +32,18 @@ public class TempBlock {
 	private long revertTime;
 	private boolean inRevertQueue;
 	private RevertTask revertTask = null;
+	private boolean preventPhysics;
+	/**Ability that created this tempblock*/
+	private Class<? extends Ability> ability;
 
+	/**@deprecated preventPhysics and ability have not been fully implemented throughout the code yet*/
+	@Deprecated
 	@SuppressWarnings("deprecation")
-	public TempBlock(Block block, Material newtype, byte newdata) {
+	public TempBlock(Block block, Material newtype, byte newdata, boolean preventPhysics, Class<? extends Ability> ability) {
 		this.block = block;
 		this.newdata = newdata;
+		this.preventPhysics = preventPhysics;
+		this.ability = ability;
 //		this.newtype = newtype;
 		if (instances.containsKey(block)) {
 			TempBlock temp = instances.get(block);
@@ -59,11 +66,19 @@ public class TempBlock {
 		if (state.getType() == Material.FIRE)
 			state.setType(Material.AIR);
 	}
+	
+	/**@deprecated preventPhysics and ability has not been fully implemented throughout the code yet*/
+	@Deprecated
+	public TempBlock(Block block, Material newtype, byte newdata, boolean preventPhysics) {
+		this(block, newtype, newdata, preventPhysics, null);
+	}
+	
+	public TempBlock(Block block, Material newtype, byte newdata) {
+		this(block, newtype, newdata, true, null);
+	}
 
 	public static TempBlock get(Block block) {
-		if (isTempBlock(block))
-			return instances.get(block);
-		return null;
+		return instances.get(block);
 	}
 
 	public static boolean isTempBlock(Block block) {
@@ -112,6 +127,30 @@ public class TempBlock {
 
 	public Block getBlock() {
 		return block;
+	}
+	
+	
+	/**This method has not been fully implemented yet, and may require significant code changes.
+	  *@return Whether or not physics should be prevented (melting, dropping as an item, etc)
+	  *@deprecated As of now, physics is not prevented by checking this method in PKListener,
+	  *but by checking many different moves with different method names to see if any of them
+	  *specify to prevent certain physics.
+	  */
+	
+	//remove deprecation when this has been properly added in PKListener and everywhere else needed
+	@Deprecated
+	public boolean preventPhysics() {
+		return preventPhysics;
+	}
+	
+	/**Gets the ability that created this tempblock
+	  *@return The ability that created this tempblock, or null if no ability set this tempblock
+	  *@deprecated Most abilities have not used this format yet.
+	  */
+	//remove deprecation when this is a requirement to make a tempblock
+	@Deprecated
+	public Class<? extends Ability> getAbility() {
+		return ability;
 	}
 
 	public Location getLocation() {

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -14,6 +14,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 
 public class TempBlock {
 

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -380,6 +380,14 @@ public class SurgeWave extends WaterAbility {
 		}
 	}
 
+	/**Determine if the block should be prevented from melting (because of being an ice block made by SurgeWave)
+	  *
+	  *@deprecated In favor of SurgeWave#preventMelting(Block). "thaw" is self-contradicted in SurgeWave- SurgeWave#thaw() and SurgeWave#thaw(Block) will only work if canThaw() is false.
+	  *
+	  *@return true = shouldn't be prevented from melting, false = should be prevented from melting
+	  */
+	
+	@Deprecated
 	public static boolean canThaw(Block block) {
 		for (SurgeWave surgeWave : getAbilities(SurgeWave.class)) {
 			if (surgeWave.frozenBlocks.containsKey(block)) {
@@ -387,6 +395,18 @@ public class SurgeWave extends WaterAbility {
 			}
 		}
 		return true;
+	}
+	
+	/**
+	  *@return If the block should be prevented from melting
+	  */
+	public static boolean preventMelting(Block block) {
+		for (SurgeWave surgeWave : getAbilities(SurgeWave.class)) {
+			if (surgeWave.frozenBlocks.containsKey(block)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public static void removeAllCleanup() {


### PR DESCRIPTION
## Additions
- Added ability (that created the tempblock) and preventPhysics variables and parameters to TempBlock
Added methods for getting both of these
Marked as deprecated, as they are not used in PKListener yet (should be un-deprecated when these are used throughout the code and in PKListener before the next version release)

## Fixes
Fixed AirSwipe not properly considering illumination torches (and breaking them)

## Misc. Changes
Deprecated contradictory method SurgeWave#canThaw(Block), added clearer method SurgeWave#preventMelting(Block)
Made Illumination.isIlluminationTorch more efficient
Deprecated Illumination.getBlocks() being used in place of Illumination.isIlluminationTorch()