### PR TITLE
fixes AirSuction not removing in some scenarios

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/AirSuction.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSuction.java
@@ -245,6 +245,10 @@ public class AirSuction extends AirAbility {
 
 			this.advanceLocation();
 		} else {
+			if (!bPlayer.canBend(this) || player.getLocation().distance(origin) > this.range || !bPlayer.getBoundAbilityName().equalsIgnoreCase("AirSuction")) {
+				remove();
+				return;
+			}
 			playAirbendingParticles(this.origin, 5, 0.5, 0.5, 0.5);
 		}
 	}


### PR DESCRIPTION
## Fixes
* AirSuction not removing when bending is toggled, player is out of range of the source, or their bound ability has been changed. The bound ability part can be removed, not sure if people would actually like that bit. But I added it in case y'all wanted it.
    > * #1049 