### PR TITLE
fixes waterarms spear going through blocks

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
@@ -256,7 +256,7 @@ public class WaterArmsSpear extends WaterAbility {
 	private boolean canPlaceBlock(final Block block) {
 		if (!isTransparent(this.player, block) && !((isWater(block) || this.isIcebendable(block)) && (TempBlock.isTempBlock(block) && !getIceBlocks().containsKey(block)))) {
 			return false;
-		} else if (GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
+		} else if (GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation()) || GeneralMethods.isSolid(block)) {
 			return false;
 		} else if (WaterArms.isUnbreakable(block) && !isWater(block)) {
 			return false;


### PR DESCRIPTION
## Fixes
* Fixes WaterArms Spear being able to go through certain blocks (like ice) as if they aren't there.
   > * [Trello link](https://trello.com/c/LCsd8Ed2/742-waterarms-bugs)