### PR TITLE
Fix WaterReturn not finding bottles after potions

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
@@ -154,7 +154,7 @@ public class WaterReturn extends WaterAbility {
 			int aux = index;
 			index = -1;
 			for (int i = aux; i < inventory.getSize(); i++) {
-				if (inventory.getItem(i).getType() == Material.POTION) {
+				if (inventory.getItem(i) != null && inventory.getItem(i).getType() == Material.POTION && inventory.getItem(i).hasItemMeta()) {
 					final PotionMeta meta = (PotionMeta) inventory.getItem(i).getItemMeta();
 					if (meta.getBasePotionData().getType().equals(PotionType.WATER)) {
 						index = i;

--- a/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
@@ -114,8 +114,8 @@ public class WaterReturn extends WaterAbility {
 
 	private void fillBottle() {
 		final PlayerInventory inventory = this.player.getInventory();
-		if (inventory.contains(Material.GLASS_BOTTLE)) {
-			final int index = inventory.first(Material.GLASS_BOTTLE);
+		final int index = inventory.first(Material.GLASS_BOTTLE);
+		if (index >= 0) {
 			final ItemStack item = inventory.getItem(index);
 
 			final ItemStack water = waterBottleItem();
@@ -146,26 +146,14 @@ public class WaterReturn extends WaterAbility {
 		return false;
 	}
 
-	public static boolean hasWaterBottle(final Player player) {
-		if (hasAbility(player, WaterReturn.class) || isBending(player)) {
-			return false;
-		}
-		final PlayerInventory inventory = player.getInventory();
-		if (inventory.contains(Material.POTION)) {
-			final ItemStack item = inventory.getItem(inventory.first(Material.POTION));
-			final PotionMeta meta = (PotionMeta) item.getItemMeta();
-			return meta.getBasePotionData().getType() == PotionType.WATER;
-		}
-		return false;
-	}
-
-	public static void emptyWaterBottle(final Player player) {
-		final PlayerInventory inventory = player.getInventory();
+	public static int firstWaterBottle(final PlayerInventory inventory) {
 		int index = inventory.first(Material.POTION);
 
 		// Check that the first one found is actually a WATER bottle. We aren't implementing potion bending just yet.
-		if (index != -1 && !((PotionMeta) inventory.getItem(index).getItemMeta()).getBasePotionData().getType().equals(PotionType.WATER)) {
-			for (int i = 0; i < inventory.getSize(); i++) {
+		if (index != -1) {
+			int aux = index;
+			index = -1;
+			for (int i = aux; i < inventory.getSize(); i++) {
 				if (inventory.getItem(i).getType() == Material.POTION) {
 					final PotionMeta meta = (PotionMeta) inventory.getItem(i).getItemMeta();
 					if (meta.getBasePotionData().getType().equals(PotionType.WATER)) {
@@ -175,6 +163,22 @@ public class WaterReturn extends WaterAbility {
 				}
 			}
 		}
+
+		return index;
+	}
+
+	public static boolean hasWaterBottle(final Player player) {
+		if (hasAbility(player, WaterReturn.class) || isBending(player)) {
+			return false;
+		}
+		final PlayerInventory inventory = player.getInventory();
+
+		return WaterReturn.firstWaterBottle(inventory) >= 0;
+	}
+
+	public static void emptyWaterBottle(final Player player) {
+		final PlayerInventory inventory = player.getInventory();
+		int index = WaterReturn.firstWaterBottle(inventory);
 
 		if (index != -1) {
 			final ItemStack item = inventory.getItem(index);


### PR DESCRIPTION
## Additions
Static Function that returns the slot id of the first water bottle found, -1 if none found. Used to not repeat code that should be the same (hasWaterBottle and emptyWaterBottle start finding this index, but they don't use the same code).

## Fixes
Fixes an error in hasWaterBottle function. In the former version of the WaterReturn.java file, hasWaterBottle only tests if the first item with Material.POTION in the inventory is of type PotionType.WATER. Having a random potion in the inventory in any slot before a Water Bottle makes this to return false, instead of checking all the potions in the Player Inventory. This causes the player to be unable to use the bottle as a water source. The new code checks all the potions.

## Misc. Changes
Since the items in an inventory aren't usually sorted (players don't sort items by id in their inventories), the "contains" method iterates all over the items on the inventory until it finds one with the specified material. The "first" method does the same, but instead of returning a boolean, it gives us the slot index of the item or -1 if not found. Since in "fillBottle" method we are going to calculate that index after checking whether the item is in the inventory or not, I've calculated this index with the "first" method and checking if it is greater or equals than 0 (not -1). Doing so we don't repeat the search task and we have a little improvement in efficiency terms.
