### PR TITLE
AirBlast and AirBurst Changes

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -217,60 +217,58 @@ public class AirBlast extends AirAbility {
 				return;
 			}
 		}
-		
-		if (!affectedEntities.contains(entity)) {
-			final boolean isUser = entity.getUniqueId() == this.player.getUniqueId();
-			double knockback = this.pushFactorForOthers;
-	
-			if (isUser) {
-				if (isFromOtherOrigin) {
-					knockback = this.pushFactor;
-				} else {
-					return;
-				}
-			}
-	
-			final double max = this.speed / this.speedFactor;
-	
-			final Vector push = this.direction.clone();
-			if (Math.abs(push.getY()) > max && !isUser) {
-				if (push.getY() < 0) {
-					push.setY(-max);
-				} else {
-					push.setY(max);
-				}
-			}
-	
-			if (this.location.getWorld().equals(this.origin.getWorld())) {
-				knockback *= 1 - this.location.distance(this.origin) / (2 * this.range);
-			}
 			
-			if (GeneralMethods.isSolid(entity.getLocation().add(0, -0.5, 0).getBlock()) && source == null) {
-				knockback *= 0.85;
-			}
-			
-			push.normalize().multiply(knockback);
-			
-			if (Math.abs(entity.getVelocity().dot(push)) > knockback && entity.getVelocity().angle(push) > Math.PI / 3) {
-				push.normalize().add(entity.getVelocity()).multiply(knockback);
-			}
-			
-			GeneralMethods.setVelocity(entity, push);
-			
-			if (this.source != null) {
-				new HorizontalVelocityTracker(entity, this.player, 200l, this.source);
+		final boolean isUser = entity.getUniqueId() == this.player.getUniqueId();
+		double knockback = this.pushFactorForOthers;
+
+		if (isUser) {
+			if (isFromOtherOrigin) {
+				knockback = this.pushFactor;
 			} else {
-				new HorizontalVelocityTracker(entity, this.player, 200l, this);
+				return;
 			}
-	
-			if (this.damage > 0 && entity instanceof LivingEntity && !entity.equals(this.player)) {
-				if (this.source != null) {
-					DamageHandler.damageEntity(entity, this.damage, this.source);
-				} else {
-					DamageHandler.damageEntity(entity, this.damage, this);
-				}
+		}
+
+		final double max = this.speed / this.speedFactor;
+
+		final Vector push = this.direction.clone();
+		if (Math.abs(push.getY()) > max && !isUser) {
+			if (push.getY() < 0) {
+				push.setY(-max);
+			} else {
+				push.setY(max);
 			}
-				
+		}
+
+		if (this.location.getWorld().equals(this.origin.getWorld())) {
+			knockback *= 1 - this.location.distance(this.origin) / (2 * this.range);
+		}
+		
+		if (GeneralMethods.isSolid(entity.getLocation().add(0, -0.5, 0).getBlock()) && source == null) {
+			knockback *= 0.85;
+		}
+		
+		push.normalize().multiply(knockback);
+		
+		if (Math.abs(entity.getVelocity().dot(push)) > knockback && entity.getVelocity().angle(push) > Math.PI / 3) {
+			push.normalize().add(entity.getVelocity()).multiply(knockback);
+		}
+		
+		GeneralMethods.setVelocity(entity, push);
+		
+		if (this.source != null) {
+			new HorizontalVelocityTracker(entity, this.player, 200l, this.source);
+		} else {
+			new HorizontalVelocityTracker(entity, this.player, 200l, this);
+		}
+
+		if (this.damage > 0 && entity instanceof LivingEntity && !entity.equals(this.player) && !this.affectedEntities.contains(entity)) {
+			if (this.source != null) {
+				DamageHandler.damageEntity(entity, this.damage, this.source);
+			} else {
+				DamageHandler.damageEntity(entity, this.damage, this);
+			}
+			
 			this.affectedEntities.add(entity);
 		}
 

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -245,13 +245,13 @@ public class AirBlast extends AirAbility {
 				knockback *= 1 - this.location.distance(this.origin) / (2 * this.range);
 			}
 			
-			if (GeneralMethods.isSolid(entity.getLocation().add(0, -.5, 0).getBlock())) {
-				knockback *= .5;
+			if (GeneralMethods.isSolid(entity.getLocation().add(0, -0.5, 0).getBlock()) && source == null) {
+				knockback *= 0.85;
 			}
 			
 			push.normalize().multiply(knockback);
 			
-			if (Math.abs(entity.getVelocity().dot(push)) > knockback) {
+			if (Math.abs(entity.getVelocity().dot(push)) > knockback && entity.getVelocity().angle(push) > Math.PI / 3) {
 				push.normalize().add(entity.getVelocity()).multiply(knockback);
 			}
 			

--- a/src/com/projectkorra/projectkorra/airbending/AirBurst.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBurst.java
@@ -321,8 +321,4 @@ public class AirBurst extends AirAbility {
 	public ArrayList<AirBlast> getBlasts() {
 		return this.blasts;
 	}
-
-	public ArrayList<Entity> getAffectedEntities() {
-		return this.affectedEntities;
-	}
 }

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -811,7 +811,7 @@ public class ConfigManager {
 
 			config.addDefault("Abilities.Air.AirBurst.Enabled", true);
 			config.addDefault("Abilities.Air.AirBurst.FallThreshold", 10);
-			config.addDefault("Abilities.Air.AirBurst.PushFactor", 1.5);
+			config.addDefault("Abilities.Air.AirBurst.PushFactor", 2.8);
 			config.addDefault("Abilities.Air.AirBurst.ChargeTime", 1750);
 			config.addDefault("Abilities.Air.AirBurst.Damage", 0);
 			config.addDefault("Abilities.Air.AirBurst.Cooldown", 0);


### PR DESCRIPTION
## Removals
* Removes `AirBurst#getAffectedEntities()`, shouldn't allow direct access to the list

## Misc. Changes
* Lowers "friction" in AirBlast knockback for entities on the ground
* Ignore "friction" in AirBlast when the AirBurst source isn't null
* Changes entity velocity comparison to only add vectors angled > pi/3 from push vector
* Increase default AirBurst push option
