### PR TITLE
Now checking if world in ProjectKorraRPG marker attribute.

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -74,7 +74,8 @@ public abstract class ElementalAbility extends CoreAbility {
 
 	public static boolean isFullMoon(World world) {
 		if (GeneralMethods.hasRPG()) {
-			return EventManager.marker.get(world).equalsIgnoreCase("FullMoon");
+			String event = EventManager.marker.get(world);
+			return event != null && event.equalsIgnoreCase("FullMoon");
 		} else {
 			long days = world.getFullTime() / 24000;
 			long phase = days % 8;
@@ -116,7 +117,8 @@ public abstract class ElementalAbility extends CoreAbility {
 			return false;
 		}
 		
-		return EventManager.marker.get(world).equalsIgnoreCase("LunarEclipse");
+		String event = EventManager.marker.get(world);
+		return event != null && event.equalsIgnoreCase("LunarEclipse");
 	}
 
 	public static boolean isSolarEclipse(World world) {
@@ -124,7 +126,8 @@ public abstract class ElementalAbility extends CoreAbility {
 			return false;
 		}
 		
-		return EventManager.marker.get(world).equalsIgnoreCase("SolarEclipse");
+		String event = EventManager.marker.get(world);
+		return event != null && event.equalsIgnoreCase("LunarEclipse");
 	}
 
 	public static boolean isMeltable(Block block) {
@@ -216,7 +219,8 @@ public abstract class ElementalAbility extends CoreAbility {
 			return false;
 		}
 		
-		return EventManager.marker.get(world).equalsIgnoreCase("SozinsComet");
+		String event = EventManager.marker.get(world);
+		return event != null && event.equalsIgnoreCase("LunarEclipse");
 	}
 
 	public static boolean isTransparent(Player player, Block block) {

--- a/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -127,7 +127,7 @@ public abstract class ElementalAbility extends CoreAbility {
 		}
 		
 		String event = EventManager.marker.get(world);
-		return event != null && event.equalsIgnoreCase("LunarEclipse");
+		return event != null && event.equalsIgnoreCase("SolarEclipse");
 	}
 
 	public static boolean isMeltable(Block block) {

--- a/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -220,7 +220,7 @@ public abstract class ElementalAbility extends CoreAbility {
 		}
 		
 		String event = EventManager.marker.get(world);
-		return event != null && event.equalsIgnoreCase("LunarEclipse");
+		return event != null && event.equalsIgnoreCase("SozinsComet");
 	}
 
 	public static boolean isTransparent(Player player, Block block) {


### PR DESCRIPTION
The console was being spammed with nullpointerexceptions when a player tries to use any ability inside a world with nether and the end environment. The exception was being thrown by the methods that checked the marker of ProjectKorraRPG, and prevented the players to use many abilities in this worlds (one player said he could still use some abilities).
I saw that the problem was that Nether and The End worlds don't get added to the marker, so when trying to use marker.get(world).equals method a null pointer exception was thrown because of .get(world) returned null. I fixed it checking if get(world) returns null before trying to access it.
After the fix the exception is not being thrown, and players can use abilities in this worlds.

This is the stacktrace I obtained after fixing ONLY isSozinsComet method. In the fix, all the methods are fixed. The stacktrace was obtained after fixing only one method.

[13:38:41] [Server thread/ERROR]: Could not pass event PlayerAnimationEvent to ProjectKorra v1.8.6
org.bukkit.event.EventException: null
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:72) ~[paperclip.jar:git-Paper-1320]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:78) ~[paperclip.jar:git-Paper-1320]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[paperclip.jar:git-Paper-1320]
	at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:515) ~[paperclip.jar:git-Paper-1320]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:500) ~[paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.PlayerConnection.a(PlayerConnection.java:1515) ~[paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.PacketPlayInArmAnimation.a(PacketPlayInArmAnimation.java:24) ~[paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.PacketPlayInArmAnimation.a(PacketPlayInArmAnimation.java:5) ~[paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:14) ~[paperclip.jar:git-Paper-1320]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_161]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_161]
	at net.minecraft.server.v1_12_R1.SystemUtils.a(SourceFile:46) [paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:843) [paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:426) [paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:767) [paperclip.jar:git-Paper-1320]
	at net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:665) [paperclip.jar:git-Paper-1320]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_161]
Caused by: java.lang.NullPointerException
	at com.projectkorra.projectkorra.ability.ElementalAbility.isLunarEclipse(ElementalAbility.java:119) ~[?:?]
	at com.projectkorra.projectkorra.ability.FireAbility.getDayFactor(FireAbility.java:119) ~[?:?]
	at com.projectkorra.projectkorra.ability.FireAbility.getDayFactor(FireAbility.java:65) ~[?:?]
	at com.projectkorra.projectkorra.firebending.HeatControl.setFields(HeatControl.java:130) ~[?:?]
	at com.projectkorra.projectkorra.firebending.HeatControl.<init>(HeatControl.java:77) ~[?:?]
	at com.projectkorra.projectkorra.PKListener.onPlayerSwing(PKListener.java:1629) ~[?:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor851.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:70) ~[paperclip.jar:git-Paper-1320]
	... 16 more

I hope this helps!