### PR TITLE
Update HealingWaters

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -884,7 +884,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.HealingWaters.Interval", 750);
 			config.addDefault("Abilities.Water.HealingWaters.ChargeTime", 1000);
 			config.addDefault("Abilities.Water.HealingWaters.Power", 1);
-			config.addDefault("Abilities.Water.HealingWaters.Duration", 70);
+			config.addDefault("Abilities.Water.HealingWaters.HealingDuration", 70);
+			config.addDefault("Abilities.Water.HealingWaters.Duration, 10000)
 			config.addDefault("Abilities.Water.HealingWaters.EnableParticles", true);
 
 			config.addDefault("Abilities.Water.IceBlast.Enabled", true);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -885,7 +885,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.HealingWaters.ChargeTime", 1000);
 			config.addDefault("Abilities.Water.HealingWaters.Power", 1);
 			config.addDefault("Abilities.Water.HealingWaters.HealingDuration", 70);
-			config.addDefault("Abilities.Water.HealingWaters.Duration, 10000)
+			config.addDefault("Abilities.Water.HealingWaters.Duration", 0)
 			config.addDefault("Abilities.Water.HealingWaters.EnableParticles", true);
 
 			config.addDefault("Abilities.Water.IceBlast.Enabled", true);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -885,7 +885,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.HealingWaters.ChargeTime", 1000);
 			config.addDefault("Abilities.Water.HealingWaters.Power", 1);
 			config.addDefault("Abilities.Water.HealingWaters.HealingDuration", 70);
-			config.addDefault("Abilities.Water.HealingWaters.Duration", 0)
+			config.addDefault("Abilities.Water.HealingWaters.Duration", 0);
 			config.addDefault("Abilities.Water.HealingWaters.EnableParticles", true);
 
 			config.addDefault("Abilities.Water.IceBlast.Enabled", true);

--- a/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
+++ b/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
@@ -80,7 +80,7 @@ public class HealingWaters extends HealingAbility {
 		chargeTime = getConfig().getLong("Abilities.Water.HealingWaters.ChargeTime");
 		power = getConfig().getInt("Abilities.Water.HealingWaters.Power");
 		potDuration = getConfig().getInt("Abilities.Water.HealingWaters.HealingDuration");
-		duration = getConfig().getInt("Abilities.Water.HealingWaters.Duration");
+		duration = getConfig().getLong("Abilities.Water.HealingWaters.Duration");
 		enableParticles = getConfig().getBoolean("Abilities.Water.HealingWaters.EnableParticles");
 		hex = "00ffff";
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
+++ b/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
@@ -93,10 +93,12 @@ public class HealingWaters extends HealingAbility {
 			return;
 		}
 		
-		if (System.getCurrentTimeMillis() >= getStartTime() + duration) {
-			bPlayer.addCooldown(this);
-			remove();
-			return;
+		if(duration != 0) {
+			if (System.getCurrentTimeMillis() >= getStartTime() + duration) {
+				bPlayer.addCooldown(this);
+				remove();
+				return;
+			}
 		}
 
 		if (!player.isSneaking()) {

--- a/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
+++ b/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
@@ -94,7 +94,7 @@ public class HealingWaters extends HealingAbility {
 		}
 		
 		if(duration != 0) {
-			if (System.getCurrentTimeMillis() >= getStartTime() + duration) {
+			if (System.currentTimeMillis() >= getStartTime() + duration) {
 				bPlayer.addCooldown(this);
 				remove();
 				return;

--- a/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
+++ b/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
@@ -31,7 +31,8 @@ public class HealingWaters extends HealingAbility {
 	private long interval;
 	private long chargeTime;
 	private int power;
-	private int duration;
+	private int potDuration;
+	private long duration;
 	private boolean enableParticles;
 
 	// Instance related and predefined variables.
@@ -78,6 +79,7 @@ public class HealingWaters extends HealingAbility {
 		interval = getConfig().getLong("Abilities.Water.HealingWaters.Interval");
 		chargeTime = getConfig().getLong("Abilities.Water.HealingWaters.ChargeTime");
 		power = getConfig().getInt("Abilities.Water.HealingWaters.Power");
+		potDuration = getConfig().getInt("Abilities.Water.HealingWaters.HealingDuration");
 		duration = getConfig().getInt("Abilities.Water.HealingWaters.Duration");
 		enableParticles = getConfig().getBoolean("Abilities.Water.HealingWaters.EnableParticles");
 		hex = "00ffff";
@@ -87,6 +89,12 @@ public class HealingWaters extends HealingAbility {
 	public void progress() {
 
 		if (!bPlayer.canBend(this)) {
+			remove();
+			return;
+		}
+		
+		if (System.getCurrentTimeMillis() >= getStartTime() + duration) {
+			bPlayer.addCooldown(this);
 			remove();
 			return;
 		}
@@ -202,7 +210,7 @@ public class HealingWaters extends HealingAbility {
 
 	private void applyHealing(Player player) {
 		if (!GeneralMethods.isRegionProtectedFromBuild(player, "HealingWaters", player.getLocation())) {
-			player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, duration, power));
+			player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, potDuration, power));
 			AirAbility.breakBreathbendingHold(player);
 			healing = true;
 			healingSelf = true;
@@ -211,7 +219,7 @@ public class HealingWaters extends HealingAbility {
 
 	private void applyHealing(LivingEntity livingEntity) {
 		if (livingEntity.getHealth() < livingEntity.getMaxHealth()) {
-			livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, duration, power));
+			livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, potDuration, power));
 			AirAbility.breakBreathbendingHold(livingEntity);
 			healing = true;
 			healingSelf = false;


### PR DESCRIPTION
## Additions
* Adds a duration value to HealingWaters that is accurately represented by its name.
## Misc. Changes
* Changes HealingWaters previous duration value to a PotionDuration in order to accurately represent what the setting represents.
