### PR TITLE
Add cooldown ignore perm, change collisions, fix fly glitches in FlightHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.projectkorra</groupId>
   <artifactId>projectkorra</artifactId>
-  <version>1.8.6</version>
+  <version>1.8.7</version>
   <packaging>jar</packaging>
   <name>ProjectKorra</name>
 

--- a/src/com/projectkorra/projectkorra/ability/util/CollisionInitializer.java
+++ b/src/com/projectkorra/projectkorra/ability/util/CollisionInitializer.java
@@ -67,6 +67,7 @@ public class CollisionInitializer {
 	private ArrayList<CoreAbility> largeAbilities;
 	private ArrayList<CoreAbility> comboAbilities;
 	private ArrayList<CoreAbility> removeSpoutAbilities;
+	private ArrayList<CoreAbility> ignoreAbilities;
 
 	public CollisionInitializer(CollisionManager collisionManager) {
 		this.collisionManager = collisionManager;
@@ -74,9 +75,9 @@ public class CollisionInitializer {
 		this.comboAbilities = new ArrayList<>();
 		this.largeAbilities = new ArrayList<>();
 		this.removeSpoutAbilities = new ArrayList<>();
+		this.ignoreAbilities = new ArrayList<>();
 	}
 
-	@SuppressWarnings("unused")
 	public void initializeDefaultCollisions() {
 		CoreAbility airBlast = CoreAbility.getAbility(AirBlast.class);
 		CoreAbility airBurst = CoreAbility.getAbility(AirBurst.class);
@@ -131,10 +132,11 @@ public class CollisionInitializer {
 		CoreAbility waterSpout = CoreAbility.getAbility(WaterSpout.class);
 		CoreAbility waterSpoutWave = CoreAbility.getAbility(WaterSpoutWave.class);
 
-		CoreAbility[] smallAbils = { airSwipe, earthBlast, waterManipulation, iceBlast, iceSpikeBlast, fireBlast, combustion, blazeArc };
+		CoreAbility[] smallAbils = { airSwipe, earthBlast, waterManipulation, iceBlast, iceSpikeBlast, fireBlast };
 		CoreAbility[] largeAbils = { earthSmash, airShield, fireBlastCharged, fireKick, fireSpin, fireWheel, airSweep, iceBullet };
 		CoreAbility[] comboAbils = { fireKick, fireSpin, fireWheel, airSweep, iceBullet };
 		CoreAbility[] removeSpoutAbils = { airSwipe, earthBlast, waterManipulation, iceBlast, iceSpikeBlast, fireBlast, fireBlastCharged, earthSmash, fireKick, fireSpin, fireWheel, airSweep, iceBullet };
+		CoreAbility[] ignoreAbils = { airBlast, airSuction, blazeArc, combustion };
 
 		for (CoreAbility smallAbil : smallAbils) {
 			addSmallAbility(smallAbil);
@@ -148,22 +150,24 @@ public class CollisionInitializer {
 		for (CoreAbility removeSpoutAbil : removeSpoutAbils) {
 			addRemoveSpoutAbility(removeSpoutAbil);
 		}
-
-		collisionManager.addCollision(new Collision(airShield, airBlast, false, true));
-		collisionManager.addCollision(new Collision(airShield, airSuction, false, true));
-		collisionManager.addCollision(new Collision(airShield, airStream, false, true));
-
-		collisionManager.addCollision(new Collision(airShield, airSwipe, false, false));
-		collisionManager.addCollision(new Collision(airShield, airSweep, false, false));
-
+		for (CoreAbility ignoreAbil : ignoreAbils) {
+			addIgnoreAbility(ignoreAbil);
+		}
 		for (CoreAbility comboAbil : comboAbils) {
 			collisionManager.addCollision(new Collision(airShield, comboAbil, false, true));
 		}
-
-		collisionManager.addCollision(new Collision(fireShield, airBlast, false, true));
-		collisionManager.addCollision(new Collision(fireShield, airSuction, false, true));
+		
+		collisionManager.addCollision(new Collision(airSwipe, airSwipe, false, false));
+		
+		collisionManager.addCollision(new Collision(airShield, airSwipe, false, false));
+		collisionManager.addCollision(new Collision(airShield, airSweep, false, false));
+		collisionManager.addCollision(new Collision(airShield, fireBlastCharged, false, false));
+		collisionManager.addCollision(new Collision(airShield, airStream, false, true));
+		
+		collisionManager.addCollision(new Collision(airSweep, airSweep, false, false));
+		
+		collisionManager.addCollision(new Collision(fireShield, fireBlastCharged, false, false));
 		collisionManager.addCollision(new Collision(fireShield, fireBlast, false, true));
-		collisionManager.addCollision(new Collision(fireShield, fireBlastCharged, false, true));
 		collisionManager.addCollision(new Collision(fireShield, waterManipulation, false, true));
 		collisionManager.addCollision(new Collision(fireShield, earthBlast, false, true));
 		collisionManager.addCollision(new Collision(fireShield, airSweep, false, true));
@@ -245,6 +249,30 @@ public class CollisionInitializer {
 		removeSpoutAbilities.add(ability);
 		collisionManager.addCollision(new Collision(ability, CoreAbility.getAbility(AirSpout.class), false, true));
 		collisionManager.addCollision(new Collision(ability, CoreAbility.getAbility(WaterSpout.class), false, true));
+	}
+
+	/**
+	 * An ability that collides with other small abilities. (EarthBlast,
+	 * FireBlast). Two colliding small abilities will remove each other. A small
+	 * ability is removed when it collides with a large ability.
+	 * 
+	 * @param smallAbility the small CoreAbility
+	 */
+	public void addIgnoreAbility(CoreAbility ignoreAbility) {
+		if (ignoreAbility == null) {
+			return;
+		}
+		ignoreAbilities.add(ignoreAbility);
+		for (CoreAbility smallAbility : smallAbilities) {
+			collisionManager.addCollision(new Collision(ignoreAbility, smallAbility, false, false));
+		}
+
+		for (CoreAbility largeAbility : largeAbilities) {
+			collisionManager.addCollision(new Collision(largeAbility, ignoreAbility, false, false));
+		}
+
+		collisionManager.addCollision(new Collision(ignoreAbility, CoreAbility.getAbility(AirSpout.class), false, false));
+		collisionManager.addCollision(new Collision(ignoreAbility, CoreAbility.getAbility(WaterSpout.class), false, false));
 	}
 
 	public CollisionManager getCollisionManager() {

--- a/src/com/projectkorra/projectkorra/ability/util/CollisionManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/CollisionManager.java
@@ -190,6 +190,15 @@ public class CollisionManager {
 		if (collision == null || collision.getAbilityFirst() == null || collision.getAbilitySecond() == null) {
 			return;
 		}
+
+		for (int x = 0; x < collisions.size(); x++) {
+			if (collisions.get(x).getAbilityFirst().equals(collision.getAbilityFirst())) {
+				if (collisions.get(x).getAbilitySecond().equals(collision.getAbilitySecond())) {
+					collisions.remove(x);
+				}
+			}
+		}
+
 		collisions.add(collision);
 	}
 

--- a/src/com/projectkorra/projectkorra/command/ChooseCommand.java
+++ b/src/com/projectkorra/projectkorra/command/ChooseCommand.java
@@ -85,11 +85,21 @@ public class ChooseCommand extends PKCommand {
 				if (!hasPermission(sender, element)) {
 					return;
 				}
-				if (bPlayer.isOnCooldown("ChooseElement") && !sender.hasPermission("bending.admin.choose")) {
-					GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + onCooldown.replace("%cooldown%", TimeUtil.formatTime(bPlayer.getCooldown("ChooseElement") - System.currentTimeMillis())));
+				if (bPlayer.isOnCooldown("ChooseElement")) {
+					if (sender.hasPermission("bending.choose.ignorecooldown") || sender.hasPermission("bending.admin.choose")) {
+						bPlayer.removeCooldown("ChooseElement");
+					} else {
+						GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + onCooldown.replace("%cooldown%", TimeUtil.formatTime(bPlayer.getCooldown("ChooseElement") - System.currentTimeMillis())));
+						return;
+					}
+				}
+
+				add(sender, (Player) sender, targetElement);
+
+				if (sender.hasPermission("bending.choose.ignorecooldown") || sender.hasPermission("bending.admin.choose")) {
 					return;
 				}
-				add(sender, (Player) sender, targetElement);
+
 				bPlayer.addCooldown("ChooseElement", cooldown, true);
 				return;
 			} else {
@@ -120,6 +130,14 @@ public class ChooseCommand extends PKCommand {
 			Element targetElement = Element.getElement(element);
 			if (Arrays.asList(Element.getAllElements()).contains(targetElement) && targetElement != Element.AVATAR) {
 				add(sender, target, targetElement);
+
+				if (target.hasPermission("bending.choose.ignorecooldown") || target.hasPermission("bending.admin.choose")) {
+					return;
+				}
+
+				BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(target);
+				bPlayer.addCooldown("ChooseElement", cooldown, true);
+
 				return;
 			} else {
 				GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + invalidElement);

--- a/src/com/projectkorra/projectkorra/util/FlightHandler.java
+++ b/src/com/projectkorra/projectkorra/util/FlightHandler.java
@@ -91,14 +91,15 @@ public class FlightHandler {
 				CLEANUP.add(ability);
 			}
 			flight.abilities.put(identifier, ability);
+		} else {
+			Flight flight = new Flight(player, source);
+			FlightAbility ability = new FlightAbility(player, identifier, duration);
+			if (duration != Flight.PERMANENT) {
+				CLEANUP.add(ability);
+			}
+			flight.abilities.put(identifier, ability);
+			INSTANCES.put(player.getUniqueId(), flight);
 		}
-		Flight flight = new Flight(player, source);
-		FlightAbility ability = new FlightAbility(player, identifier, duration);
-		if (duration != Flight.PERMANENT) {
-			CLEANUP.add(ability);
-		}
-		flight.abilities.put(identifier, ability);
-		INSTANCES.put(player.getUniqueId(), flight);
 	}
 
 	/**
@@ -198,7 +199,6 @@ public class FlightHandler {
 		public String toString() {
 			return "Flight{player=" + player.getName() + ",source=" + (source != null ? source.getName() : "null") + ",couldFly=" + couldFly + ",wasFlying=" + wasFlying + ",abilities=" + abilities + "}";
 		}
-
 	}
 
 	public static class FlightAbility {

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -20,6 +20,7 @@ permissions:
       bending.command.add: true
       bending.command.rechoose: true
       bending.admin.choose: true
+      bending.choose.ignorecooldown: true
       bending.ability.AvatarState: true
       bending.water.bloodbending.anytime: true
       bending.water.bloodbending: true


### PR DESCRIPTION
Bumped version from 1.8.6 to 1.8.7

## Additions
* Adds `bending.choose.ignorecooldown`
    > * Allows the player in question to bypass the choose command cooldown if it is enabled
* Adds overriding capabilities to CollisionManager
    > * Redefining an existing collision will override the pre-existing one
* Adds ignoreAbils array to CollisionInitializer.
    > * Abilities in this array will not collide with any Abilties

## Fixes
* Fixes FlightHandler issues causing fly glitches
* Fixes choose command cooldown being applied to players even if they can bypass it with `bending.admin.choose`