### PR TITLE
remove metalbendable check for extraction

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
@@ -39,46 +39,44 @@ public class Extraction extends MetalAbility {
 		}
 
 		if (!GeneralMethods.isRegionProtectedFromBuild(this, originBlock.getLocation())) {
-			if (EarthAbility.isEarthbendable(player, "Extraction", originBlock)) {
-				Material material = originBlock.getType();
-				Material type = null;
+			Material material = originBlock.getType();
+			Material type = null;
 
-				switch (material) {
-					case IRON_ORE:
-						originBlock.setType(Material.STONE);
-						player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.IRON_INGOT, getAmount()));
-						type = Material.STONE;
-						break;
-					case GOLD_ORE:
-						originBlock.setType(Material.STONE);
-						player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.GOLD_INGOT, getAmount()));
-						type = Material.STONE;
-						break;
-					case QUARTZ_ORE:
-						originBlock.setType(Material.NETHERRACK);
-						player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.QUARTZ, getAmount()));
-						type = Material.NETHERRACK;
-						break;
-					default:
-						return;
-				}
-
-				if (type != null) {
-					/*
-					 * Update the block from Methods.movedearth to Stone
-					 * otherwise players can use RaiseEarth > Extraction >
-					 * Collapse to dupe the material from the block.
-					 */
-					if (getMovedEarth().containsKey(originBlock)) {
-						getMovedEarth().remove(originBlock);
-					}
-				}
-
-				playMetalbendingSound(originBlock.getLocation());
-				start();
-				bPlayer.addCooldown(this);
-				remove();
+			switch (material) {
+				case IRON_ORE:
+					originBlock.setType(Material.STONE);
+					player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.IRON_INGOT, getAmount()));
+					type = Material.STONE;
+					break;
+				case GOLD_ORE:
+					originBlock.setType(Material.STONE);
+					player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.GOLD_INGOT, getAmount()));
+					type = Material.STONE;
+					break;
+				case QUARTZ_ORE:
+					originBlock.setType(Material.NETHERRACK);
+					player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.QUARTZ, getAmount()));
+					type = Material.NETHERRACK;
+					break;
+				default:
+					return;
 			}
+
+			if (type != null) {
+				/*
+				* Update the block from Methods.movedearth to Stone
+				* otherwise players can use RaiseEarth > Extraction >
+				* Collapse to dupe the material from the block.
+				*/
+				if (getMovedEarth().containsKey(originBlock)) {
+					getMovedEarth().remove(originBlock);
+				}
+			}
+
+			playMetalbendingSound(originBlock.getLocation());
+			start();
+			bPlayer.addCooldown(this);
+			remove();
 		}
 
 	}


### PR DESCRIPTION
we are checking 3 specific ores hardcoded, so its not necessary to check, also by default they arent in the list anymore. Makes it possible to use extraction while not allowing the ores to be used in other moves. If you didn't want this then you would just disable the move entirely