### PR TITLE
Change AirSweep and FireJet + Lightning

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -81,6 +81,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MainHand;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -1105,6 +1106,16 @@ public class GeneralMethods {
 	public static Location getRightSide(final Location location, final double distance) {
 		final float angle = location.getYaw() / 60;
 		return location.clone().subtract(new Vector(Math.cos(angle), 0, Math.sin(angle)).normalize().multiply(distance));
+	}
+
+	public static Location getMainHandLocation(final Player player) {
+		Location loc;
+		if (player.getMainHand() == MainHand.LEFT) {
+			loc = GeneralMethods.getLeftSide(player.getLocation(), .55).add(0, 1.2, 0);
+		} else {
+			loc = GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0);
+		}
+		return loc;
 	}
 
 	public static Plugin getProbending() {

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -77,7 +77,7 @@ public class AirSwipe extends AirAbility {
 		}
 
 		this.charging = charging;
-		this.origin = GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0);
+		this.origin = GeneralMethods.getMainHandLocation(player);
 		this.particles = getConfig().getInt("Abilities.Air.AirSwipe.Particles");
 		this.arc = getConfig().getInt("Abilities.Air.AirSwipe.Arc");
 		this.arcIncrement = getConfig().getInt("Abilities.Air.AirSwipe.StepSize");

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -77,7 +77,7 @@ public class AirSwipe extends AirAbility {
 		}
 
 		this.charging = charging;
-		this.origin = player.getEyeLocation();
+		this.origin = GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0);
 		this.particles = getConfig().getInt("Abilities.Air.AirSwipe.Particles");
 		this.arc = getConfig().getInt("Abilities.Air.AirSwipe.Arc");
 		this.arcIncrement = getConfig().getInt("Abilities.Air.AirSwipe.StepSize");

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -132,22 +132,22 @@ public class AirSweep extends AirAbility implements ComboAbility {
 
 		if (this.origin == null) {
 			this.direction = this.player.getEyeLocation().getDirection().normalize();
-			this.origin = GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0).add(this.direction.clone().multiply(10));
+			this.origin = GeneralMethods.getMainHandLocation(player).add(this.direction.clone().multiply(10));
 		}
 		if (this.progressCounter < 8) {
 			return;
 		}
 		if (this.destination == null) {
-			this.destination = GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0).add(GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0).getDirection().normalize().multiply(10));
+			this.destination = GeneralMethods.getMainHandLocation(player).add(GeneralMethods.getMainHandLocation(player).getDirection().normalize().multiply(10));
 			final Vector origToDest = GeneralMethods.getDirection(this.origin, this.destination);
 			for (double i = 0; i < 30; i++) {
 				final Location endLoc = this.origin.clone().add(origToDest.clone().multiply(i / 30));
-				if (GeneralMethods.locationEqualsIgnoreDirection(GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0), endLoc)) {
+				if (GeneralMethods.locationEqualsIgnoreDirection(GeneralMethods.getMainHandLocation(player), endLoc)) {
 					continue;
 				}
-				final Vector vec = GeneralMethods.getDirection(GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0), endLoc);
+				final Vector vec = GeneralMethods.getDirection(GeneralMethods.getMainHandLocation(player), endLoc);
 
-				final FireComboStream fs = new FireComboStream(this.player, this, vec, GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0), this.range, this.speed);
+				final FireComboStream fs = new FireComboStream(this.player, this, vec, GeneralMethods.getMainHandLocation(player), this.range, this.speed);
 				fs.setDensity(1);
 				fs.setSpread(0F);
 				fs.setUseNewParticles(true);

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -140,14 +140,15 @@ public class AirSweep extends AirAbility implements ComboAbility {
 		if (this.destination == null) {
 			this.destination = GeneralMethods.getMainHandLocation(player).add(GeneralMethods.getMainHandLocation(player).getDirection().normalize().multiply(10));
 			final Vector origToDest = GeneralMethods.getDirection(this.origin, this.destination);
+			final Location hand = GeneralMethods.getMainHandLocation(player);
 			for (double i = 0; i < 30; i++) {
 				final Location endLoc = this.origin.clone().add(origToDest.clone().multiply(i / 30));
-				if (GeneralMethods.locationEqualsIgnoreDirection(GeneralMethods.getMainHandLocation(player), endLoc)) {
+				if (GeneralMethods.locationEqualsIgnoreDirection(hand, endLoc)) {
 					continue;
 				}
-				final Vector vec = GeneralMethods.getDirection(GeneralMethods.getMainHandLocation(player), endLoc);
+				final Vector vec = GeneralMethods.getDirection(hand, endLoc);
 
-				final FireComboStream fs = new FireComboStream(this.player, this, vec, GeneralMethods.getMainHandLocation(player), this.range, this.speed);
+				final FireComboStream fs = new FireComboStream(this.player, this, vec, hand, this.range, this.speed);
 				fs.setDensity(1);
 				fs.setSpread(0F);
 				fs.setUseNewParticles(true);
@@ -203,11 +204,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 							this.affectedEntities.add(entity);
 							if (this.damage != 0) {
 								if (entity instanceof LivingEntity) {
-									if (fstream.getAbility().getName().equalsIgnoreCase("AirSweep")) {
-										DamageHandler.damageEntity(entity, this.damage, this);
-									} else {
-										DamageHandler.damageEntity(entity, this.damage, this);
-									}
+									DamageHandler.damageEntity(entity, this.damage, this);
 								}
 							}
 						}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.airbending.combo;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.projectkorra.projectkorra.object.HorizontalVelocityTracker;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -131,22 +132,22 @@ public class AirSweep extends AirAbility implements ComboAbility {
 
 		if (this.origin == null) {
 			this.direction = this.player.getEyeLocation().getDirection().normalize();
-			this.origin = this.player.getLocation().add(this.direction.clone().multiply(10));
+			this.origin = GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0).add(this.direction.clone().multiply(10));
 		}
 		if (this.progressCounter < 8) {
 			return;
 		}
 		if (this.destination == null) {
-			this.destination = this.player.getLocation().add(this.player.getEyeLocation().getDirection().normalize().multiply(10));
+			this.destination = GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0).add(GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0).getDirection().normalize().multiply(10));
 			final Vector origToDest = GeneralMethods.getDirection(this.origin, this.destination);
 			for (double i = 0; i < 30; i++) {
 				final Location endLoc = this.origin.clone().add(origToDest.clone().multiply(i / 30));
-				if (GeneralMethods.locationEqualsIgnoreDirection(this.player.getLocation(), endLoc)) {
+				if (GeneralMethods.locationEqualsIgnoreDirection(GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0), endLoc)) {
 					continue;
 				}
-				final Vector vec = GeneralMethods.getDirection(this.player.getLocation(), endLoc);
+				final Vector vec = GeneralMethods.getDirection(GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0), endLoc);
 
-				final FireComboStream fs = new FireComboStream(this.player, this, vec, this.player.getLocation(), this.range, this.speed);
+				final FireComboStream fs = new FireComboStream(this.player, this, vec, GeneralMethods.getRightSide(player.getLocation(), .55).add(0, 1.2, 0), this.range, this.speed);
 				fs.setDensity(1);
 				fs.setSpread(0F);
 				fs.setUseNewParticles(true);
@@ -191,18 +192,22 @@ public class AirSweep extends AirAbility implements ComboAbility {
 						this.remove();
 						return;
 					}
-					if (!entity.equals(this.player) && !this.affectedEntities.contains(entity) && !(entity instanceof Player && Commands.invincible.contains(((Player) entity).getName()))) {
-						this.affectedEntities.add(entity);
+					if (!entity.equals(this.player) && !(entity instanceof Player && Commands.invincible.contains(((Player) entity).getName()))) {
 						if (this.knockback != 0) {
-							final Vector force = fstream.getDirection();
-							entity.setVelocity(force.multiply(this.knockback));
+							final Vector force = fstream.getLocation().getDirection();
+							GeneralMethods.setVelocity(entity, force.clone().multiply(this.knockback));
+							new HorizontalVelocityTracker(entity, this.player, 200l, this);
+							entity.setFallDistance(0);
 						}
-						if (this.damage != 0) {
-							if (entity instanceof LivingEntity) {
-								if (fstream.getAbility().getName().equalsIgnoreCase("AirSweep")) {
-									DamageHandler.damageEntity(entity, this.damage, this);
-								} else {
-									DamageHandler.damageEntity(entity, this.damage, this);
+						if(!this.affectedEntities.contains(entity)) {
+							this.affectedEntities.add(entity);
+							if (this.damage != 0) {
+								if (entity instanceof LivingEntity) {
+									if (fstream.getAbility().getName().equalsIgnoreCase("AirSweep")) {
+										DamageHandler.damageEntity(entity, this.damage, this);
+									} else {
+										DamageHandler.damageEntity(entity, this.damage, this);
+									}
 								}
 							}
 						}

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -3,6 +3,8 @@ package com.projectkorra.projectkorra.firebending.lightning;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.firebending.FireJet;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -179,6 +181,9 @@ public class Lightning extends LightningAbility {
 			return;
 		} else if (!this.bPlayer.canBendIgnoreCooldowns(this)) {
 			this.remove();
+			return;
+		} else if (CoreAbility.hasAbility(player, FireJet.class)){
+			this.removeWithTasks();
 			return;
 		}
 


### PR DESCRIPTION
## Additions
* Adds HorizontalVelocityTracker to AirSweep
* Adds `GeneralMethods#getMainHandLocation(final Player player)`

## Changes
* Changed AirSweep and AirSwipe to originate from a Player's main hand location
* Changed the knockback caused by AirSweep more consistent in the air and on the ground
* Disable Lightning use when using FireJet