### PR TITLE
AirSwipe improvements & new general method

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -994,7 +994,7 @@ public class GeneralMethods {
 			for (Entity entity : getEntitiesAroundPoint(location, radius)) {
 				Location entityLocation = entity.getLocation();
 				Vector direction = new Vector(1, 0, 0).add(entityLocation.toVector().subtract(location.toVector())).multiply(1);
-				Location blockCheck = location.clone().add(direction.multiply(1));
+				Location blockCheck = location.clone().add(direction);
 
 				if (isTransparent(blockCheck.getBlock()))
 					validEntities.add(entity);

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -978,6 +978,32 @@ public class GeneralMethods {
 		return new ArrayList<>(location.getWorld().getNearbyEntities(location, radius, radius, radius, entity -> !(entity.isDead() || (entity instanceof Player && ((Player) entity).getGameMode().equals(GameMode.SPECTATOR)))));
 	}
 
+	/**
+	 * Gets a {@code List<Entity>} of entities around a specified radius from
+	 * the specified area while ignoring entities that may be behind walls.
+	 *
+	 * @param location The base location
+	 * @param radius The radius of blocks to look for entities from the location
+	 * @param respectBlocks Whether or not to check for any blocks between the location and entity.
+	 * @return A list of entities around a point
+	 */
+	public static List<Entity> getEntitiesAroundPoint(final Location location, final double radius, final boolean respectBlocks) {
+		List<Entity> validEntities = new ArrayList<>();
+
+		if (respectBlocks) {
+			for (Entity entity : getEntitiesAroundPoint(location, radius)) {
+				Location entityLocation = entity.getLocation();
+				Vector direction = new Vector(1, 0, 0).add(entityLocation.toVector().subtract(location.toVector())).multiply(1);
+				Location blockCheck = location.clone().add(direction.multiply(1));
+
+				if (blockCheck.getBlock().getType().equals(Material.AIR))
+					validEntities.add(entity);
+			}
+		} else return getEntitiesAroundPoint(location, radius);
+
+		return validEntities;
+	}
+
 	public static long getGlobalCooldown() {
 		return ConfigManager.defaultConfig.get().getLong("Properties.GlobalCooldown");
 	}

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -993,7 +993,7 @@ public class GeneralMethods {
 		if (respectBlocks) {
 			for (Entity entity : getEntitiesAroundPoint(location, radius)) {
 				Location entityLocation = entity.getLocation();
-				Vector direction = new Vector(1, 0, 0).add(entityLocation.toVector().subtract(location.toVector())).multiply(1);
+				Vector direction = new Vector(1, 0, 0).add(entityLocation.toVector().subtract(location.toVector()));
 				Location blockCheck = location.clone().add(direction);
 
 				if (isTransparent(blockCheck.getBlock()))

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -988,19 +988,18 @@ public class GeneralMethods {
 	 * @return A list of entities around a point
 	 */
 	public static List<Entity> getEntitiesAroundPoint(final Location location, final double radius, final boolean respectBlocks) {
-		List<Entity> validEntities = new ArrayList<>();
+		List<Entity> validEntities = getEntitiesAroundPoint(location, radius);
 
 		if (respectBlocks) {
-			for (Entity entity : getEntitiesAroundPoint(location, radius)) {
+			for (Entity entity : validEntities) {
 				Location entityLocation = entity.getLocation();
 				Vector direction = new Vector(1, 0, 0).add(entityLocation.toVector().subtract(location.toVector()));
 				Location blockCheck = location.clone().add(direction);
 
-				if (isTransparent(blockCheck.getBlock()))
-					validEntities.add(entity);
+				if (!isTransparent(blockCheck.getBlock()))
+					validEntities.remove(entity);
 			}
-		} else return getEntitiesAroundPoint(location, radius);
-
+		}
 		return validEntities;
 	}
 

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -996,7 +996,7 @@ public class GeneralMethods {
 				Vector direction = new Vector(1, 0, 0).add(entityLocation.toVector().subtract(location.toVector())).multiply(1);
 				Location blockCheck = location.clone().add(direction.multiply(1));
 
-				if (blockCheck.getBlock().getType().equals(Material.AIR))
+				if (isTransparent(blockCheck.getBlock()))
 					validEntities.add(entity);
 			}
 		} else return getEntitiesAroundPoint(location, radius);


### PR DESCRIPTION
## Additions
* Added new `getEntitiesAroundPoint` method to `GeneralMethods` which can be used to ignore entities that are being blocked by some form of wall or barrier. I'm using this method in this PR because AirSwipe was able to hurt entities behind walls with my new change. This new method could be implemented across the project but didn't want to do the unnecessary work if y'all don't like my method.

## Fixes
* Fixed an unintentional feature where AirSwipe will remove entirely when 1 stream comes into contact with a solid block. Now, only the stream that is being blocked will be removed while others will continue like normal.

## Misc. Changes
* Renamed the `elements` collection in AirSwipe to `streams` to more accurately describe what the collection is used for. Considering what this plugin is made and used for, calling it "elements" is a little confusing.
* Implemented a variable in the `affectPeople` method in AirSwipe that was created but never used.
* Removed an `isEmpty` check because it was checked twice: In the `advanceSwipe` method and in the `progress` method right before `advanceSwipe` is called.