### PR TITLE
Added database cooldowns

### DIFF
--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -162,6 +162,10 @@ public class ProjectKorra extends JavaPlugin {
 		GeneralMethods.stopBending();
 		for (Player player : getServer().getOnlinePlayers()) {
 			statistics.save(player.getUniqueId(), false);
+			BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+			if (bPlayer != null) {
+				bPlayer.saveCooldowns();
+			}
 		}
 		if (DBConnection.isOpen()) {
 			DBConnection.sql.close();

--- a/src/com/projectkorra/projectkorra/avatar/AvatarState.java
+++ b/src/com/projectkorra/projectkorra/avatar/AvatarState.java
@@ -62,7 +62,7 @@ public class AvatarState extends AvatarAbility {
 		playAvatarSound(player.getLocation());
 
 		start();
-		bPlayer.addCooldown(this);
+		bPlayer.addCooldown(this, true);
 		if (duration != 0) {
 			START_TIMES.put(player.getName(), System.currentTimeMillis());
 			GLOBAL_COOLDOWNS.put(player.getUniqueId(), System.currentTimeMillis() + cooldown);

--- a/src/com/projectkorra/projectkorra/command/ChooseCommand.java
+++ b/src/com/projectkorra/projectkorra/command/ChooseCommand.java
@@ -86,11 +86,11 @@ public class ChooseCommand extends PKCommand {
 					return;
 				}
 				if (bPlayer.isOnCooldown("ChooseElement") && !sender.hasPermission("bending.admin.choose")) {
-					GeneralMethods.sendBrandingMessage(sender, onCooldown.replace("%cooldown%", TimeUtil.formatTime(bPlayer.getCooldown("ChooseElement") - System.currentTimeMillis())));
+					GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + onCooldown.replace("%cooldown%", TimeUtil.formatTime(bPlayer.getCooldown("ChooseElement") - System.currentTimeMillis())));
 					return;
 				}
 				add(sender, (Player) sender, targetElement);
-				bPlayer.addCooldown("ChooseElement", cooldown);
+				bPlayer.addCooldown("ChooseElement", cooldown, true);
 				return;
 			} else {
 				GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + invalidElement);

--- a/src/com/projectkorra/projectkorra/storage/DBConnection.java
+++ b/src/com/projectkorra/projectkorra/storage/DBConnection.java
@@ -59,6 +59,11 @@ public class DBConnection {
 				String query = "CREATE TABLE `pk_presets` (" + "`uuid` varchar(36) NOT NULL," + "`name` varchar(255) NOT NULL," + "`slot1` varchar(255)," + "`slot2` varchar(255)," + "`slot3` varchar(255)," + "`slot4` varchar(255)," + "`slot5` varchar(255)," + "`slot6` varchar(255)," + "`slot7` varchar(255)," + "`slot8` varchar(255)," + "`slot9` varchar(255)," + " PRIMARY KEY (uuid, name));";
 				sql.modifyQuery(query, false);
 			}
+			if (!sql.tableExists("pk_cooldowns")) {
+				ProjectKorra.log.info("Creating pk_cooldowns table");
+				String query = "CREATE TABLE `pk_cooldowns` (" + "`uuid` varchar(36) PRIMARY KEY);";
+				sql.modifyQuery(query, false);
+			}
 		} else {
 			sql = new SQLite(ProjectKorra.log, "Establishing SQLite Connection.", "projectkorra.db", ProjectKorra.plugin.getDataFolder().getAbsolutePath());
 			if (((SQLite) sql).open() == null) {
@@ -92,6 +97,11 @@ public class DBConnection {
 			if (!sql.tableExists("pk_presets")) {
 				ProjectKorra.log.info("Creating pk_presets table");
 				String query = "CREATE TABLE `pk_presets` (" + "`uuid` TEXT(36)," + "`name` TEXT(255)," + "`slot1` TEXT(255)," + "`slot2` TEXT(255)," + "`slot3` TEXT(255)," + "`slot4` TEXT(255)," + "`slot5` TEXT(255)," + "`slot6` TEXT(255)," + "`slot7` TEXT(255)," + "`slot8` TEXT(255)," + "`slot9` TEXT(255)," + "PRIMARY KEY (uuid, name));";
+				sql.modifyQuery(query, false);
+			}
+			if (!sql.tableExists("pk_cooldowns")) {
+				ProjectKorra.log.info("Creating pk_cooldowns table");
+				String query = "CREATE TABLE `pk_cooldowns` (" + "`uuid` TEXT(36) PRIMARY KEY);";
 				sql.modifyQuery(query, false);
 			}
 		}

--- a/src/com/projectkorra/projectkorra/util/Cooldown.java
+++ b/src/com/projectkorra/projectkorra/util/Cooldown.java
@@ -1,0 +1,26 @@
+package com.projectkorra.projectkorra.util;
+
+public class Cooldown {
+
+	/**
+	 * The amount of time the cooldown is valid including the system time when
+	 * the cooldown was created
+	 */
+	private long cooldown;
+	/** If the cooldown should be saved in the database */
+	private boolean database;
+
+	public Cooldown(long cooldown, boolean database) {
+		this.cooldown = cooldown;
+		this.database = database;
+	}
+
+	public long getCooldown() {
+		return cooldown;
+	}
+
+	public boolean isDatabase() {
+		return database;
+	}
+
+}


### PR DESCRIPTION
**Overview**
In order for cooldowns to be saved through server restarts, a new database table has been introduced (pk_cooldowns) which will hold information for specific player's who have abilities on cooldown. This data will be saved onDisable and loaded back in onEnable.

**Utilising the API**
To create a cooldown for a player which will be saved in this database table, simply provide an extra boolean argument to the end of BendingPlayer#addCooldown(...) defining this feature. A couple new BendingPlayer#addCooldown(...) methods have been introduced to take this extra argument, leaving it false for all the previous addCooldown methods.