### PR TITLE
patch catapult and metalclips not respecting invincible or region protection

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/Catapult.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Catapult.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -69,6 +70,9 @@ public class Catapult extends EarthAbility {
 	private void moveEarth(final Vector apply, final Vector direction) {
 		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.origin, 2)) {
 			if (entity.getEntityId() != this.player.getEntityId()) {
+				if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) || ((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
+					continue;
+				}
 				entity.setVelocity(apply);
 			}
 		}

--- a/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Zombie;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
+import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.MetalAbility;
@@ -165,7 +166,7 @@ public class MetalClips extends MetalAbility {
 			return;
 		} else if (this.metalClipsCount == 3 && !this.canUse4Clips) {
 			return;
-		} else if (this.targetEntity != null && GeneralMethods.isRegionProtectedFromBuild(this, this.targetEntity.getLocation())) {
+		} else if (this.targetEntity != null && (GeneralMethods.isRegionProtectedFromBuild(this, this.targetEntity.getLocation()) || ((targetEntity instanceof Player) && Commands.invincible.contains(((Player) targetEntity).getName())))) {
 			return;
 		}
 


### PR DESCRIPTION
## Fixes
* Fixes catapult launching player with invincible toggled or protected region
* Fixes metalclip working on players with invincible toggled
