### PR TITLE
Fixed the update checker

### DIFF
--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra;
 import java.util.HashMap;
 import java.util.logging.Logger;
 
+import com.projectkorra.projectkorra.configuration.ConfigType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Statistic;
@@ -35,163 +36,174 @@ import com.projectkorra.projectkorra.waterbending.util.WaterbendingManager;
 
 public class ProjectKorra extends JavaPlugin {
 
-	public static ProjectKorra plugin;
-	public static Logger log;
-	// public static PKLogHandler handler;
-	public static CollisionManager collisionManager;
-	public static CollisionInitializer collisionInitializer;
-	public static StatisticsManager statistics;
-	public static DBCooldownManager cooldowns;
-	public static FlightHandler flightHandler;
-	public static long time_step = 1;
-	public Updater updater;
+    public static ProjectKorra plugin;
+    public static Logger log;
+    // public static PKLogHandler handler;
+    public static CollisionManager collisionManager;
+    public static CollisionInitializer collisionInitializer;
+    public static StatisticsManager statistics;
+    public static DBCooldownManager cooldowns;
+    public static FlightHandler flightHandler;
+    public static long time_step = 1;
+    public Updater updater;
 
-	@Override
-	public void onEnable() {
-		plugin = this;
-		ProjectKorra.log = this.getLogger();
+    @Override
+    public void onEnable() {
+        plugin = this;
+        ProjectKorra.log = this.getLogger();
 
-		/*
-		 * try { File logFolder = new File(getDataFolder(), "Logs"); if
-		 * (!logFolder.exists()) { logFolder.mkdirs(); } handler = new
-		 * PKLogHandler(logFolder + File.separator + "ERROR.%g.log");
-		 * log.getParent().addHandler(handler); } catch (SecurityException |
-		 * IOException e) { e.printStackTrace(); }
-		 */
+        /*
+        try {
+            File logFolder = new File(getDataFolder(), "Logs");
+            if (!logFolder.exists()) {
+                logFolder.mkdirs();
+            }
+            handler = new PKLogHandler(logFolder + File.separator + "ERROR.%g.log");
+            log.getParent().addHandler(handler);
+        } catch (SecurityException | IOException e) {
+            e.printStackTrace();
+        }
+		*/
 
-		new ConfigManager();
-		new GeneralMethods(this);
-		updater = new Updater(this, "http://projectkorra.com/forum/forums/dev-builds.16/index.rss");
-		new Commands(this);
-		new MultiAbilityManager();
-		new ComboManager();
-		collisionManager = new CollisionManager();
-		collisionInitializer = new CollisionInitializer(collisionManager);
-		CoreAbility.registerAbilities();
-		collisionInitializer.initializeDefaultCollisions();
-		collisionManager.startCollisionDetection();
+        new ConfigManager();
+        new GeneralMethods(this);
+        boolean checkUpdateOnStartup = ConfigManager.getConfig().getBoolean("Properties.UpdateChecker");
+        updater = new Updater(this, "http://projectkorra.com/forum/resources/projectkorra-core.1/", checkUpdateOnStartup);
+        new Commands(this);
+        new MultiAbilityManager();
+        new ComboManager();
+        collisionManager = new CollisionManager();
+        collisionInitializer = new CollisionInitializer(collisionManager);
+        CoreAbility.registerAbilities();
+        collisionInitializer.initializeDefaultCollisions();
+        collisionManager.startCollisionDetection();
 
-		Preset.loadExternalPresets();
+        Preset.loadExternalPresets();
 
-		DBConnection.init();
-		if (!DBConnection.isOpen()) {
-			// Message is logged by DBConnection
-			return;
-		}
+        DBConnection.init();
+        if (!DBConnection.isOpen()) {
+            // Message is logged by DBConnection
+            return;
+        }
 
-		statistics = new StatisticsManager();
-		cooldowns = new DBCooldownManager();
-		flightHandler = new FlightHandler();
+        statistics = new StatisticsManager();
+        cooldowns = new DBCooldownManager();
+        flightHandler = new FlightHandler();
 
-		getServer().getPluginManager().registerEvents(new PKListener(this), this);
-		getServer().getScheduler().scheduleSyncRepeatingTask(this, new BendingManager(), 0, 1);
-		getServer().getScheduler().scheduleSyncRepeatingTask(this, new AirbendingManager(this), 0, 1);
-		getServer().getScheduler().scheduleSyncRepeatingTask(this, new WaterbendingManager(this), 0, 1);
-		getServer().getScheduler().scheduleSyncRepeatingTask(this, new EarthbendingManager(this), 0, 1);
-		getServer().getScheduler().scheduleSyncRepeatingTask(this, new FirebendingManager(this), 0, 1);
-		getServer().getScheduler().scheduleSyncRepeatingTask(this, new ChiblockingManager(this), 0, 1);
-		// getServer().getScheduler().scheduleSyncRepeatingTask(this, new
-		// PassiveHandler(), 0, 1);
-		getServer().getScheduler().runTaskTimerAsynchronously(this, new RevertChecker(this), 0, 200);
-		if (ConfigManager.languageConfig.get().getBoolean("Chat.Branding.AutoAnnouncer.Enabled")) {
-			getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
-				@Override
-				public void run() {
-					ChatColor color = ChatColor.valueOf(ConfigManager.languageConfig.get().getString("Chat.Branding.Color").toUpperCase());
-					color = color == null ? ChatColor.GOLD : color;
-					String topBorder = ConfigManager.languageConfig.get().getString("Chat.Branding.Borders.TopBorder");
-					String bottomBorder = ConfigManager.languageConfig.get().getString("Chat.Branding.Borders.BottomBorder");
-					if (!topBorder.isEmpty()) {
-						Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', topBorder));
-					}
-					Bukkit.broadcastMessage(color + "This server is running ProjectKorra version " + ProjectKorra.plugin.getDescription().getVersion() + " for bending! Find out more at http://www.projectkorra.com!");
-					if (!bottomBorder.isEmpty()) {
-						Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', bottomBorder));
-					}
-				}
-			}, (long) (ConfigManager.languageConfig.get().getDouble("Chat.Branding.AutoAnnouncer.Interval") * 60 * 20), (long) (ConfigManager.languageConfig.get().getDouble("Chat.Branding.AutoAnnouncer.Interval") * 60 * 20));
-		}
-		TempBlock.startReversion();
+        getServer().getPluginManager().registerEvents(new PKListener(this), this);
+        getServer().getScheduler().scheduleSyncRepeatingTask(this, new BendingManager(), 0, 1);
+        getServer().getScheduler().scheduleSyncRepeatingTask(this, new AirbendingManager(this), 0, 1);
+        getServer().getScheduler().scheduleSyncRepeatingTask(this, new WaterbendingManager(this), 0, 1);
+        getServer().getScheduler().scheduleSyncRepeatingTask(this, new EarthbendingManager(this), 0, 1);
+        getServer().getScheduler().scheduleSyncRepeatingTask(this, new FirebendingManager(this), 0, 1);
+        getServer().getScheduler().scheduleSyncRepeatingTask(this, new ChiblockingManager(this), 0, 1);
+        // getServer().getScheduler().scheduleSyncRepeatingTask(this, new
+        // PassiveHandler(), 0, 1);
+        getServer().getScheduler().runTaskTimerAsynchronously(this, new RevertChecker(this), 0, 200);
+        if (ConfigManager.languageConfig.get().getBoolean("Chat.Branding.AutoAnnouncer.Enabled")) {
+            getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
+                @Override
+                public void run() {
+                    ChatColor color = ChatColor.valueOf(ConfigManager.languageConfig.get().getString("Chat.Branding" +
+							".Color").toUpperCase());
+                    color = color == null ? ChatColor.GOLD : color;
+                    String topBorder = ConfigManager.languageConfig.get().getString("Chat.Branding.Borders.TopBorder");
+                    String bottomBorder = ConfigManager.languageConfig.get().getString("Chat.Branding.Borders" +
+							".BottomBorder");
+                    if (!topBorder.isEmpty()) {
+                        Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', topBorder));
+                    }
+                    Bukkit.broadcastMessage(color + "This server is running ProjectKorra version " + ProjectKorra
+							.plugin.getDescription().getVersion() + " for bending! Find out more at http://www" +
+							".projectkorra.com!");
+                    if (!bottomBorder.isEmpty()) {
+                        Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', bottomBorder));
+                    }
+                }
+            }, (long) (ConfigManager.languageConfig.get().getDouble("Chat.Branding.AutoAnnouncer.Interval") * 60 *
+					20), (long) (ConfigManager.languageConfig.get().getDouble("Chat.Branding.AutoAnnouncer.Interval")
+					* 60 * 20));
+        }
+        TempBlock.startReversion();
 
-		for (final Player player : Bukkit.getOnlinePlayers()) {
-			PKListener.getJumpStatistics().put(player, player.getStatistic(Statistic.JUMP));
+        for (final Player player : Bukkit.getOnlinePlayers()) {
+            PKListener.getJumpStatistics().put(player, player.getStatistic(Statistic.JUMP));
 
-			GeneralMethods.createBendingPlayer(player.getUniqueId(), player.getName());
-			GeneralMethods.removeUnusableAbilities(player.getName());
-			statistics.load(player.getUniqueId());
-			Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, new Runnable() {
-				@Override
-				public void run() {
-					PassiveManager.registerPassives(player);
-					GeneralMethods.removeUnusableAbilities(player.getName());
-				}
-			}, 5);
-		}
+            GeneralMethods.createBendingPlayer(player.getUniqueId(), player.getName());
+            GeneralMethods.removeUnusableAbilities(player.getName());
+            statistics.load(player.getUniqueId());
+            Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, new Runnable() {
+                @Override
+                public void run() {
+                    PassiveManager.registerPassives(player);
+                    GeneralMethods.removeUnusableAbilities(player.getName());
+                }
+            }, 5);
+        }
 
-		Metrics metrics = new Metrics(this);
-		metrics.addCustomChart(new Metrics.AdvancedPie("Elements") {
+        Metrics metrics = new Metrics(this);
+        metrics.addCustomChart(new Metrics.AdvancedPie("Elements") {
 
-			@Override
-			public HashMap<String, Integer> getValues(HashMap<String, Integer> valueMap) {
-				for (Element element : Element.getMainElements()) {
-					valueMap.put(element.getName(), getPlayersWithElement(element));
-				}
+            @Override
+            public HashMap<String, Integer> getValues(HashMap<String, Integer> valueMap) {
+                for (Element element : Element.getMainElements()) {
+                    valueMap.put(element.getName(), getPlayersWithElement(element));
+                }
 
-				return valueMap;
-			}
+                return valueMap;
+            }
 
-			private int getPlayersWithElement(Element element) {
-				int counter = 0;
-				for (Player player : Bukkit.getOnlinePlayers()) {
-					BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-					if (bPlayer != null && bPlayer.hasElement(element)) {
-						counter++;
-					}
-				}
+            private int getPlayersWithElement(Element element) {
+                int counter = 0;
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+                    if (bPlayer != null && bPlayer.hasElement(element)) {
+                        counter++;
+                    }
+                }
 
-				return counter;
-			}
-		});
+                return counter;
+            }
+        });
 
-		double cacheTime = ConfigManager.getConfig().getDouble("Properties.RegionProtection.CacheBlockTime");
-		if (Bukkit.getPluginManager().getPlugin("Residence") != null) {
-			FlagPermissions.addFlag(ConfigManager.defaultConfig.get().getString("Properties.RegionProtection.Residence.Flag"));
-		}
+        double cacheTime = ConfigManager.getConfig().getDouble("Properties.RegionProtection.CacheBlockTime");
+        if (Bukkit.getPluginManager().getPlugin("Residence") != null) {
+            FlagPermissions.addFlag(ConfigManager.defaultConfig.get().getString("Properties.RegionProtection.Residence.Flag"));
+        }
 
-		GeneralMethods.deserializeFile();
-		GeneralMethods.startCacheCleaner(cacheTime);
-		updater.checkUpdate();
-	}
+        GeneralMethods.deserializeFile();
+        GeneralMethods.startCacheCleaner(cacheTime);
+    }
 
-	@Override
-	public void onDisable() {
-		GeneralMethods.stopBending();
-		for (Player player : getServer().getOnlinePlayers()) {
-			statistics.save(player.getUniqueId(), false);
-			BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer != null) {
-				bPlayer.saveCooldowns();
-			}
-		}
-		if (DBConnection.isOpen()) {
-			DBConnection.sql.close();
-		}
-	}
+    @Override
+    public void onDisable() {
+        GeneralMethods.stopBending();
+        for (Player player : getServer().getOnlinePlayers()) {
+            statistics.save(player.getUniqueId(), false);
+            BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+            if (bPlayer != null) {
+                bPlayer.saveCooldowns();
+            }
+        }
+        if (DBConnection.isOpen()) {
+            DBConnection.sql.close();
+        }
+    }
 
-	public static CollisionManager getCollisionManager() {
-		return collisionManager;
-	}
+    public static CollisionManager getCollisionManager() {
+        return collisionManager;
+    }
 
-	public static void setCollisionManager(CollisionManager collisionManager) {
-		ProjectKorra.collisionManager = collisionManager;
-	}
+    public static void setCollisionManager(CollisionManager collisionManager) {
+        ProjectKorra.collisionManager = collisionManager;
+    }
 
-	public static CollisionInitializer getCollisionInitializer() {
-		return collisionInitializer;
-	}
+    public static CollisionInitializer getCollisionInitializer() {
+        return collisionInitializer;
+    }
 
-	public static void setCollisionInitializer(CollisionInitializer collisionInitializer) {
-		ProjectKorra.collisionInitializer = collisionInitializer;
-	}
+    public static void setCollisionInitializer(CollisionInitializer collisionInitializer) {
+        ProjectKorra.collisionInitializer = collisionInitializer;
+    }
 
 }

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -484,6 +484,7 @@ public class ConfigManager {
 			ArrayList<String> snowBlocks = new ArrayList<>();
 			snowBlocks.add("SNOW");
 
+			config.addDefault("Properties.UpdateChecker", true);
 			config.addDefault("Properties.BendingPreview", true);
 			config.addDefault("Properties.BendingAffectFallingSand.Normal", true);
 			config.addDefault("Properties.BendingAffectFallingSand.NormalStrengthMultiplier", 1.0);


### PR DESCRIPTION
Fixed the update checker.

Most import change: The update checker now runs async.

The update checker now sends a HTTP request to http://projectkorra.com/forum/resources/projectkorra-core.1/ to retrieve the site, and then proceeds to find the current version number on that website.

The isUpdateAvailable method now simply takes the new version number and the current version number, removes any non numeric character from it, and then checks whether the new version number is greater than the current version number or not.

At last but not least, a config option to disable the automatic update checker has been added. This option might be a bit misleading however, because the plugin still looks up the new version number, it just don't run the compare code upon startup. This is to prevent /bending check from not functioning when setting the config option to false.