### PR TITLE
some of my suffocate edits without the new animation

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/Suffocate.java
+++ b/src/com/projectkorra/projectkorra/airbending/Suffocate.java
@@ -151,11 +151,7 @@ public class Suffocate extends AirAbility {
 		for (int i = 0; i < this.targets.size(); i++) {
 			final LivingEntity target = this.targets.get(i);
 
-			if (target.isDead() ||
-					!target.getWorld().equals(this.player.getWorld()) ||
-					target.getLocation().distanceSquared(this.player.getEyeLocation()) > this.range * this.range ||
-					GeneralMethods.isRegionProtectedFromBuild(this, target.getLocation()) ||
-					target instanceof ArmorStand) {
+			if (target.isDead() || !target.getWorld().equals(this.player.getWorld()) || target.getLocation().distanceSquared(this.player.getEyeLocation()) > this.range * this.range || GeneralMethods.isRegionProtectedFromBuild(this, target.getLocation()) || target instanceof ArmorStand) {
 				this.breakSuffocateLocal(target);
 				i--;
 			} else if (target instanceof Player) {
@@ -230,6 +226,7 @@ public class Suffocate extends AirAbility {
 
 		if (!this.player.isSneaking()) {
 			this.remove();
+			return;
 		}
 	}
 


### PR DESCRIPTION
This contains some of my edits/fixes to Suffocate without the new animation (which wasn't very well executed before).

## Fixes
* Fixed being able to use Suffocate on armor stands.

## Removals
* Removed an unnecessary LivingEntity variable.

## Misc. Changes
* Moved a for loop out of the animate method and placed it inside of the progress method. This was used to separate the different animations (under and above water) in my old PR and can be used for the same thing when an underwater animation gets worked on.
