### PR TITLE
Fix cooldowns of fire abilities with a duration, getClosestEntity, and Surge Wall diagonal check

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -872,17 +872,17 @@ public class GeneralMethods {
 	 */
 	public static Entity getClosestEntity(Location center, double radius) {
 		Entity found = null;
-		double distance = radius * radius;
+		Double distance = null;
 		
 		for (Entity entity : GeneralMethods.getEntitiesAroundPoint(center, radius)) {
-			double check = center.distance(entity.getLocation());
+			double check = center.distanceSquared(entity.getLocation());
 			
-			if (check < distance) {
+			if (distance == null || check < distance) {
 				found = entity;
 				distance = check;
 			}
 		}
-		
+
 		return found;
 	}
 	
@@ -894,12 +894,12 @@ public class GeneralMethods {
 	 */
 	public static LivingEntity getClosestLivingEntity(Location center, double radius) {
 		LivingEntity le = null;
-		double distance = radius * radius;
+		Double distance = null;
 		
 		for (Entity entity : GeneralMethods.getEntitiesAroundPoint(center, radius)) {
-			double check = center.distance(entity.getLocation());
+			double check = center.distanceSquared(entity.getLocation());
 			
-			if (entity instanceof LivingEntity && check < distance) {
+			if (entity instanceof LivingEntity && (distance == null || check < distance)) {
 				le = (LivingEntity) entity;
 				distance = check;
 			}

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -77,7 +77,6 @@ public class FireJet extends FireAbility {
 				this.previousGlidingState = player.isGliding();
 				player.setGliding(true);
 			}
-			this.bPlayer.addCooldown(this);
 		}
 	}
 
@@ -118,6 +117,7 @@ public class FireJet extends FireAbility {
 		}
 		this.flightHandler.removeInstance(this.player, this.getName());
 		this.player.setFallDistance(0);
+		this.bPlayer.addCooldown(this);
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -102,7 +102,6 @@ public class WallOfFire extends FireAbility {
 
 		this.initializeBlocks();
 		this.start();
-		this.bPlayer.addCooldown(this);
 	}
 
 	private void affect(final Entity entity) {
@@ -208,6 +207,12 @@ public class WallOfFire extends FireAbility {
 			this.damageTick++;
 			this.damage();
 		}
+	}
+
+	@Override
+	public void remove() {
+		super.remove();
+		this.bPlayer.addCooldown(this);
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
@@ -79,7 +79,6 @@ public class JetBlast extends FireAbility implements ComboAbility {
 					return;
 				}
 
-				this.bPlayer.addCooldown("JetBlast", this.cooldown);
 				this.firstTime = false;
 				final float spread = 0F;
 				ParticleEffect.EXPLOSION_LARGE.display(this.player.getLocation(), 1, spread, spread, spread, 0);
@@ -106,6 +105,7 @@ public class JetBlast extends FireAbility implements ComboAbility {
 			task.remove();
 		}
 		super.remove();
+		this.bPlayer.addCooldown("JetBlast", this.cooldown);
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
@@ -88,7 +88,6 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 				this.remove();
 				return;
 			}
-			this.bPlayer.addCooldown("JetBlaze", this.cooldown);
 			this.firstTime = false;
 		} else if (System.currentTimeMillis() - this.time > this.duration) {
 			this.remove();
@@ -121,6 +120,7 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 			task.remove();
 		}
 		super.remove();
+		this.bPlayer.addCooldown("JetBlaze", this.cooldown);
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
@@ -103,7 +103,7 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 			fs.setDensity(8);
 			fs.setSpread(1.0F);
 			fs.setUseNewParticles(true);
-			fs.setCollisionRadius(3);
+			fs.setCollisionRadius(2);
 			fs.setParticleEffect(ParticleEffect.SMOKE_LARGE);
 			fs.setDamage(this.damage);
 			fs.setFireTicks(this.fireTicks);

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -255,12 +255,11 @@ public class SurgeWall extends WaterAbility {
 				}
 
 				final ArrayList<Block> blocks = new ArrayList<Block>();
-				final Location targetLoc = GeneralMethods.getTargetedLocation(this.player, (int) this.range, Material.WATER, Material.ICE);
+				final Location targetLoc = GeneralMethods.getTargetedLocation(this.player, (int) this.range, false, false, Material.WATER, Material.ICE);
 				this.location = targetLoc.clone();
 				final Vector eyeDir = this.player.getEyeLocation().getDirection();
 				Vector vector;
 				Block block;
-
 				for (double i = 0; i <= this.getNightFactor(this.radius); i += 0.5) {
 					for (double angle = 0; angle < 360; angle += 10) {
 						vector = GeneralMethods.getOrthogonalVector(eyeDir.clone(), angle, i);


### PR DESCRIPTION
## Fixes
* Fixes getClosestEntity to not rely on a distance check for if the entity is returned, but instead purely get the closest entity from getEntitiesAroundPoint
* Fixes SurgeWall to not do that new diagonal check, fixes Ice wall glitching out

## Misc. Changes
* Changes JetBlaze hitbox size, was way too big
* Changes FireJet, WallOfFire, and the FireJet Combos cooldowns to activate when the move completes