### PR TITLE
Add duration and proper cooldown to WaterSpout and OctopusForm

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -924,6 +924,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.OctopusForm.Knockback", 1.75);
 			config.addDefault("Abilities.Water.OctopusForm.FormDelay", 40);
 			config.addDefault("Abilities.Water.OctopusForm.Cooldown", 0);
+			config.addDefault("Abilities.Water.OctopusForm.Duration", 0);
 			config.addDefault("Abilities.Water.OctopusForm.UsageCooldown", 0);
 			config.addDefault("Abilities.Water.OctopusForm.AngleIncrement", 45);
 
@@ -1055,6 +1056,7 @@ public class ConfigManager {
 
 			config.addDefault("Abilities.Water.WaterSpout.Enabled", true);
 			config.addDefault("Abilities.Water.WaterSpout.Cooldown", 0);
+			config.addDefault("Abilities.Water.WaterSpout.Duration", 0);
 			config.addDefault("Abilities.Water.WaterSpout.Height", 16);
 			config.addDefault("Abilities.Water.WaterSpout.Interval", 50);
 			config.addDefault("Abilities.Water.WaterSpout.BlockSpiral", true);

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -42,8 +42,10 @@ public class OctopusForm extends WaterAbility {
 	private int stepCounter;
 	private int totalStepCount;
 	private long time;
+	private long startTime;
 	private long interval;
 	private long cooldown;
+	private long duration;
 	private double attackRange;
 	private long usageCooldown;
 	private double knockback;
@@ -94,6 +96,7 @@ public class OctopusForm extends WaterAbility {
 		this.knockback = getConfig().getDouble("Abilities.Water.OctopusForm.Knockback");
 		this.radius = getConfig().getDouble("Abilities.Water.OctopusForm.Radius");
 		this.cooldown = getConfig().getLong("Abilities.Water.OctopusForm.Cooldown");
+		this.duration = getConfig().getLong("Abilities.Water.OctopusForm.Duration");
 		this.angleIncrement = getConfig().getDouble("Abilities.Water.OctopusForm.AngleIncrement");
 		this.currentFormHeight = 0;
 		this.blocks = new ArrayList<TempBlock>();
@@ -111,6 +114,7 @@ public class OctopusForm extends WaterAbility {
 			this.radius = getConfig().getDouble("Abilities.Avatar.AvatarState.Water.OctopusForm.Radius");
 		}
 		this.time = System.currentTimeMillis();
+		this.startTime = System.currentTimeMillis();
 		if (!player.isSneaking()) {
 			this.sourceBlock = BlockSource.getWaterSourceBlock(player, range, ClickType.LEFT_CLICK, true, true, bPlayer.canPlantbend());
 		}
@@ -126,18 +130,15 @@ public class OctopusForm extends WaterAbility {
 		if (sourceSelected) {
 			sourceSelected = false;
 			settingUp = true;
-			bPlayer.addCooldown(this);
 		} else if (settingUp) {
 			settingUp = false;
 			forming = true;
 		} else if (forming) {
 			forming = false;
 			formed = true;
-			bPlayer.addCooldown(this);
 		}
 	}
 
-	@SuppressWarnings("deprecation")
 	public static void form(Player player) {
 		OctopusForm oldForm = getAbility(player, OctopusForm.class);
 
@@ -221,6 +222,10 @@ public class OctopusForm extends WaterAbility {
 			remove();
 			return;
 		} else if (sourceBlock.getLocation().distanceSquared(player.getLocation()) > range * range && sourceSelected) {
+			remove();
+			return;
+		} else if (this.duration != 0 && System.currentTimeMillis() > this.startTime + this.duration) {
+			bPlayer.addCooldown(this);
 			remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
@@ -16,6 +16,7 @@ import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
+import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.util.ParticleEffect;
 import com.projectkorra.projectkorra.util.TempBlock;
 
@@ -30,6 +31,10 @@ public class WaterSpout extends WaterAbility {
 	private int angle;
 	private long time;
 	private long interval;
+	@Attribute(Attribute.COOLDOWN)
+	private long cooldown;
+	private long duration;
+	private long startTime;
 	private double rotation;
 	private double height;
 	private double maxHeight;
@@ -48,8 +53,11 @@ public class WaterSpout extends WaterAbility {
 		this.canBendOnPackedIce = getConfig().getStringList("Properties.Water.IceBlocks").contains(Material.PACKED_ICE.toString());
 		this.useParticles = getConfig().getBoolean("Abilities.Water.WaterSpout.Particles");
 		this.useBlockSpiral = getConfig().getBoolean("Abilities.Water.WaterSpout.BlockSpiral");
+		this.cooldown = getConfig().getLong("Abilities.Water.WaterSpout.Cooldown");
 		this.height = getConfig().getDouble("Abilities.Water.WaterSpout.Height");
 		this.interval = getConfig().getLong("Abilities.Water.WaterSpout.Interval");
+		this.duration = getConfig().getLong("Abilities.Water.WaterSpout.Duration");
+		this.startTime = System.currentTimeMillis();
 
 		maxHeight = getNightFactor(height);
 		WaterSpoutWave spoutWave = new WaterSpoutWave(player, WaterSpoutWave.AbilityType.CLICK);
@@ -115,6 +123,10 @@ public class WaterSpout extends WaterAbility {
 		if (player.isDead() || !player.isOnline() || !bPlayer.canBendIgnoreBindsCooldowns(this)) {
 			remove();
 			return;
+		} else if (this.duration != 0 && System.currentTimeMillis() > this.startTime + this.duration) {
+			bPlayer.addCooldown(this);
+			remove();
+			return;
 		} else {
 			blocks.clear();
 			player.setFallDistance(0);
@@ -133,6 +145,7 @@ public class WaterSpout extends WaterAbility {
 				location = base.getLocation();
 				double heightRemoveThreshold = 2;
 				if (!isWithinMaxSpoutHeight(location, heightRemoveThreshold)) {
+					bPlayer.addCooldown(this);
 					remove();
 					return;
 				}
@@ -155,6 +168,7 @@ public class WaterSpout extends WaterAbility {
 					player.setFlying(true);
 				}
 			} else {
+				bPlayer.addCooldown(this);
 				remove();
 				return;
 			}
@@ -319,7 +333,7 @@ public class WaterSpout extends WaterAbility {
 
 	@Override
 	public long getCooldown() {
-		return 0;
+		return this.cooldown;
 	}
 
 	@Override


### PR DESCRIPTION
## Additions
* Adds duration to OctopusForm and WaterSpout, defaults to 0 which results in infinite usage.

## Fixes
* Fixes OctopusForm adding the cooldown immediately after creation.
* Fixes WaterSpout not reading/adding its cooldown correctly.
