### PR TITLE
Preset Command Creation Error

### DIFF
--- a/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -40,6 +40,8 @@ public class PresetCommand extends PKCommand {
 	private final String alreadyExists;
 	private final String createdNewPreset;
 	private final String cantEditBinds;
+	private final String playerNotFound;
+	private final String needPresetName;
 
 	public PresetCommand() {
 		super("preset", "/bending preset <Bind/Create/Delete/List> [Preset]", ConfigManager.languageConfig.get().getString("Commands.Preset.Description"), new String[] { "preset", "presets", "pre", "set", "p" });
@@ -58,6 +60,8 @@ public class PresetCommand extends PKCommand {
 		this.alreadyExists = ConfigManager.languageConfig.get().getString("Commands.Preset.AlreadyExists");
 		this.createdNewPreset = ConfigManager.languageConfig.get().getString("Commands.Preset.Created");
 		this.cantEditBinds = ConfigManager.languageConfig.get().getString("Commands.Preset.CantEditBinds");
+		this.playerNotFound = ConfigManager.languageConfig.get().getString("Commands.Preset.PlayerNotFound");
+		this.needPresetName = ConfigManager.languageConfig.get().getString("Commands.Preset.NeedPresetName");
 	}
 
 	@Override
@@ -177,7 +181,7 @@ public class PresetCommand extends PKCommand {
 					}
 					return;
 				} else {
-					GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + ConfigManager.languageConfig.get().getString("Commands.Preset.PlayerNotFound"));
+					GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + this.playerNotFound);
 				}
 			} else if (this.hasPermission(sender, "bind.assign") && Preset.presetExists(player, name)) {
 				if (!Preset.presetExists(player, name)) {
@@ -207,10 +211,15 @@ public class PresetCommand extends PKCommand {
 					}
 					return;
 				} else {
-					GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + ConfigManager.languageConfig.get().getString("Commands.Preset.PlayerNotFound"));
+					GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + this.playerNotFound);
 				}
 			}
 		} else if (Arrays.asList(createaliases).contains(args.get(0)) && this.hasPermission(sender, "create")) { // bending preset create name.
+			if (name == null) {
+				GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + this.needPresetName);
+				return;
+			}
+
 			final int limit = GeneralMethods.getMaxPresets(player);
 
 			if (Preset.presets.get(player.getUniqueId()) != null && Preset.presets.get(player.getUniqueId()).size() >= limit) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -125,6 +125,7 @@ public class ConfigManager {
 			config.addDefault("Commands.Preset.Description", "This command manages Presets, which are saved bindings. Use /bending preset list to view your existing presets, use /bending [create|delete] [name] to manage your presets, and use /bending bind [name] to bind an existing preset.");
 			config.addDefault("Commands.Preset.NoPresets", "You do not have any presets.");
 			config.addDefault("Commands.Preset.NoPresetName", "You don't have a preset with that name.");
+			config.addDefault("Commands.Preset.NeedPresetName", "You must enter a name for your preset.");
 			config.addDefault("Commands.Preset.Created", "Created a new preset named '{name}'.");
 			config.addDefault("Commands.Preset.Delete", "You have deleted your '{name}' preset.");
 			config.addDefault("Commands.Preset.Removed", "Your bending has been permanently removed.");


### PR DESCRIPTION
## Fixes
* Bending Preset Creation Error
    > * I added a check to make sure that there's a name for the preset, otherwise, it breaks presets for the player in general.

## Misc. Changes
* Changed error messages in PresetCommand class to be implemented the same way (through a variable)
    > * This was just my OCD rip
