### PR TITLE
synchronize display command headers

### DIFF
--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -118,7 +118,7 @@ public class DisplayCommand extends PKCommand {
 						return;
 					}
 
-					sender.sendMessage(element.getColor() + (ChatColor.BOLD + element.getName()) + element.getType().getBending() + ChatColor.WHITE + (ChatColor.BOLD + " Combos"));
+					sender.sendMessage(element.getColor() + (ChatColor.BOLD + element.getName()) + element.getType().getBending() + (ChatColor.BOLD + " Combos"));
 
 					for (final String comboMove : combos) {
 						ChatColor comboColor = color;
@@ -179,7 +179,7 @@ public class DisplayCommand extends PKCommand {
 					return;
 				}
 
-				sender.sendMessage(element.getColor() + (ChatColor.BOLD + element.getName()) + element.getType().getBending() + ChatColor.WHITE + (ChatColor.BOLD + " Passives"));
+				sender.sendMessage(element.getColor() + (ChatColor.BOLD + element.getName()) + element.getType().getBending() + (ChatColor.BOLD + " Passives"));
 
 				for (final String passiveAbil : passives) {
 					ChatColor passiveColor = color;


### PR DESCRIPTION
Just a personal suggestion.

## Misc. Changes
* Synchronizes the display command header for a more clean, uniform look.

![Screen Shot 2019-09-07 at 9 14 46 PM](https://user-images.githubusercontent.com/25273023/71562967-cc7fd700-2a4d-11ea-9173-9d1602ee4abf.png)
