### PR TITLE
Statistics fixes & optimisations

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -155,7 +155,6 @@ import com.projectkorra.projectkorra.firebending.passive.FirePassive;
 import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
 import com.projectkorra.projectkorra.object.HorizontalVelocityTracker;
 import com.projectkorra.projectkorra.object.Preset;
-import com.projectkorra.projectkorra.util.ActionBar;
 import com.projectkorra.projectkorra.util.BlockSource;
 import com.projectkorra.projectkorra.util.ClickType;
 import com.projectkorra.projectkorra.util.DamageHandler;
@@ -195,7 +194,7 @@ public class PKListener implements Listener {
 	public PKListener(ProjectKorra plugin) {
 		this.plugin = plugin;
 	}
-	
+
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent event) {
 		Block block = event.getBlock();
@@ -462,7 +461,7 @@ public class PKListener implements Listener {
 			event.setCancelled(true);
 			FireDamageTimer.dealFlameDamage(entity);
 		}
-		
+
 		if (entity instanceof LivingEntity && TempArmor.hasTempArmor((LivingEntity) entity)) {
 			event.setDamage(DamageModifier.ARMOR, 0);
 		}
@@ -473,7 +472,7 @@ public class PKListener implements Listener {
 			if (bPlayer == null) {
 				return;
 			}
-			
+
 			if (CoreAbility.hasAbility(player, EarthGrab.class)) {
 				EarthGrab abil = CoreAbility.getAbility(player, EarthGrab.class);
 				abil.remove();
@@ -507,7 +506,7 @@ public class PKListener implements Listener {
 
 			armor.revert();
 		}
-		
+
 		LivingEntity entity = event.getEntity();
 		if (entity.hasMetadata("earthgrab:trap")) {
 			event.getDrops().clear();
@@ -780,7 +779,7 @@ public class PKListener implements Listener {
 			} else if (bPlayer.isChiBlocked()) {
 				return;
 			}
-			
+
 			if (FlightMultiAbility.getFlyingPlayers().contains(player.getUniqueId())) {
 				FlightMultiAbility fma = CoreAbility.getAbility(player, FlightMultiAbility.class);
 				fma.cancel("damage potential");
@@ -1025,14 +1024,14 @@ public class PKListener implements Listener {
 		if (bPlayer.canCurrentlyBendWithWeapons()) {
 			ComboManager.addComboAbility(player, ClickType.RIGHT_CLICK_ENTITY);
 		}
-		
+
 		if (event.getRightClicked().hasMetadata("earthgrab:trap")) {
 			EarthGrab eg = (EarthGrab) event.getRightClicked().getMetadata("earthgrab:trap").get(0).value();
 			eg.damageTrap();
 			event.setCancelled(true);
 			return;
 		}
-		
+
 		if (event.getRightClicked().hasMetadata("temparmorstand")) {
 			event.setCancelled(true);
 			return;
@@ -1069,7 +1068,7 @@ public class PKListener implements Listener {
 				} else if (FlightMultiAbility.getFlyingPlayers().contains(target.getUniqueId())) {
 					FlightMultiAbility.acceptCarryRequest(player, target);
 				}
-			} 
+			}
 		}
 	}
 
@@ -1226,6 +1225,7 @@ public class PKListener implements Listener {
 		Player player = event.getPlayer();
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
+		ProjectKorra.statistics.store(player.getUniqueId());
 		if (bPlayer != null) {
 			if (TOGGLED_OUT.contains(player.getUniqueId()) && bPlayer.isToggled()) {
 				TOGGLED_OUT.remove(player.getUniqueId());
@@ -1701,7 +1701,7 @@ public class PKListener implements Listener {
 			event.setCancelled(player.getGameMode() != GameMode.CREATIVE);
 			return;
 		}
-		
+
 		if (FlightMultiAbility.getFlyingPlayers().contains(player.getUniqueId())) {
 			if (player.isFlying()) {
 				event.setCancelled(true);
@@ -1709,12 +1709,13 @@ public class PKListener implements Listener {
 			}
 		}
 	}
-	
+
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerToggleGlide(EntityToggleGlideEvent event) {
-		if (!(event.getEntity() instanceof Player)) return;
+		if (!(event.getEntity() instanceof Player))
+			return;
 		Player player = (Player) event.getEntity();
-		
+
 		if (FlightMultiAbility.getFlyingPlayers().contains(player.getUniqueId())) {
 			if (player.isGliding()) {
 				event.setCancelled(true);

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -25,7 +25,6 @@ import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.AirAbility;
-import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;
@@ -112,7 +111,7 @@ public class AirBlast extends AirAbility {
 		this.location = location.clone();
 
 		setFields();
-		
+
 		this.affectedLevers = new ArrayList<>();
 		this.affectedEntities = new ArrayList<>();
 		//prevent the airburst related airblasts from triggering doors/levers/buttons
@@ -124,7 +123,7 @@ public class AirBlast extends AirAbility {
 			this.pushFactor = getConfig().getDouble("Abilities.Avatar.AvatarState.Air.AirBlast.Push.Self");
 			this.pushFactorForOthers = getConfig().getDouble("Abilities.Avatar.AvatarState.Air.AirBlast.Push.Entities");
 		}
-		
+
 		this.pushFactor *= modifiedPushFactor;
 
 		start();
@@ -249,7 +248,7 @@ public class AirBlast extends AirAbility {
 
 			GeneralMethods.setVelocity(entity, velocity);
 			if (source != null) {
-				new HorizontalVelocityTracker(entity, player, 200l, CoreAbility.getAbility("AirBurst"));
+				new HorizontalVelocityTracker(entity, player, 200l, source);
 			} else {
 				new HorizontalVelocityTracker(entity, player, 200l, this);
 			}
@@ -265,7 +264,7 @@ public class AirBlast extends AirAbility {
 			breakBreathbendingHold(entity);
 
 			if (source != null && (this.damage > 0 && entity instanceof LivingEntity && !entity.equals(player) && !affectedEntities.contains(entity))) {
-				DamageHandler.damageEntity((LivingEntity) entity, damage, CoreAbility.getAbility("AirBurst"));
+				DamageHandler.damageEntity((LivingEntity) entity, damage, source);
 				affectedEntities.add(entity);
 			} else if (source == null && (damage > 0 && entity instanceof LivingEntity && !entity.equals(player) && !affectedEntities.contains(entity))) {
 				DamageHandler.damageEntity((LivingEntity) entity, damage, this);
@@ -330,7 +329,7 @@ public class AirBlast extends AirAbility {
 				if (!button.isPowered()) {
 					button.setPowered(!button.isPowered());
 					block.setData(button.getData());
-	
+
 					Block supportBlock = block.getRelative(button.getAttachedFace());
 					if (supportBlock != null && supportBlock.getType() != Material.AIR) {
 						BlockState initialSupportState = supportBlock.getState();
@@ -339,13 +338,13 @@ public class AirBlast extends AirAbility {
 						supportState.update(true, false);
 						initialSupportState.update(true);
 					}
-	
+
 					final Block btBlock = block;
 					new BukkitRunnable() {
 						public void run() {
 							button.setPowered(!button.isPowered());
 							btBlock.setData(button.getData());
-	
+
 							Block supportBlock = btBlock.getRelative(button.getAttachedFace());
 							if (supportBlock != null && supportBlock.getType() != Material.AIR) {
 								BlockState initialSupportState = supportBlock.getState();
@@ -356,7 +355,7 @@ public class AirBlast extends AirAbility {
 							}
 						}
 					}.runTaskLater(ProjectKorra.plugin, 10);
-	
+
 					affectedLevers.add(block);
 				}
 			} else if ((block.getType() == Material.WOOD_BUTTON) && !affectedLevers.contains(block) && canPressButtons) {
@@ -364,7 +363,7 @@ public class AirBlast extends AirAbility {
 				if (!button.isPowered()) {
 					button.setPowered(!button.isPowered());
 					block.setData(button.getData());
-	
+
 					Block supportBlock = block.getRelative(button.getAttachedFace());
 					if (supportBlock != null && supportBlock.getType() != Material.AIR) {
 						BlockState initialSupportState = supportBlock.getState();
@@ -373,14 +372,14 @@ public class AirBlast extends AirAbility {
 						supportState.update(true, false);
 						initialSupportState.update(true);
 					}
-	
+
 					final Block btBlock = block;
-	
+
 					new BukkitRunnable() {
 						public void run() {
 							button.setPowered(!button.isPowered());
 							btBlock.setData(button.getData());
-	
+
 							Block supportBlock = btBlock.getRelative(button.getAttachedFace());
 							if (supportBlock != null && supportBlock.getType() != Material.AIR) {
 								BlockState initialSupportState = supportBlock.getState();
@@ -391,7 +390,7 @@ public class AirBlast extends AirAbility {
 							}
 						}
 					}.runTaskLater(ProjectKorra.plugin, 15);
-	
+
 					affectedLevers.add(block);
 				}
 			}
@@ -401,7 +400,7 @@ public class AirBlast extends AirAbility {
 				if (block.getData() == 0x0) {
 					new TempBlock(block, Material.OBSIDIAN, (byte) 0);
 				} else {
-					new TempBlock(block, Material.COBBLESTONE, (byte)0);
+					new TempBlock(block, Material.COBBLESTONE, (byte) 0);
 				}
 			}
 			remove();
@@ -449,37 +448,42 @@ public class AirBlast extends AirAbility {
 		}
 		return removed;
 	}
-	
+
 	private void handleDoorMechanics(Block block) {
 		boolean tDoor = false;
 		boolean open = (block.getData() & 0x4) == 0x4;
-		
+
 		if (block.getType() != Material.TRAP_DOOR) {
 			Door door = (Door) block.getState().getData();
 			BlockFace face = door.getFacing();
 			Vector toPlayer = GeneralMethods.getDirection(block.getLocation(), player.getLocation().getBlock().getLocation());
 			double[] dims = { toPlayer.getX(), toPlayer.getY(), toPlayer.getZ() };
-			
+
 			for (int i = 0; i < 3; i++) {
-				if (i == 1) continue;
+				if (i == 1)
+					continue;
 				BlockFace bf = GeneralMethods.getBlockFaceFromValue(i, dims[i]);
-				
+
 				if (bf == face) {
-					if (open) return;
+					if (open)
+						return;
 				} else if (bf.getOppositeFace() == face) {
-					if (!open) return;
+					if (!open)
+						return;
 				}
 			}
 		} else {
 			tDoor = true;
-			
+
 			if (origin.getY() < block.getY()) {
-				if (!open) return;
+				if (!open)
+					return;
 			} else {
-				if (open) return;
+				if (open)
+					return;
 			}
 		}
-		
+
 		block.setData((byte) ((block.getData() & 0x4) == 0x4 ? (block.getData() & ~0x4) : (block.getData() | 0x4)));
 		String sound = "BLOCK_WOODEN_" + (tDoor ? "TRAP" : "") + "DOOR_" + (!open ? "OPEN" : "CLOSE");
 		block.getWorld().playSound(block.getLocation(), sound, 0.5f, 0);

--- a/src/com/projectkorra/projectkorra/util/StatisticsMethods.java
+++ b/src/com/projectkorra/projectkorra/util/StatisticsMethods.java
@@ -1,10 +1,15 @@
 package com.projectkorra.projectkorra.util;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.UUID;
+
+import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.storage.DBConnection;
 
 public class StatisticsMethods {
 
@@ -64,7 +69,11 @@ public class StatisticsMethods {
 			CoreAbility ability = CoreAbility.getAbility(abilName);
 			if (ability == null) {
 				continue;
-			} else if (ability.getElement() != element) {
+			} else if (!ability.getElement().equals(element)) {
+				continue;
+			}
+			// If the ID for this statistic and ability do not equal statId, then it must be a different statistic type
+			else if (getId(statistic.getStatisticName(ability)) != statId) {
 				continue;
 			}
 			long value = getStatisticAbility(uuid, ability, statistic);
@@ -90,6 +99,10 @@ public class StatisticsMethods {
 			String abilName = getAbilityName(statId);
 			CoreAbility ability = CoreAbility.getAbility(abilName);
 			if (ability == null) {
+				continue;
+			}
+			// If the ID for this statistic and ability do not equal statId, then it must be a different statistic type
+			else if (getId(statistic.getStatisticName(ability)) != statId) {
 				continue;
 			}
 			long value = getStatisticAbility(uuid, ability, statistic);
@@ -138,6 +151,18 @@ public class StatisticsMethods {
 	 *         return -1.
 	 */
 	public static int getId(String statName) {
+		if (!ProjectKorra.statistics.getKeysByName().containsKey(statName)) {
+			DBConnection.sql.modifyQuery("INSERT INTO pk_statKeys (statName) VALUES ('" + statName + "')", false);
+			try (ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_statKeys WHERE statName = '" + statName + "'")) {
+				if (rs.next()) {
+					ProjectKorra.statistics.getKeysByName().put(rs.getString("statName"), rs.getInt("id"));
+					ProjectKorra.statistics.getKeysById().put(rs.getInt("id"), rs.getString("statName"));
+				}
+			}
+			catch (SQLException e) {
+				e.printStackTrace();
+			}
+		}
 		return ProjectKorra.statistics.getKeysByName().containsKey(statName) ? ProjectKorra.statistics.getKeysByName().get(statName) : -1;
 	}
 

--- a/src/com/projectkorra/projectkorra/util/TimeUtil.java
+++ b/src/com/projectkorra/projectkorra/util/TimeUtil.java
@@ -30,7 +30,7 @@ public class TimeUtil {
 		if (minutes > 0) {
 			formatted += String.valueOf(minutes) + "m ";
 		}
-		if (seconds > 0) {
+		if (seconds >= 0) {
 			formatted += String.valueOf(seconds) + "s";
 		}
 		return formatted;

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -376,7 +376,7 @@ public class WaterArmsWhip extends WaterAbility {
 			if (GeneralMethods.isRegionProtectedFromBuild(this, location) && grappleRespectRegions) {
 				return;
 			}
-			
+
 			Vector vector = player.getLocation().toVector().subtract(location.toVector());
 			if (!GeneralMethods.isSolid(location.clone().add(vector).multiply(1).getBlock())) {
 				return;
@@ -411,7 +411,7 @@ public class WaterArmsWhip extends WaterAbility {
 			if (hasDamaged) {
 				waterArms.setMaxPunches(waterArms.getMaxPunches() - 1);
 			}
-			
+
 			waterArms.setMaxUses(waterArms.getMaxUses() - 1);
 		}
 	}


### PR DESCRIPTION
* Fixed bug when pulling categorised statistics information resulting in mixed statistic type searches.
* Fixed bad code when storing statistics information.
* Fixed AirBlast damageEntity call not using correct AirBurst instance.
* Changed StatsCommand#getLeaderboard(...) to run asynchronously to prevent halting the server when making multiple OfflinePlayer calls.
* Fixed bug with statistic leaderboard pages.
* Fixed pk_statKeys table not generating statistic keys for foreign abilities.