### PR TITLE
fix error with direction vector in airblast

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -92,7 +92,7 @@ public class AirBlast extends AirAbility {
 			if (entity != null) {
 				this.direction = GeneralMethods.getDirection(this.origin, entity.getLocation()).normalize();
 			} else {
-				this.direction = GeneralMethods.getDirection(this.origin, GeneralMethods.getTargetedLocation(player, this.range)).normalize();
+				this.direction = player.getEyeLocation().getDirection().normalize();
 			}
 		} else {
 			this.origin = player.getEyeLocation();


### PR DESCRIPTION
## Fixes
* Fixes airblast direction variable being invalid

there may be some deeper issue with GeneralMethods.getTargetedLocation as normalize the vector can make it NaN when the origin location is the same location as the result from getTargetedLocation which can happen when a player is inside or very close to blocks