### PR TITLE
Blue Fire Addition & Firebending Refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.13.2-R0.1-SNAPSHOT</version>
+      <version>1.16.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <!-- lang3 -->

--- a/src/com/projectkorra/projectkorra/Element.java
+++ b/src/com/projectkorra/projectkorra/Element.java
@@ -57,10 +57,11 @@ public class Element {
 	public static final SubElement SAND = new SubElement("Sand", EARTH);
 	public static final SubElement LIGHTNING = new SubElement("Lightning", FIRE);
 	public static final SubElement COMBUSTION = new SubElement("Combustion", FIRE);
+	public static final SubElement BLUE_FIRE = new SubElement("Blue Fire", FIRE);
 
-	private static final Element[] ELEMENTS = { AIR, WATER, EARTH, FIRE, CHI, FLIGHT, SPIRITUAL, BLOOD, HEALING, ICE, PLANT, LAVA, METAL, SAND, LIGHTNING, COMBUSTION };
+	private static final Element[] ELEMENTS = { AIR, WATER, EARTH, FIRE, CHI, FLIGHT, SPIRITUAL, BLOOD, HEALING, ICE, PLANT, LAVA, METAL, SAND, LIGHTNING, COMBUSTION, BLUE_FIRE };
 	private static final Element[] MAIN_ELEMENTS = { AIR, WATER, EARTH, FIRE, CHI };
-	private static final SubElement[] SUB_ELEMENTS = { FLIGHT, SPIRITUAL, BLOOD, HEALING, ICE, PLANT, LAVA, METAL, SAND, LIGHTNING, COMBUSTION };
+	private static final SubElement[] SUB_ELEMENTS = { FLIGHT, SPIRITUAL, BLOOD, HEALING, ICE, PLANT, LAVA, METAL, SAND, LIGHTNING, COMBUSTION, BLUE_FIRE };
 
 	private final String name;
 	private final ElementType type;

--- a/src/com/projectkorra/projectkorra/Element.java
+++ b/src/com/projectkorra/projectkorra/Element.java
@@ -57,7 +57,7 @@ public class Element {
 	public static final SubElement SAND = new SubElement("Sand", EARTH);
 	public static final SubElement LIGHTNING = new SubElement("Lightning", FIRE);
 	public static final SubElement COMBUSTION = new SubElement("Combustion", FIRE);
-	public static final SubElement BLUE_FIRE = new SubElement("Blue Fire", FIRE);
+	public static final SubElement BLUE_FIRE = new SubElement("Blue_Fire", FIRE);
 
 	private static final Element[] ELEMENTS = { AIR, WATER, EARTH, FIRE, CHI, FLIGHT, SPIRITUAL, BLOOD, HEALING, ICE, PLANT, LAVA, METAL, SAND, LIGHTNING, COMBUSTION, BLUE_FIRE };
 	private static final Element[] MAIN_ELEMENTS = { AIR, WATER, EARTH, FIRE, CHI };

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -429,6 +429,9 @@ public class GeneralMethods {
 							}
 						}
 					} else if (split[0] != null) {
+						if (split[0].contains("r")) {
+							subelements.add(Element.BLUE_FIRE);
+						}
 						if (split[0].contains("m")) {
 							subelements.add(Element.METAL);
 						}
@@ -462,6 +465,7 @@ public class GeneralMethods {
 						if (split[0].contains("p")) {
 							subelements.add(Element.PLANT);
 						}
+
 						if (hasAddon) {
 							final CopyOnWriteArrayList<String> addonClone = new CopyOnWriteArrayList<String>(Arrays.asList(split[split.length - 1].split(",")));
 							final long startTime = System.currentTimeMillis();
@@ -700,32 +704,32 @@ public class GeneralMethods {
 	 */
 	public static BlockFace getBlockFaceFromValue(final int xyz, final double value) {
 		switch (xyz) {
-			case 0:
-				if (value > 0) {
-					return BlockFace.EAST;
-				} else if (value < 0) {
-					return BlockFace.WEST;
-				} else {
-					return BlockFace.SELF;
-				}
-			case 1:
-				if (value > 0) {
-					return BlockFace.UP;
-				} else if (value < 0) {
-					return BlockFace.DOWN;
-				} else {
-					return BlockFace.SELF;
-				}
-			case 2:
-				if (value > 0) {
-					return BlockFace.SOUTH;
-				} else if (value < 0) {
-					return BlockFace.NORTH;
-				} else {
-					return BlockFace.SELF;
-				}
-			default:
-				return null;
+		case 0:
+			if (value > 0) {
+				return BlockFace.EAST;
+			} else if (value < 0) {
+				return BlockFace.WEST;
+			} else {
+				return BlockFace.SELF;
+			}
+		case 1:
+			if (value > 0) {
+				return BlockFace.UP;
+			} else if (value < 0) {
+				return BlockFace.DOWN;
+			} else {
+				return BlockFace.SELF;
+			}
+		case 2:
+			if (value > 0) {
+				return BlockFace.SOUTH;
+			} else if (value < 0) {
+				return BlockFace.NORTH;
+			} else {
+				return BlockFace.SELF;
+			}
+		default:
+			return null;
 		}
 	}
 
@@ -863,7 +867,7 @@ public class GeneralMethods {
 		}
 		return circleblocks;
 	}
-	
+
 	/**
 	 * Gets the closest entity within the specified radius around a point
 	 * @param center point to check around
@@ -873,10 +877,10 @@ public class GeneralMethods {
 	public static Entity getClosestEntity(Location center, double radius) {
 		Entity found = null;
 		Double distance = null;
-		
+
 		for (Entity entity : GeneralMethods.getEntitiesAroundPoint(center, radius)) {
 			double check = center.distanceSquared(entity.getLocation());
-			
+
 			if (distance == null || check < distance) {
 				found = entity;
 				distance = check;
@@ -885,7 +889,7 @@ public class GeneralMethods {
 
 		return found;
 	}
-	
+
 	/**
 	 * Gets the closest LivingEntity within the specified radius around a point
 	 * @param center point to check around
@@ -895,16 +899,16 @@ public class GeneralMethods {
 	public static LivingEntity getClosestLivingEntity(Location center, double radius) {
 		LivingEntity le = null;
 		Double distance = null;
-		
+
 		for (Entity entity : GeneralMethods.getEntitiesAroundPoint(center, radius)) {
 			double check = center.distanceSquared(entity.getLocation());
-			
+
 			if (entity instanceof LivingEntity && (distance == null || check < distance)) {
 				le = (LivingEntity) entity;
 				distance = check;
 			}
 		}
-		
+
 		return le;
 	}
 
@@ -998,24 +1002,24 @@ public class GeneralMethods {
 		final BlockFace face = getCardinalDirection(vector);
 
 		switch (face) {
-			case SOUTH:
-				return 7;
-			case SOUTH_WEST:
-				return 6;
-			case WEST:
-				return 3;
-			case NORTH_WEST:
-				return 0;
-			case NORTH:
-				return 1;
-			case NORTH_EAST:
-				return 2;
-			case EAST:
-				return 5;
-			case SOUTH_EAST:
-				return 8;
-			default:
-				return 4;
+		case SOUTH:
+			return 7;
+		case SOUTH_WEST:
+			return 6;
+		case WEST:
+			return 3;
+		case NORTH_WEST:
+			return 0;
+		case NORTH:
+			return 1;
+		case NORTH_EAST:
+			return 2;
+		case EAST:
+			return 5;
+		case SOUTH_EAST:
+			return 8;
+		default:
+			return 4;
 		}
 	}
 
@@ -1187,7 +1191,7 @@ public class GeneralMethods {
 	public static Entity getTargetedEntity(final Player player, final double range) {
 		return getTargetedEntity(player, range, new ArrayList<Entity>());
 	}
-	
+
 	public static Location getTargetedLocation(final Player player, final double range, final boolean ignoreTempBlocks, final boolean checkDiagonals, final Material... nonOpaque2) {
 		final Location origin = player.getEyeLocation();
 		final Vector direction = origin.getDirection();
@@ -1208,7 +1212,7 @@ public class GeneralMethods {
 
 		for (double i = 0; i < range; i += 0.2) {
 			location.add(vec);
-			
+
 			if (checkDiagonals && checkDiagonalWall(location, vec)) {
 				location.subtract(vec);
 				break;
@@ -1653,22 +1657,22 @@ public class GeneralMethods {
 		if (entity == null) {
 			return false;
 		}
-		
+
 		switch (entity.getType()) {
-			case SKELETON:
-			case STRAY:
-			case WITHER_SKELETON:
-			case WITHER:
-			case ZOMBIE:
-			case HUSK:
-			case ZOMBIE_VILLAGER:
-			case DROWNED:
-			case ZOMBIE_HORSE:
-			case SKELETON_HORSE:
-			case PHANTOM:
-				return true;
-			default:
-				return false;
+		case SKELETON:
+		case STRAY:
+		case WITHER_SKELETON:
+		case WITHER:
+		case ZOMBIE:
+		case HUSK:
+		case ZOMBIE_VILLAGER:
+		case DROWNED:
+		case ZOMBIE_HORSE:
+		case SKELETON_HORSE:
+		case PHANTOM:
+			return true;
+		default:
+			return false;
 		}
 	}
 
@@ -2334,19 +2338,19 @@ public class GeneralMethods {
 
 	public static boolean isLightEmitting(final Material material) {
 		switch (material) {
-			case GLOWSTONE:
-			case TORCH:
-			case SEA_LANTERN:
-			case BEACON:
-			case REDSTONE_LAMP:
-			case REDSTONE_TORCH:
-			case MAGMA_BLOCK:
-			case LAVA:
-			case JACK_O_LANTERN:
-			case END_ROD:
-				return true;
-			default:
-				return false;
+		case GLOWSTONE:
+		case TORCH:
+		case SEA_LANTERN:
+		case BEACON:
+		case REDSTONE_LAMP:
+		case REDSTONE_TORCH:
+		case MAGMA_BLOCK:
+		case LAVA:
+		case JACK_O_LANTERN:
+		case END_ROD:
+			return true;
+		default:
+			return false;
 		}
 	}
 }

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1666,6 +1666,8 @@ public class GeneralMethods {
 		case ZOMBIE:
 		case HUSK:
 		case ZOMBIE_VILLAGER:
+		case ZOMBIFIED_PIGLIN:
+		case ZOGLIN:
 		case DROWNED:
 		case ZOMBIE_HORSE:
 		case SKELETON_HORSE:
@@ -2347,6 +2349,18 @@ public class GeneralMethods {
 		case MAGMA_BLOCK:
 		case LAVA:
 		case JACK_O_LANTERN:
+		case CRYING_OBSIDIAN:
+		case SHROOMLIGHT:
+		case CAMPFIRE:
+		case SOUL_CAMPFIRE:
+		case SOUL_TORCH:
+		case LANTERN:
+		case CONDUIT:
+		case RESPAWN_ANCHOR:
+		case BROWN_MUSHROOM:
+		case BREWING_STAND:
+		case ENDER_CHEST:
+		case END_PORTAL_FRAME:
 		case END_ROD:
 			return true;
 		default:

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1662,7 +1662,6 @@ public class GeneralMethods {
 			case ZOMBIE:
 			case HUSK:
 			case ZOMBIE_VILLAGER:
-			case PIG_ZOMBIE:
 			case DROWNED:
 			case ZOMBIE_HORSE:
 			case SKELETON_HORSE:

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -143,7 +143,6 @@ import com.projectkorra.projectkorra.event.HorizontalVelocityChangeEvent;
 import com.projectkorra.projectkorra.event.PlayerChangeElementEvent;
 import com.projectkorra.projectkorra.event.PlayerJumpEvent;
 import com.projectkorra.projectkorra.firebending.Blaze;
-import com.projectkorra.projectkorra.firebending.BlazeArc;
 import com.projectkorra.projectkorra.firebending.BlazeRing;
 import com.projectkorra.projectkorra.firebending.FireBlast;
 import com.projectkorra.projectkorra.firebending.FireBlastCharged;
@@ -372,10 +371,6 @@ public class PKListener implements Listener {
 		if (!event.isCancelled()) {
 			event.setCancelled(!Torrent.canThaw(block));
 		}
-
-		if (BlazeArc.getIgnitedBlocks().containsKey(block)) {
-			BlazeArc.removeBlock(block);
-		}
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -477,8 +472,8 @@ public class PKListener implements Listener {
 	public void onEntityCombust(final EntityCombustEvent event) {
 		final Entity entity = event.getEntity();
 		final Block block = entity.getLocation().getBlock();
-		if (BlazeArc.getIgnitedBlocks().containsKey(block) && entity instanceof LivingEntity) {
-			new FireDamageTimer(entity, BlazeArc.getIgnitedBlocks().get(block));
+		if (FireAbility.getSourcePlayers().containsKey(block) && entity instanceof LivingEntity) {
+			new FireDamageTimer(entity, FireAbility.getSourcePlayers().get(block));
 		}
 	}
 
@@ -504,8 +499,8 @@ public class PKListener implements Listener {
 	public void onEntityDamageEvent(final EntityDamageEvent event) {
 		final Entity entity = event.getEntity();
 
-		if (event.getCause() == DamageCause.FIRE && BlazeArc.getIgnitedBlocks().containsKey(entity.getLocation().getBlock())) {
-			new FireDamageTimer(entity, BlazeArc.getIgnitedBlocks().get(entity.getLocation().getBlock()));
+		if (event.getCause() == DamageCause.FIRE && FireAbility.getSourcePlayers().containsKey(entity.getLocation().getBlock())) {
+			new FireDamageTimer(entity, FireAbility.getSourcePlayers().get(entity.getLocation().getBlock()));
 		}
 
 		if (FireDamageTimer.isEnflamed(entity) && event.getCause() == DamageCause.FIRE_TICK) {

--- a/src/com/projectkorra/projectkorra/ability/BlueFireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/BlueFireAbility.java
@@ -10,27 +10,26 @@ public abstract class BlueFireAbility extends FireAbility implements SubAbility 
 	public BlueFireAbility(final Player player) {
 		super(player);
 	}
-	
+
 	@Override
 	public Class<? extends Ability> getParentAbility() {
 		return FireAbility.class;
 	}
-	
+
 	@Override
 	public Element getElement() {
 		return Element.BLUE_FIRE;
 	}
-	
-	
-	public double getDamageFactor() {
+
+	public static double getDamageFactor() {
 		return Config.getConfig().getDouble("Properties.Fire.BlueFire.DamageFactor");
 	}
-	
-	public double getCooldownFactor() {
+
+	public static double getCooldownFactor() {
 		return Config.getConfig().getDouble("Properties.Fire.BlueFire.CooldownFactor");
 	}
-	
-	public double getRangeFactor() {
+
+	public static double getRangeFactor() {
 		return Config.getConfig().getDouble("Properties.Fire.BlueFire.CooldownFactor");
 	}
 

--- a/src/com/projectkorra/projectkorra/ability/BlueFireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/BlueFireAbility.java
@@ -1,0 +1,37 @@
+package com.projectkorra.projectkorra.ability;
+
+import org.bukkit.entity.Player;
+
+import com.projectkorra.projectkorra.Element;
+import com.songoda.kingdoms.main.Config;
+
+public abstract class BlueFireAbility extends FireAbility implements SubAbility {
+
+	public BlueFireAbility(final Player player) {
+		super(player);
+	}
+	
+	@Override
+	public Class<? extends Ability> getParentAbility() {
+		return FireAbility.class;
+	}
+	
+	@Override
+	public Element getElement() {
+		return Element.BLUE_FIRE;
+	}
+	
+	
+	public double getDamageFactor() {
+		return Config.getConfig().getDouble("Properties.Fire.BlueFire.DamageFactor");
+	}
+	
+	public double getCooldownFactor() {
+		return Config.getConfig().getDouble("Properties.Fire.BlueFire.CooldownFactor");
+	}
+	
+	public double getRangeFactor() {
+		return Config.getConfig().getDouble("Properties.Fire.BlueFire.CooldownFactor");
+	}
+
+}

--- a/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -80,6 +80,14 @@ public abstract class ElementalAbility extends CoreAbility {
 	public static boolean isEarth(final Material material) {
 		return getConfig().getStringList("Properties.Earth.EarthBlocks").contains(material.toString());
 	}
+	
+	public static boolean isFire(final Block block) {
+		return block != null ? isFire(block.getType()) : false;
+	}
+	
+	public static boolean isFire(final Material material) {
+		return material == Material.SOUL_FIRE || material == Material.FIRE;
+	}
 
 	public static boolean isFullMoon(final World world) {
 		final double days = Math.ceil(world.getFullTime() / 24000) + 1;

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -22,14 +22,14 @@ import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
-import com.projectkorra.projectkorra.firebending.BlazeArc;
 import com.projectkorra.projectkorra.util.Information;
 import com.projectkorra.projectkorra.util.ParticleEffect;
 
 public abstract class FireAbility extends ElementalAbility {
 
 	private static final Map<Location, Information> TEMP_FIRE = new ConcurrentHashMap<Location, Information>();
-
+	private static final Map<Block, Player> SOURCE_PLAYERS = new ConcurrentHashMap<>();
+	
 	public FireAbility(final Player player) {
 		super(player);
 	}
@@ -94,6 +94,7 @@ public abstract class FireAbility extends ElementalAbility {
 		info.setTime(time + System.currentTimeMillis());
 		loc.getBlock().setType(fireType);
 		TEMP_FIRE.put(loc, info);
+		SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
 	}
 
 	public double getDayFactor(final double value) {
@@ -257,6 +258,14 @@ public abstract class FireAbility extends ElementalAbility {
 		for (final Location loc : TEMP_FIRE.keySet()) {
 			revertTempFire(loc);
 		}
+	}
+	
+	public static Map<Location, Information> getTempFire() {
+		return TEMP_FIRE;
+	}
+
+	public static Map<Block, Player> getSourcePlayers() {
+		return SOURCE_PLAYERS;
 	}
 
 }

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -31,7 +31,7 @@ public abstract class FireAbility extends ElementalAbility {
 
 	private static final Map<Location, Information> TEMP_FIRE = new ConcurrentHashMap<Location, Information>();
 	private static final Map<Block, Player> SOURCE_PLAYERS = new ConcurrentHashMap<>();
-	
+
 	public FireAbility(final Player player) {
 		super(player);
 	}
@@ -75,13 +75,13 @@ public abstract class FireAbility extends ElementalAbility {
 	public void createTempFire(final Location loc) {
 		createTempFire(loc, getConfig().getLong("Properties.Fire.RevertTicks") + (long) ((new Random()).nextDouble() * getConfig().getLong("Properties.Fire.RevertTicks")));
 	}
-	
-	
+
+
 	public void createTempFire(final Location loc, final long time) {
 		Material fireType = this.getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE) ? Material.SOUL_FIRE : Material.FIRE;
-		
+
 		new TempBlock(loc.getBlock(), fireType.createBlockData(), time);
-		
+
 		SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
 	}
 
@@ -247,7 +247,7 @@ public abstract class FireAbility extends ElementalAbility {
 			revertTempFire(loc);
 		}
 	}
-	
+
 	public static Map<Location, Information> getTempFire() {
 		return TEMP_FIRE;
 	}

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -1,7 +1,6 @@
 package com.projectkorra.projectkorra.ability;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -15,7 +14,6 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -23,13 +21,11 @@ import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
-import com.projectkorra.projectkorra.util.Information;
 import com.projectkorra.projectkorra.util.ParticleEffect;
 import com.projectkorra.projectkorra.util.TempBlock;
 
 public abstract class FireAbility extends ElementalAbility {
 
-	private static final Map<Location, Information> TEMP_FIRE = new ConcurrentHashMap<Location, Information>();
 	private static final Map<Block, Player> SOURCE_PLAYERS = new ConcurrentHashMap<>();
 
 	public FireAbility(final Player player) {
@@ -205,51 +201,9 @@ public abstract class FireAbility extends ElementalAbility {
 			}
 		}
 	}
-
-	/** Removes all temp fire that no longer needs to be there */
-	public static void removeFire() {
-		final Iterator<Location> it = TEMP_FIRE.keySet().iterator();
-		while (it.hasNext()) {
-			final Location loc = it.next();
-			final Information info = TEMP_FIRE.get(loc);
-			if (info.getLocation().getBlock().getType() != Material.FIRE && !ElementalAbility.isAir(info.getLocation().getBlock().getType())) {
-				revertTempFire(loc);
-			} else if (ElementalAbility.isAir(info.getBlock().getType()) || System.currentTimeMillis() > info.getTime()) {
-				revertTempFire(loc);
-			}
-		}
-	}
-
-	/**
-	 * Revert the temp fire at the location if any is there.
-	 *
-	 * @param location The Location
-	 */
-	public static void revertTempFire(final Location location) {
-		if (!TEMP_FIRE.containsKey(location)) {
-			return;
-		}
-		final Information info = TEMP_FIRE.get(location);
-		if (!isFire(info.getLocation().getBlock().getType()) && !ElementalAbility.isAir(info.getLocation().getBlock().getType())) {
-			if (info.getState().getType().isBurnable() && !info.getState().getType().isOccluding()) {
-				final ItemStack itemStack = new ItemStack(info.getState().getType(), 1);
-				info.getState().getBlock().getWorld().dropItemNaturally(info.getLocation(), itemStack);
-			}
-		} else {
-			info.getBlock().setType(info.getState().getType());
-			info.getBlock().setBlockData(info.getState().getBlockData());
-		}
-		TEMP_FIRE.remove(location);
-	}
-
+	
 	public static void stopBending() {
-		for (final Location loc : TEMP_FIRE.keySet()) {
-			revertTempFire(loc);
-		}
-	}
-
-	public static Map<Location, Information> getTempFire() {
-		return TEMP_FIRE;
+		SOURCE_PLAYERS.clear();
 	}
 
 	public static Map<Block, Player> getSourcePlayers() {

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -13,6 +13,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -24,6 +25,7 @@ import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.util.Information;
 import com.projectkorra.projectkorra.util.ParticleEffect;
+import com.projectkorra.projectkorra.util.TempBlock;
 
 public abstract class FireAbility extends ElementalAbility {
 
@@ -78,22 +80,8 @@ public abstract class FireAbility extends ElementalAbility {
 	public void createTempFire(final Location loc, final long time) {
 		Material fireType = this.getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE) ? Material.SOUL_FIRE : Material.FIRE;
 		
+		new TempBlock(loc.getBlock(), fireType.createBlockData(), time);
 		
-		if (ElementalAbility.isAir(loc.getBlock().getType())) {
-			loc.getBlock().setType(fireType);
-			return;
-		}
-		Information info = new Information();
-		if (TEMP_FIRE.containsKey(loc)) {
-			info = TEMP_FIRE.get(loc);
-		} else {
-			info.setBlock(loc.getBlock());
-			info.setLocation(loc);
-			info.setState(loc.getBlock().getState());
-		}
-		info.setTime(time + System.currentTimeMillis());
-		loc.getBlock().setType(fireType);
-		TEMP_FIRE.put(loc, info);
 		SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
 	}
 
@@ -128,7 +116,7 @@ public abstract class FireAbility extends ElementalAbility {
 	}
 
 	public static boolean isIgnitable(final Block block) {
-		return block != null ? isIgnitable(block.getType()) : false;
+		return isIgnitable(block.getType()) || (GeneralMethods.isSolid(block.getRelative(BlockFace.DOWN)) && isAir(block.getType()));
 	}
 
 	public static boolean isIgnitable(final Material material) {

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -57,6 +57,14 @@ public abstract class FireAbility extends ElementalAbility {
 	}
 
 	/**
+	 * 
+	 * @return Material based on whether the player is a Blue Firebender, SOUL_FIRE if true, FIRE if false.
+	 */
+	public Material getFireType() {
+		return getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE) ? Material.SOUL_FIRE : Material.FIRE;
+	}
+
+	/**
 	 * Returns if fire is allowed to completely replace blocks or if it should
 	 * place a temp fire block.
 	 */
@@ -74,9 +82,7 @@ public abstract class FireAbility extends ElementalAbility {
 
 
 	public void createTempFire(final Location loc, final long time) {
-		Material fireType = this.getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE) ? Material.SOUL_FIRE : Material.FIRE;
-
-		new TempBlock(loc.getBlock(), fireType.createBlockData(), time);
+		new TempBlock(loc.getBlock(), getFireType().createBlockData(), time);
 
 		SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
 	}
@@ -153,7 +159,7 @@ public abstract class FireAbility extends ElementalAbility {
 	}
 
 	public void playFirebendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
-		if (this.getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE)) {
+		if (getFireType() == Material.SOUL_FIRE) {
 			ParticleEffect.SOUL_FIRE_FLAME.display(loc, amount, xOffset, yOffset, zOffset);
 		} else {
 			ParticleEffect.FLAME.display(loc, amount, xOffset, yOffset, zOffset);

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -26,6 +26,7 @@ import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;
@@ -301,7 +302,7 @@ public class AirBlast extends AirAbility {
 		final Block block = this.location.getBlock();
 
 		for (final Block testblock : GeneralMethods.getBlocksAroundPoint(this.location, this.radius)) {
-			if (testblock.getType() == Material.FIRE) {
+			if (FireAbility.isFire(testblock.getType())) {
 				testblock.setType(Material.AIR);
 				testblock.getWorld().playEffect(testblock.getLocation(), Effect.EXTINGUISH, 0);
 				continue;

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -14,6 +14,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.avatar.AvatarState;
@@ -167,7 +168,7 @@ public class AirShield extends AirAbility {
 		}
 
 		for (final Block testblock : GeneralMethods.getBlocksAroundPoint(this.player.getLocation(), this.radius)) {
-			if (testblock.getType() == Material.FIRE) {
+			if (FireAbility.isFire(testblock.getType())) {
 				testblock.setType(Material.AIR);
 				testblock.getWorld().playEffect(testblock.getLocation(), Effect.EXTINGUISH, 0);
 			}

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -21,6 +21,7 @@ import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;
@@ -157,7 +158,7 @@ public class AirSwipe extends AirAbility {
 					}
 
 					for (final Block testblock : GeneralMethods.getBlocksAroundPoint(location, this.radius)) {
-						if (testblock.getType() == Material.FIRE) {
+						if (FireAbility.isFire(testblock.getType())) {
 							testblock.setType(Material.AIR);
 						}
 					}

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -460,14 +460,20 @@ public class ConfigManager {
 			earthBlocks.add(Material.ANDESITE.toString());
 			earthBlocks.add(Material.GRANITE.toString());
 			earthBlocks.add(Material.DIORITE.toString());
+			earthBlocks.add(Material.BASALT.toString());
+			earthBlocks.add(Material.ANCIENT_DEBRIS.toString());
+			earthBlocks.add(Material.BLACKSTONE.toString());
 
 			final ArrayList<String> metalBlocks = new ArrayList<String>();
 			metalBlocks.add(Material.IRON_ORE.toString());
 			metalBlocks.add(Material.GOLD_ORE.toString());
 			metalBlocks.add(Material.NETHER_QUARTZ_ORE.toString());
+			earthBlocks.add(Material.GILDED_BLACKSTONE.toString());
 			metalBlocks.add(Material.IRON_BLOCK.toString());
 			metalBlocks.add(Material.GOLD_BLOCK.toString());
 			metalBlocks.add(Material.QUARTZ_BLOCK.toString());
+			metalBlocks.add(Material.CHAIN.toString());
+			metalBlocks.add(Material.NETHERITE_BLOCK.toString());
 
 			final ArrayList<String> sandBlocks = new ArrayList<String>();
 			sandBlocks.add(Material.SAND.toString());
@@ -512,12 +518,19 @@ public class ConfigManager {
 			plantBlocks.add(Material.SUNFLOWER.toString());
 			plantBlocks.add(Material.POPPY.toString());
 			plantBlocks.add(Material.FERN.toString());
+			plantBlocks.add(Material.LILY_OF_THE_VALLEY.toString());
+			plantBlocks.add(Material.WITHER_ROSE.toString());
 			plantBlocks.add(Material.LARGE_FERN.toString());
 			plantBlocks.add(Material.RED_MUSHROOM.toString());
 			plantBlocks.add(Material.RED_MUSHROOM_BLOCK.toString());
 			plantBlocks.add(Material.BROWN_MUSHROOM.toString());
 			plantBlocks.add(Material.BROWN_MUSHROOM_BLOCK.toString());
 			plantBlocks.add(Material.MUSHROOM_STEM.toString());
+			plantBlocks.add(Material.WARPED_ROOTS.toString());
+			plantBlocks.add(Material.CRIMSON_ROOTS.toString());
+			plantBlocks.add(Material.TWISTING_VINES_PLANT.toString());
+			plantBlocks.add(Material.WEEPING_VINES_PLANT.toString());
+			plantBlocks.add(Material.NETHER_SPROUTS.toString());
 			plantBlocks.add(Material.CACTUS.toString());
 			plantBlocks.add(Material.PUMPKIN.toString());
 			plantBlocks.add(Material.PUMPKIN_STEM.toString());

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -633,7 +633,10 @@ public class ConfigManager {
 			config.addDefault("Properties.Fire.LightningSound.Sound", "ENTITY_CREEPER_HURT");
 			config.addDefault("Properties.Fire.LightningSound.Volume", 1);
 			config.addDefault("Properties.Fire.LightningSound.Pitch", 0);
-
+			config.addDefault("Properties.Fire.BlueFire.DamageFactor", 1.1);
+			config.addDefault("Properties.Fire.BlueFire.CooldownFactor", .9);
+			config.addDefault("Properties.Fire.BlueFire.RangeFactor", 1.2);
+			
 			config.addDefault("Properties.Chi.CanBendWithWeapons", true);
 
 			final ArrayList<String> disabledWorlds = new ArrayList<String>();

--- a/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
@@ -1,20 +1,15 @@
 package com.projectkorra.projectkorra.firebending;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+
 
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
-import com.projectkorra.projectkorra.BendingPlayer;
-import com.projectkorra.projectkorra.Element;
+
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.waterbending.plant.PlantRegrowth;
@@ -22,8 +17,6 @@ import com.projectkorra.projectkorra.waterbending.plant.PlantRegrowth;
 public class BlazeArc extends FireAbility {
 
 	private static final long DISSIPATE_REMOVE_TIME = 400;
-	private static final Map<Block, Player> IGNITED_BLOCKS = new ConcurrentHashMap<>();
-	private static final Map<Location, BlockState> REPLACED_BLOCKS = new ConcurrentHashMap<>();
 
 	private long time;
 	private long interval;
@@ -59,12 +52,11 @@ public class BlazeArc extends FireAbility {
 					new PlantRegrowth(this.player, block);
 				}
 			} else if (!isFire(block.getType())) {
-				REPLACED_BLOCKS.put(block.getLocation(), block.getState());
+				
 			}
 		}
 		
-		createTempFire(block.getLocation());
-		IGNITED_BLOCKS.put(block, this.getPlayer());
+		createTempFire(block.getLocation(), DISSIPATE_REMOVE_TIME);
 	}
 
 	@Override
@@ -117,12 +109,6 @@ public class BlazeArc extends FireAbility {
 		}
 	}
 
-	public static void removeAllCleanup() {
-		for (final Block block : IGNITED_BLOCKS.keySet()) {
-			removeBlock(block);
-		}
-	}
-
 	public static void removeAroundPoint(final Location location, final double radius) {
 		for (final BlazeArc stream : getAbilities(BlazeArc.class)) {
 			if (stream.location.getWorld().equals(location.getWorld())) {
@@ -130,14 +116,6 @@ public class BlazeArc extends FireAbility {
 					stream.remove();
 				}
 			}
-		}
-	}
-
-	public static void removeBlock(final Block block) {
-		if (REPLACED_BLOCKS.containsKey(block.getLocation())) {
-			block.setType(REPLACED_BLOCKS.get(block.getLocation()).getType());
-			block.setBlockData(REPLACED_BLOCKS.get(block.getLocation()).getBlockData());
-			REPLACED_BLOCKS.remove(block.getLocation());
 		}
 	}
 
@@ -219,10 +197,6 @@ public class BlazeArc extends FireAbility {
 
 	public static long getDissipateRemoveTime() {
 		return DISSIPATE_REMOVE_TIME;
-	}
-
-	public static Map<Location, BlockState> getReplacedBlocks() {
-		return REPLACED_BLOCKS;
 	}
 
 	public void setLocation(final Location location) {

--- a/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
@@ -56,7 +56,9 @@ public class BlazeArc extends FireAbility {
 			}
 		}
 		
-		createTempFire(block.getLocation(), DISSIPATE_REMOVE_TIME);
+		if(isIgnitable(block)) {
+			createTempFire(block.getLocation(), DISSIPATE_REMOVE_TIME);
+		}
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
@@ -14,6 +14,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.waterbending.plant.PlantRegrowth;
@@ -22,7 +23,6 @@ public class BlazeArc extends FireAbility {
 
 	private static final long DISSIPATE_REMOVE_TIME = 400;
 	private static final Map<Block, Player> IGNITED_BLOCKS = new ConcurrentHashMap<>();
-	private static final Map<Block, Long> IGNITED_TIMES = new ConcurrentHashMap<>();
 	private static final Map<Location, BlockState> REPLACED_BLOCKS = new ConcurrentHashMap<>();
 
 	private long time;
@@ -53,19 +53,18 @@ public class BlazeArc extends FireAbility {
 	}
 
 	private void ignite(final Block block) {
-		if (block.getType() != Material.FIRE && !isAir(block.getType())) {
+		if (!isFire(block.getType()) && !isAir(block.getType())) {
 			if (canFireGrief()) {
 				if (isPlant(block) || isSnow(block)) {
 					new PlantRegrowth(this.player, block);
 				}
-			} else if (block.getType() != Material.FIRE) {
+			} else if (!isFire(block.getType())) {
 				REPLACED_BLOCKS.put(block.getLocation(), block.getState());
 			}
 		}
-
-		block.setType(Material.FIRE);
-		IGNITED_BLOCKS.put(block, this.player);
-		IGNITED_TIMES.put(block, System.currentTimeMillis());
+		
+		createTempFire(block.getLocation());
+		IGNITED_BLOCKS.put(block, this.getPlayer());
 	}
 
 	@Override
@@ -78,7 +77,7 @@ public class BlazeArc extends FireAbility {
 			this.time = System.currentTimeMillis();
 
 			final Block block = this.location.getBlock();
-			if (block.getType() == Material.FIRE) {
+			if (isFire(block.getType())) {
 				return;
 			}
 
@@ -96,30 +95,6 @@ public class BlazeArc extends FireAbility {
 		}
 	}
 
-	public static void dissipateAll() {
-		if (DISSIPATE_REMOVE_TIME != 0) {
-			for (final Block block : IGNITED_TIMES.keySet()) {
-				if (block.getType() != Material.FIRE) {
-					removeBlock(block);
-				} else {
-					final long time = IGNITED_TIMES.get(block);
-					if (System.currentTimeMillis() > time + DISSIPATE_REMOVE_TIME) {
-						block.setType(Material.AIR);
-						removeBlock(block);
-					}
-				}
-			}
-		}
-	}
-
-	public static void handleDissipation() {
-		for (final Block block : IGNITED_BLOCKS.keySet()) {
-			if (block.getType() != Material.FIRE) {
-				IGNITED_BLOCKS.remove(block);
-			}
-		}
-	}
-
 	public static Block getIgnitable(final Block block) {
 		Block top = block;
 
@@ -131,7 +106,7 @@ public class BlazeArc extends FireAbility {
 			top = top.getRelative(BlockFace.DOWN);
 		}
 
-		if (top.getType() == Material.FIRE) {
+		if (isFire(block.getType())) {
 			return top;
 		} else if (top.getType().isBurnable()) {
 			return top;
@@ -139,22 +114,6 @@ public class BlazeArc extends FireAbility {
 			return top;
 		} else {
 			return null;
-		}
-	}
-
-	public static boolean isIgnitable(final Player player, final Block block) {
-		if (!BendingPlayer.getBendingPlayer(player).hasElement(Element.FIRE)) {
-			return false;
-		} else if (!GeneralMethods.isSolid(block.getRelative(BlockFace.DOWN))) {
-			return false;
-		} else if (block.getType() == Material.FIRE) {
-			return true;
-		} else if (block.getType().isBurnable()) {
-			return true;
-		} else if (isAir(block.getType())) {
-			return true;
-		} else {
-			return false;
 		}
 	}
 
@@ -175,12 +134,6 @@ public class BlazeArc extends FireAbility {
 	}
 
 	public static void removeBlock(final Block block) {
-		if (IGNITED_BLOCKS.containsKey(block)) {
-			IGNITED_BLOCKS.remove(block);
-		}
-		if (IGNITED_TIMES.containsKey(block)) {
-			IGNITED_TIMES.remove(block);
-		}
 		if (REPLACED_BLOCKS.containsKey(block.getLocation())) {
 			block.setType(REPLACED_BLOCKS.get(block.getLocation()).getType());
 			block.setBlockData(REPLACED_BLOCKS.get(block.getLocation()).getBlockData());
@@ -266,14 +219,6 @@ public class BlazeArc extends FireAbility {
 
 	public static long getDissipateRemoveTime() {
 		return DISSIPATE_REMOVE_TIME;
-	}
-
-	public static Map<Block, Player> getIgnitedBlocks() {
-		return IGNITED_BLOCKS;
-	}
-
-	public static Map<Block, Long> getIgnitedTimes() {
-		return IGNITED_TIMES;
 	}
 
 	public static Map<Location, BlockState> getReplacedBlocks() {

--- a/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
@@ -8,8 +8,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
-
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.BlueFireAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.waterbending.plant.PlantRegrowth;
@@ -33,6 +34,11 @@ public class BlazeArc extends FireAbility {
 		this.range = this.getDayFactor(range);
 		this.speed = getConfig().getLong("Abilities.Fire.Blaze.Speed");
 		this.interval = (long) (1000. / this.speed);
+
+		if(bPlayer.canUseSubElement(SubElement.BLUE_FIRE)) {
+			this.range += BlueFireAbility.getRangeFactor() * range;
+		}
+
 		this.origin = location.clone();
 		this.location = this.origin.clone();
 
@@ -51,11 +57,9 @@ public class BlazeArc extends FireAbility {
 				if (isPlant(block) || isSnow(block)) {
 					new PlantRegrowth(this.player, block);
 				}
-			} else if (!isFire(block.getType())) {
-				
 			}
 		}
-		
+
 		if(isIgnitable(block)) {
 			createTempFire(block.getLocation(), DISSIPATE_REMOVE_TIME);
 		}

--- a/src/com/projectkorra/projectkorra/firebending/BlazeRing.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeRing.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -162,7 +162,7 @@ public class FireBlast extends FireAbility {
 
 	private void ignite(final Location location) {
 		for (final Block block : GeneralMethods.getBlocksAroundPoint(location, this.collisionRadius)) {
-			if (isIgnitable(this.player, block) && !this.safeBlocks.contains(block) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
+			if (isIgnitable(block) && !this.safeBlocks.contains(block) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 				if (canFireGrief()) {
 					if (isPlant(block) || isSnow(block)) {
 						new PlantRegrowth(this.player, block);
@@ -201,7 +201,7 @@ public class FireBlast extends FireAbility {
 				furnace.setBurnTime((short) 800);
 				furnace.setCookTime((short) 800);
 				furnace.update();
-			} else if (BlazeArc.isIgnitable(this.player, block.getRelative(BlockFace.UP))) {
+			} else if (isIgnitable(block.getRelative(BlockFace.UP))) {
 				if ((this.isFireBurst && this.fireBurstIgnite) || !this.isFireBurst) {
 					this.ignite(this.location);
 				}

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -127,8 +127,7 @@ public class FireBlast extends FireAbility {
 		}
 		
 		if (this.showParticles) {
-			ParticleEffect.FLAME.display(this.location, 6, this.flameRadius, this.flameRadius, this.flameRadius);
-			ParticleEffect.SMOKE_NORMAL.display(this.location, 3, this.smokeRadius, this.smokeRadius, this.smokeRadius);
+			playFirebendingParticles(this.location, 6, this.flameRadius, this.flameRadius, this.flameRadius);
 		}
 		
 		if (GeneralMethods.checkDiagonalWall(this.location, this.direction)) {
@@ -167,7 +166,7 @@ public class FireBlast extends FireAbility {
 					if (isPlant(block) || isSnow(block)) {
 						new PlantRegrowth(this.player, block);
 					}
-					block.setType(Material.FIRE);
+					createTempFire(block.getLocation());
 				} else {
 					createTempFire(block.getLocation());
 				}

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -188,14 +188,8 @@ public class FireBlast extends FireAbility {
 					if (isPlant(block) || isSnow(block)) {
 						new PlantRegrowth(this.player, block);
 					}
-					createTempFire(block.getLocation());
-				} else {
-					createTempFire(block.getLocation());
 				}
-
-				if (this.dissipate) {
-					removeFire();
-				}
+				createTempFire(block.getLocation());	
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -162,7 +162,7 @@ public class FireBlast extends FireAbility {
 
 	private void ignite(final Location location) {
 		for (final Block block : GeneralMethods.getBlocksAroundPoint(location, this.collisionRadius)) {
-			if (BlazeArc.isIgnitable(this.player, block) && !this.safeBlocks.contains(block) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
+			if (isIgnitable(this.player, block) && !this.safeBlocks.contains(block) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 				if (canFireGrief()) {
 					if (isPlant(block) || isSnow(block)) {
 						new PlantRegrowth(this.player, block);
@@ -173,8 +173,7 @@ public class FireBlast extends FireAbility {
 				}
 
 				if (this.dissipate) {
-					BlazeArc.getIgnitedBlocks().put(block, this.player);
-					BlazeArc.getIgnitedTimes().put(block, System.currentTimeMillis());
+					removeFire();
 				}
 			}
 		}

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
@@ -16,7 +15,9 @@ import org.bukkit.entity.TNTPrimed;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.BlueFireAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -78,15 +79,29 @@ public class FireBlastCharged extends FireAbility {
 		this.fireTicks = getConfig().getDouble("Abilities.Fire.FireBlast.Charged.FireTicks");
 		this.innerRadius = this.damageRadius / 2;
 
+
+		long chargeTimeMod = 0;
+		int damageMod = 0;
+		int rangeMod = 0;
+
 		if (isDay(player.getWorld())) {
-			this.chargeTime = (long) (this.chargeTime / getDayFactor());
-			this.maxDamage = this.getDayFactor(this.maxDamage);
-			this.range = this.getDayFactor(this.range);
+			chargeTimeMod = (long) (this.chargeTime / getDayFactor()) - this.chargeTime;
+			damageMod = (int) (this.getDayFactor(this.maxDamage) - this.maxDamage);
+			rangeMod = (int) (this.getDayFactor(this.range) - this.range);
 		}
+
+		chargeTimeMod = (long) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (chargeTime / BlueFireAbility.getCooldownFactor() - chargeTime) + chargeTimeMod : chargeTimeMod);
+		damageMod = (int) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (BlueFireAbility.getDamageFactor() * maxDamage - maxDamage) + damageMod : damageMod);
+		rangeMod = (int) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (BlueFireAbility.getRangeFactor() * range - range) + rangeMod : rangeMod);
+
 		if (this.bPlayer.isAvatarState()) {
 			this.chargeTime = getConfig().getLong("Abilities.Avatar.AvatarState.Fire.FireBlast.Charged.ChargeTime");
 			this.maxDamage = getConfig().getDouble("Abilities.Avatar.AvatarState.Fire.FireBlast.Charged.Damage");
 		}
+
+		this.chargeTime += chargeTimeMod;
+		this.maxDamage += damageMod;
+		this.range += rangeMod;
 
 		if (!player.getEyeLocation().getBlock().isLiquid()) {
 			this.start();
@@ -273,7 +288,7 @@ public class FireBlastCharged extends FireAbility {
 			if (!this.launched && !this.charged) {
 				return;
 			} else if (!this.launched) {
-				playFirebendingParticles(this.player.getEyeLocation(), 3, 0, 0, 0);
+				playFirebendingParticles(this.player.getEyeLocation().clone().add(this.player.getEyeLocation().getDirection().clone()), 3, 0, 0, 0);
 				return;
 			}
 

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -207,8 +207,7 @@ public class FireBlastCharged extends FireAbility {
 
 	private void executeFireball() {
 		for (final Block block : GeneralMethods.getBlocksAroundPoint(this.location, this.collisionRadius)) {
-			ParticleEffect.FLAME.display(block.getLocation(), 5, 0.5, 0.5, 0.5, 0);
-			ParticleEffect.SMOKE_NORMAL.display(block.getLocation(), 2, 0.5, 0.5, 0.5, 0);
+			playFirebendingParticles(block.getLocation(), 5, 0.5, 0.5, 0.5);
 			if ((new Random()).nextInt(4) == 0) {
 				playFirebendingSound(this.location);
 			}
@@ -233,15 +232,8 @@ public class FireBlastCharged extends FireAbility {
 
 	private void ignite(final Location location) {
 		for (final Block block : GeneralMethods.getBlocksAroundPoint(location, this.collisionRadius)) {
-			if (BlazeArc.isIgnitable(this.player, block)) {
-				if (block.getType() != Material.FIRE) {
-					BlazeArc.getReplacedBlocks().put(block.getLocation(), block.getState());
-				}
-				block.setType(Material.FIRE);
-				if (this.dissipate) {
-					BlazeArc.getIgnitedBlocks().put(block, this.player);
-					BlazeArc.getIgnitedTimes().put(block, System.currentTimeMillis());
-				}
+			if (isIgnitable(block)) {
+				createTempFire(block.getLocation());
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Effect;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -273,7 +273,7 @@ public class FireBlastCharged extends FireAbility {
 			if (!this.launched && !this.charged) {
 				return;
 			} else if (!this.launched) {
-				this.player.getWorld().playEffect(this.player.getEyeLocation(), Effect.MOBSPAWNER_FLAMES, 0, 3);
+				playFirebendingParticles(this.player.getEyeLocation(), 3, 0, 0, 0);
 				return;
 			}
 

--- a/src/com/projectkorra/projectkorra/firebending/FireBurst.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBurst.java
@@ -11,6 +11,8 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.Element.SubElement;
+import com.projectkorra.projectkorra.ability.BlueFireAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 
@@ -48,14 +50,23 @@ public class FireBurst extends FireAbility {
 			return;
 		}
 
+
+		long chargeTimeMod = 0;
+
 		if (isDay(player.getWorld())) {
-			this.chargeTime /= getDayFactor();
+			chargeTimeMod = (long) (this.getDayFactor(chargeTime) - chargeTime);
 		}
+
+		chargeTimeMod = (long) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (chargeTime / BlueFireAbility.getCooldownFactor() - chargeTime) + chargeTimeMod : chargeTimeMod);
+
+
 		if (this.bPlayer.isAvatarState()) {
 			this.chargeTime = getConfig().getLong("Abilities.Avatar.AvatarState.Fire.FireBurst.Damage");
 			this.damage = getConfig().getInt("Abilities.Avatar.AvatarState.Fire.FireBurst.Damage");
 			this.cooldown = getConfig().getLong("Abilities.Avatar.AvatarState.Fire.FireBurst.Cooldown");
 		}
+
+		this.chargeTime += chargeTimeMod;
 
 		this.start();
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireBurst.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBurst.java
@@ -50,7 +50,6 @@ public class FireBurst extends FireAbility {
 			return;
 		}
 
-
 		long chargeTimeMod = 0;
 
 		if (isDay(player.getWorld())) {
@@ -58,7 +57,6 @@ public class FireBurst extends FireAbility {
 		}
 
 		chargeTimeMod = (long) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (chargeTime / BlueFireAbility.getCooldownFactor() - chargeTime) + chargeTimeMod : chargeTimeMod);
-
 
 		if (this.bPlayer.isAvatarState()) {
 			this.chargeTime = getConfig().getLong("Abilities.Avatar.AvatarState.Fire.FireBurst.Damage");

--- a/src/com/projectkorra/projectkorra/firebending/FireBurst.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBurst.java
@@ -3,7 +3,6 @@ package com.projectkorra.projectkorra.firebending;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;

--- a/src/com/projectkorra/projectkorra/firebending/FireBurst.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBurst.java
@@ -137,8 +137,9 @@ public class FireBurst extends FireAbility {
 				this.remove();
 			}
 		} else if (this.charged) {
-			final Location location = this.player.getEyeLocation();
-			location.getWorld().playEffect(location, Effect.MOBSPAWNER_FLAMES, 4, 3);
+			final Location location = this.player.getEyeLocation().clone();
+			location.add(location.getDirection().clone());
+			playFirebendingParticles(location, 1, .01, .01, .01);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -65,7 +65,7 @@ public class FireJet extends FireAbility {
 				}
 
 			} else if (ElementalAbility.isAir(block.getType())) {
-				block.setType(Material.FIRE);
+				createTempFire(block.getLocation());
 			}
 
 			this.flightHandler.createInstance(player, this.getName());
@@ -93,8 +93,7 @@ public class FireJet extends FireAbility {
 				playFirebendingSound(this.player.getLocation());
 			}
 
-			ParticleEffect.FLAME.display(this.player.getLocation(), 20, 0.6, 0.6, 0.6);
-			ParticleEffect.SMOKE_NORMAL.display(this.player.getLocation(), 10, 0.6, 0.6, 0.6);
+			ParticleEffect.FLAME.display(this.player.getLocation(), 10, 0.3, 0.3, 0.3);
 			double timefactor;
 
 			if (this.bPlayer.isAvatarState() && this.avatarStateToggled) {

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -57,7 +57,7 @@ public class FireJet extends FireAbility {
 		this.speed = this.getDayFactor(this.speed);
 		final Block block = player.getLocation().getBlock();
 
-		if (BlazeArc.isIgnitable(player, block) || ElementalAbility.isAir(block.getType()) || block.getType() == Material.STONE_SLAB || block.getType() == Material.ACACIA_SLAB || block.getType() == Material.BIRCH_SLAB || block.getType() == Material.DARK_OAK_SLAB || block.getType() == Material.JUNGLE_SLAB || block.getType() == Material.OAK_SLAB || block.getType() == Material.SPRUCE_SLAB || isIlluminationTorch(block) || this.bPlayer.isAvatarState()) {
+		if (isIgnitable(player, block) || ElementalAbility.isAir(block.getType()) || block.getType() == Material.STONE_SLAB || block.getType() == Material.ACACIA_SLAB || block.getType() == Material.BIRCH_SLAB || block.getType() == Material.DARK_OAK_SLAB || block.getType() == Material.JUNGLE_SLAB || block.getType() == Material.OAK_SLAB || block.getType() == Material.SPRUCE_SLAB || isIlluminationTorch(block) || this.bPlayer.isAvatarState()) {
 			player.setVelocity(player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
 			if (!canFireGrief()) {
 				if (ElementalAbility.isAir(block.getType())) {

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -93,7 +93,7 @@ public class FireJet extends FireAbility {
 				playFirebendingSound(this.player.getLocation());
 			}
 
-			ParticleEffect.FLAME.display(this.player.getLocation(), 10, 0.3, 0.3, 0.3);
+			playFirebendingParticles(this.player.getLocation(), 10, 0.3, 0.3, 0.3);
 			double timefactor;
 
 			if (this.bPlayer.isAvatarState() && this.avatarStateToggled) {

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -57,7 +57,7 @@ public class FireJet extends FireAbility {
 		this.speed = this.getDayFactor(this.speed);
 		final Block block = player.getLocation().getBlock();
 
-		if (isIgnitable(player, block) || ElementalAbility.isAir(block.getType()) || block.getType() == Material.STONE_SLAB || block.getType() == Material.ACACIA_SLAB || block.getType() == Material.BIRCH_SLAB || block.getType() == Material.DARK_OAK_SLAB || block.getType() == Material.JUNGLE_SLAB || block.getType() == Material.OAK_SLAB || block.getType() == Material.SPRUCE_SLAB || isIlluminationTorch(block) || this.bPlayer.isAvatarState()) {
+		if (isIgnitable(block) || ElementalAbility.isAir(block.getType()) || block.getType() == Material.STONE_SLAB || block.getType() == Material.ACACIA_SLAB || block.getType() == Material.BIRCH_SLAB || block.getType() == Material.DARK_OAK_SLAB || block.getType() == Material.JUNGLE_SLAB || block.getType() == Material.OAK_SLAB || block.getType() == Material.SPRUCE_SLAB || isIlluminationTorch(block) || this.bPlayer.isAvatarState()) {
 			player.setVelocity(player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
 			if (!canFireGrief()) {
 				if (ElementalAbility.isAir(block.getType())) {

--- a/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
@@ -15,7 +15,6 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.util.DamageHandler;
-import com.projectkorra.projectkorra.util.ParticleEffect;
 
 public class FireManipulation extends FireAbility {
 
@@ -113,8 +112,7 @@ public class FireManipulation extends FireAbility {
 					this.points.remove(point);
 					return;
 				}
-				ParticleEffect.FLAME.display(point, 12, 0.25, 0.25, 0.25);
-				ParticleEffect.SMOKE_NORMAL.display(point, 6, 0.25, 0.25, 0.25);
+				playFirebendingParticles(point, 12, 0.25, 0.25, 0.25);
 				for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(point, 1.2D)) {
 					if (entity instanceof LivingEntity && entity.getUniqueId() != this.player.getUniqueId()) {
 						DamageHandler.damageEntity(entity, this.shieldDamage, this);
@@ -143,8 +141,7 @@ public class FireManipulation extends FireAbility {
 			for (final Location point : this.points.keySet()) {
 				final Vector direction = this.focalPoint.toVector().subtract(point.toVector());
 				point.add(direction.clone().multiply(this.streamSpeed / 5));
-				ParticleEffect.FLAME.display(point, this.shieldParticles, 0.25, 0.25, 0.25);
-				ParticleEffect.SMOKE_NORMAL.display(point, this.shieldParticles / 2, 0.25, 0.25, 0.25);
+				playFirebendingParticles(point, this.shieldParticles, 0.25, 0.25, 0.25);
 			}
 		} else {
 			Vector direction = this.player.getLocation().getDirection().clone();
@@ -173,8 +170,7 @@ public class FireManipulation extends FireAbility {
 				return;
 			}
 
-			ParticleEffect.FLAME.display(this.shotPoint, this.streamParticles, 0.5, 0.5, 0.5, 0.01);
-			ParticleEffect.SMOKE_NORMAL.display(this.shotPoint, this.streamParticles / 2, 0.5, 0.5, 0.5, 0.01);
+			playFirebendingParticles(this.shotPoint, this.streamParticles, 0.5, 0.5, 0.5);
 			for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.shotPoint, 2)) {
 				if (entity instanceof LivingEntity && entity.getUniqueId() != this.player.getUniqueId()) {
 					DamageHandler.damageEntity(entity, this.streamDamage, this);

--- a/src/com/projectkorra/projectkorra/firebending/FireShield.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireShield.java
@@ -2,10 +2,7 @@ package com.projectkorra.projectkorra.firebending;
 
 import java.util.Random;
 
-import org.bukkit.Effect;
 import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -17,7 +14,6 @@ import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
-import com.projectkorra.projectkorra.util.ParticleEffect;
 
 public class FireShield extends FireAbility {
 
@@ -125,11 +121,8 @@ public class FireShield extends FireAbility {
 					final double rtheta = Math.toRadians(theta);
 
 					final Location display = this.location.clone().add(this.shieldRadius / 1.5 * Math.cos(rphi) * Math.sin(rtheta), this.shieldRadius / 1.5 * Math.cos(rtheta), this.shieldRadius / 1.5 * Math.sin(rphi) * Math.sin(rtheta));
-					if (this.random.nextInt(6) == 0) {
-						ParticleEffect.SMOKE_NORMAL.display(display, 1, 0, 0, 0);
-					}
 					if (this.random.nextInt(4) == 0) {
-						ParticleEffect.FLAME.display(display, 1, 0.1, 0.1, 0.1, 0.013);
+						playFirebendingParticles(display, 1, 0.1, 0.1, 0.1);
 					}
 					if (this.random.nextInt(7) == 0) {
 						playFirebendingSound(display);
@@ -140,13 +133,6 @@ public class FireShield extends FireAbility {
 			this.increment += 20;
 			if (this.increment >= 70) {
 				this.increment = 20;
-			}
-
-			for (final Block testblock : GeneralMethods.getBlocksAroundPoint(this.player.getLocation(), this.shieldRadius)) {
-				if (testblock.getType() == Material.FIRE) {
-					testblock.setType(Material.AIR);
-					testblock.getWorld().playEffect(testblock.getLocation(), Effect.EXTINGUISH, 0);
-				}
 			}
 
 			for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, this.shieldRadius)) {
@@ -165,15 +151,12 @@ public class FireShield extends FireAbility {
 			this.location = this.player.getEyeLocation().clone();
 			final Vector direction = this.location.getDirection();
 			this.location.add(direction.multiply(this.shieldRadius));
-			ParticleEffect.FLAME.display(this.location, 3, 0.2, 0.2, 0.2, 0.00023);
+			playFirebendingParticles(this.location, 3, 0.2, 0.2, 0.2);
 
 			for (double theta = 0; theta < 360; theta += 20) {
 				final Vector vector = GeneralMethods.getOrthogonalVector(direction, theta, this.discRadius / 1.5);
 				final Location display = this.location.add(vector);
-				if (this.random.nextInt(6) == 0) {
-					ParticleEffect.SMOKE_NORMAL.display(display, 1, 0, 0, 0);
-				}
-				ParticleEffect.FLAME.display(display, 2, 0.3, 0.2, 0.3, 0.023);
+				playFirebendingParticles(display, 2, 0.3, 0.2, 0.3);
 				if (this.random.nextInt(4) == 0) {
 					playFirebendingSound(display);
 				}

--- a/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -22,6 +22,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.FireAbility;
@@ -43,7 +44,7 @@ public class HeatControl extends FireAbility {
 		COOK, EXTINGUISH, MELT, SOLIDIFY
 	}
 
-	private static final Material[] COOKABLE_MATERIALS = { Material.BEEF, Material.CHICKEN, Material.COD, Material.PORKCHOP, Material.POTATO, Material.RABBIT, Material.MUTTON, Material.SALMON, Material.KELP, Material.WET_SPONGE, Material.CHORUS_FRUIT };
+	private static final Material[] COOKABLE_MATERIALS = { Material.BEEF, Material.CHICKEN, Material.COD, Material.PORKCHOP, Material.POTATO, Material.RABBIT, Material.MUTTON, Material.SALMON, Material.KELP, Material.WET_SPONGE, Material.CHORUS_FRUIT, Material.STICK };
 
 	private HeatControlType heatControlType;
 
@@ -281,6 +282,9 @@ public class HeatControl extends FireAbility {
 				break;
 			case WET_SPONGE:
 				cooked = new ItemStack(Material.SPONGE);
+				break;
+			case STICK:
+				cooked = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? new ItemStack(Material.SOUL_TORCH) : new ItemStack(Material.TORCH);
 			default:
 				break;
 		}

--- a/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -277,9 +277,6 @@ public class HeatControl extends FireAbility {
 			case CHORUS_FRUIT:
 				cooked = new ItemStack(Material.POPPED_CHORUS_FRUIT);
 				break;
-			case WHEAT:
-				cooked = new ItemStack(Material.BREAD);
-				break;
 			case WET_SPONGE:
 				cooked = new ItemStack(Material.SPONGE);
 				break;

--- a/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -43,7 +43,7 @@ public class HeatControl extends FireAbility {
 		COOK, EXTINGUISH, MELT, SOLIDIFY
 	}
 
-	private static final Material[] COOKABLE_MATERIALS = { Material.BEEF, Material.CHICKEN, Material.COD, Material.PORKCHOP, Material.POTATO, Material.RABBIT, Material.MUTTON, Material.SALMON, Material.KELP };
+	private static final Material[] COOKABLE_MATERIALS = { Material.BEEF, Material.CHICKEN, Material.COD, Material.PORKCHOP, Material.POTATO, Material.RABBIT, Material.MUTTON, Material.SALMON, Material.KELP, Material.WET_SPONGE, Material.CHORUS_FRUIT };
 
 	private HeatControlType heatControlType;
 
@@ -289,7 +289,7 @@ public class HeatControl extends FireAbility {
 	}
 
 	public void displayCookParticles() {
-		ParticleEffect.FLAME.display(this.player.getLocation().clone().add(0, 1, 0), 3, 0.5, 0.5, 0.5);
+		playFirebendingParticles(this.player.getLocation().clone().add(0, 1, 0), 3, 0.5, 0.5, 0.5);
 		ParticleEffect.SMOKE_NORMAL.display(this.player.getLocation().clone().add(0, 1, 0), 2, 0.5, 0.5, 0.5);
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -194,7 +194,7 @@ public class HeatControl extends FireAbility {
 
 			for (final Block block : GeneralMethods.getBlocksAroundPoint(this.player.getLocation(), this.extinguishRadius)) {
 				final Material material = block.getType();
-				if (material == Material.FIRE && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
+				if (isFire(material) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 
 					block.setType(Material.AIR);
 					block.getWorld().playEffect(block.getLocation(), Effect.EXTINGUISH, 0);
@@ -273,6 +273,14 @@ public class HeatControl extends FireAbility {
 			case KELP:
 				cooked = new ItemStack(Material.DRIED_KELP);
 				break;
+			case CHORUS_FRUIT:
+				cooked = new ItemStack(Material.POPPED_CHORUS_FRUIT);
+				break;
+			case WHEAT:
+				cooked = new ItemStack(Material.BREAD);
+				break;
+			case WET_SPONGE:
+				cooked = new ItemStack(Material.SPONGE);
 			default:
 				break;
 		}

--- a/src/com/projectkorra/projectkorra/firebending/Illumination.java
+++ b/src/com/projectkorra/projectkorra/firebending/Illumination.java
@@ -11,6 +11,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -123,7 +124,7 @@ public class Illumination extends FireAbility {
 		}
 
 		this.revert();
-		this.block = new TempBlock(standingBlock, Material.TORCH);
+		this.block = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? new TempBlock(standingBlock, Material.SOUL_TORCH) : new TempBlock(standingBlock, Material.TORCH);
 		BLOCKS.put(this.block, this.player);
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/Illumination.java
+++ b/src/com/projectkorra/projectkorra/firebending/Illumination.java
@@ -112,9 +112,7 @@ public class Illumination extends FireAbility {
 		final Block standingBlock = this.player.getLocation().getBlock();
 		final Block standBlock = standingBlock.getRelative(BlockFace.DOWN);
 
-		if (!BlazeArc.isIgnitable(this.player, standingBlock)) {
-			return;
-		} else if (!GeneralMethods.isSolid(standBlock)) {
+		if (!GeneralMethods.isSolid(standBlock)) {
 			return;
 		} else if (this.block != null && standingBlock.equals(this.block.getBlock())) {
 			return;

--- a/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -17,7 +17,6 @@ import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
 import com.projectkorra.projectkorra.util.DamageHandler;
-import com.projectkorra.projectkorra.util.ParticleEffect;
 import com.projectkorra.projectkorra.util.TempBlock;
 
 public class WallOfFire extends FireAbility {
@@ -147,8 +146,8 @@ public class WallOfFire extends FireAbility {
 			if (!this.isTransparent(block)) {
 				continue;
 			}
-			ParticleEffect.FLAME.display(block.getLocation(), 3, 0.6, 0.6, 0.6);
-			ParticleEffect.SMOKE_NORMAL.display(block.getLocation(), 2, 0.6, 0.6, 0.6);
+			playFirebendingParticles(block.getLocation(), 3, 0.6, 0.6, 0.6);
+			
 
 			if (this.random.nextInt(7) == 0) {
 				playFirebendingSound(block.getLocation());

--- a/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -11,8 +11,10 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.BlueFireAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
@@ -71,12 +73,23 @@ public class WallOfFire extends FireAbility {
 
 		this.origin = GeneralMethods.getTargetedLocation(player, this.range);
 
+		int widthMod = 0;
+		int heightMod = 0;
+		long durationMod = 0;
+		int damageMod = 0;
+
 		if (isDay(player.getWorld())) {
-			this.width = (int) this.getDayFactor(this.width);
-			this.height = (int) this.getDayFactor(this.height);
-			this.duration = (long) this.getDayFactor(this.duration);
-			this.damage = (int) this.getDayFactor(this.damage);
+			widthMod = (int) this.getDayFactor(this.width) - this.width;
+			heightMod = (int) this.getDayFactor(this.height) - this.height;
+			durationMod = ((long) this.getDayFactor(this.duration) - this.duration);
+			damageMod = (int) (this.getDayFactor(this.damage) - this.damage);
 		}
+
+		widthMod = (int) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (BlueFireAbility.getRangeFactor() * width - width) + widthMod : widthMod);
+		heightMod = (int) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (BlueFireAbility.getRangeFactor() * height - height) + heightMod : heightMod);
+		durationMod = (int) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (duration / BlueFireAbility.getCooldownFactor() - duration) + durationMod : durationMod);
+		damageMod = (int) (bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (BlueFireAbility.getDamageFactor() * damage - damage) + damageMod : damageMod);
+
 
 		if (this.bPlayer.isAvatarState()) {
 			this.width = getConfig().getInt("Abilities.Avatar.AvatarState.Fire.WallOfFire.Width");
@@ -85,6 +98,12 @@ public class WallOfFire extends FireAbility {
 			this.damage = getConfig().getInt("Abilities.Avatar.AvatarState.Fire.WallOfFire.Damage");
 			this.fireTicks = getConfig().getDouble("Abilities.Avatar.AvatarState.Fire.WallOfFire.FireTicks");
 		}
+
+		this.width += widthMod;
+		this.height += heightMod;
+		this.duration += durationMod;
+		this.damage += damageMod;
+
 
 		this.time = System.currentTimeMillis();
 		final Block block = this.origin.getBlock();
@@ -147,7 +166,7 @@ public class WallOfFire extends FireAbility {
 				continue;
 			}
 			playFirebendingParticles(block.getLocation(), 3, 0.6, 0.6, 0.6);
-			
+
 
 			if (this.random.nextInt(7) == 0) {
 				playFirebendingSound(block.getLocation());

--- a/src/com/projectkorra/projectkorra/firebending/bluefire/BlueFirePassive.java
+++ b/src/com/projectkorra/projectkorra/firebending/bluefire/BlueFirePassive.java
@@ -1,0 +1,80 @@
+package com.projectkorra.projectkorra.firebending.bluefire;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.BlueFireAbility;
+import com.projectkorra.projectkorra.ability.PassiveAbility;
+import com.projectkorra.projectkorra.util.TempBlock;
+
+public class BlueFirePassive extends BlueFireAbility implements PassiveAbility {
+
+	public BlueFirePassive(Player player) {
+		super(player);
+		// TODO Auto-generated constructor stub
+
+	}
+
+	@Override
+	public void progress() {
+		// TODO Auto-generated method stub
+		if(bPlayer.canBendPassive(this)) {
+			for(Block b : GeneralMethods.getBlocksAroundPoint(player.getLocation(), 5)) {
+				if (b.getType() == Material.TORCH ) { 
+					new TempBlock(b, Material.SOUL_TORCH.createBlockData(), 5000);
+				} else if (b.getType() == Material.WALL_TORCH) {
+					new TempBlock(b, Material.SOUL_WALL_TORCH.createBlockData(), 5000);
+				} else if (b.getType() == Material.FIRE) {
+					new TempBlock(b, Material.SOUL_FIRE.createBlockData(), 5000);
+				} else {
+					// do nothing
+				}
+			}
+		}
+	}
+
+	@Override
+	public boolean isSneakAbility() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isHarmlessAbility() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public long getCooldown() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public String getName() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Location getLocation() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isInstantiable() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isProgressable() {
+		// TODO Auto-generated method stub
+		return true;
+	}
+
+}

--- a/src/com/projectkorra/projectkorra/firebending/bluefire/BlueFirePassive.java
+++ b/src/com/projectkorra/projectkorra/firebending/bluefire/BlueFirePassive.java
@@ -13,13 +13,10 @@ public class BlueFirePassive extends BlueFireAbility implements PassiveAbility {
 
 	public BlueFirePassive(Player player) {
 		super(player);
-		// TODO Auto-generated constructor stub
-
 	}
 
 	@Override
 	public void progress() {
-		// TODO Auto-generated method stub
 		if(bPlayer.canBendPassive(this)) {
 			for(Block b : GeneralMethods.getBlocksAroundPoint(player.getLocation(), 5)) {
 				if (b.getType() == Material.TORCH ) { 
@@ -37,43 +34,36 @@ public class BlueFirePassive extends BlueFireAbility implements PassiveAbility {
 
 	@Override
 	public boolean isSneakAbility() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
 	@Override
 	public boolean isHarmlessAbility() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
 	@Override
 	public long getCooldown() {
-		// TODO Auto-generated method stub
 		return 0;
 	}
 
 	@Override
 	public String getName() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public Location getLocation() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public boolean isInstantiable() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
 	@Override
 	public boolean isProgressable() {
-		// TODO Auto-generated method stub
 		return true;
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -15,6 +15,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
@@ -61,9 +62,9 @@ public class FireComboStream extends BukkitRunnable {
 		this.checkCollisionCounter = 0;
 		this.spread = 0;
 		this.collisionRadius = 2;
-		this.particleEffect = ParticleEffect.FLAME;
 		this.player = player;
 		this.bPlayer = BendingPlayer.getBendingPlayer(player);
+		this.particleEffect = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? ParticleEffect.SOUL_FIRE_FLAME : ParticleEffect.FLAME;
 		this.coreAbility = coreAbility;
 		this.direction = direction;
 		this.speed = speed;

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
@@ -21,7 +21,6 @@ import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
 import com.projectkorra.projectkorra.util.ClickType;
 import com.projectkorra.projectkorra.util.DamageHandler;
-import com.projectkorra.projectkorra.util.ParticleEffect;
 
 public class FireWheel extends FireAbility implements ComboAbility {
 
@@ -139,7 +138,7 @@ public class FireWheel extends FireAbility implements ComboAbility {
 			final Vector newDir = this.direction.clone().multiply(this.radius * Math.cos(Math.toRadians(i)));
 			tempLoc.add(newDir);
 			tempLoc.setY(tempLoc.getY() + (this.radius * Math.sin(Math.toRadians(i))));
-			ParticleEffect.FLAME.display(tempLoc, 0, 0, 0, 0, 1);
+			playFirebendingParticles(tempLoc, 0, 0, 0, 0);
 		}
 
 		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, this.radius + 0.5)) {

--- a/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
+++ b/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
@@ -103,7 +103,8 @@ public class Combustion extends CombustionAbility {
 	}
 
 	private void advanceLocation() {
-		ParticleEffect.FIREWORKS_SPARK.display(this.location, 8, Math.random() / 2, Math.random() / 2, Math.random() / 2, 0);
+		ParticleEffect.FIREWORKS_SPARK.display(this.location, 2, .001, .001, .001, 0);
+		ParticleEffect.CRIT.display(this.location, 3, Math.random() * 2, Math.random() * 2, Math.random() * 2, 0);
 		playCombustionSound(this.location);
 		this.location = this.location.add(this.direction.clone().multiply(this.speedFactor));
 	}

--- a/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
+++ b/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
@@ -103,8 +103,7 @@ public class Combustion extends CombustionAbility {
 	}
 
 	private void advanceLocation() {
-		ParticleEffect.FIREWORKS_SPARK.display(this.location, 5, Math.random() / 2, Math.random() / 2, Math.random() / 2, 0);
-		ParticleEffect.FLAME.display(this.location, 2, Math.random() / 2, Math.random() / 2, Math.random() / 2);
+		ParticleEffect.FIREWORKS_SPARK.display(this.location, 8, Math.random() / 2, Math.random() / 2, Math.random() / 2, 0);
 		playCombustionSound(this.location);
 		this.location = this.location.add(this.direction.clone().multiply(this.speedFactor));
 	}

--- a/src/com/projectkorra/projectkorra/firebending/util/FirebendingManager.java
+++ b/src/com/projectkorra/projectkorra/firebending/util/FirebendingManager.java
@@ -2,7 +2,6 @@ package com.projectkorra.projectkorra.firebending.util;
 
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.FireAbility;
-import com.projectkorra.projectkorra.firebending.BlazeArc;
 
 public class FirebendingManager implements Runnable {
 

--- a/src/com/projectkorra/projectkorra/firebending/util/FirebendingManager.java
+++ b/src/com/projectkorra/projectkorra/firebending/util/FirebendingManager.java
@@ -14,9 +14,7 @@ public class FirebendingManager implements Runnable {
 
 	@Override
 	public void run() {
-		BlazeArc.handleDissipation();
 		FireDamageTimer.handleFlames();
-		BlazeArc.dissipateAll();
 		FireAbility.removeFire();
 	}
 }

--- a/src/com/projectkorra/projectkorra/firebending/util/FirebendingManager.java
+++ b/src/com/projectkorra/projectkorra/firebending/util/FirebendingManager.java
@@ -1,7 +1,6 @@
 package com.projectkorra.projectkorra.firebending.util;
 
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.FireAbility;
 
 public class FirebendingManager implements Runnable {
 
@@ -14,6 +13,5 @@ public class FirebendingManager implements Runnable {
 	@Override
 	public void run() {
 		FireDamageTimer.handleFlames();
-		FireAbility.removeFire();
 	}
 }

--- a/src/com/projectkorra/projectkorra/util/ParticleEffect.java
+++ b/src/com/projectkorra/projectkorra/util/ParticleEffect.java
@@ -40,6 +40,7 @@ public enum ParticleEffect {
 	FALLING_DUST (Particle.FALLING_DUST),
 	FIREWORKS_SPARK (Particle.FIREWORKS_SPARK),
 	FLAME (Particle.FLAME),
+	SOUL_FIRE_FLAME (Particle.SOUL_FIRE_FLAME),
 	HEART (Particle.HEART),
 	
 	/**

--- a/src/com/projectkorra/projectkorra/util/ParticleEffect.java
+++ b/src/com/projectkorra/projectkorra/util/ParticleEffect.java
@@ -6,6 +6,9 @@ import org.bukkit.Particle.DustOptions;
 import org.bukkit.inventory.ItemStack;
 
 public enum ParticleEffect {
+	
+	ASH (Particle.ASH),
+	
 	BARRIER (Particle.BARRIER),
 	
 	/**
@@ -19,7 +22,11 @@ public enum ParticleEffect {
 	BLOCK_DUST (Particle.BLOCK_DUST),
 	BUBBLE_COLUMN_UP (Particle.BUBBLE_COLUMN_UP),
 	BUBBLE_POP (Particle.BUBBLE_POP),
+	CAMPFIRE_COSY_SMOKE (Particle.CAMPFIRE_COSY_SMOKE),
+	CAMPFIRE_SIGNAL_SMOKE (Particle.CAMPFIRE_SIGNAL_SMOKE),
 	CLOUD (Particle.CLOUD),
+	COMPOSTER (Particle.COMPOSTER),
+	CRIMSON_SPORE (Particle.CRIMSON_SPORE),
 	CRIT (Particle.CRIT),
 	CRIT_MAGIC (Particle.CRIT_MAGIC), @Deprecated MAGIC_CRIT (Particle.CRIT_MAGIC),
 	CURRENT_DOWN (Particle.CURRENT_DOWN),
@@ -28,6 +35,8 @@ public enum ParticleEffect {
 	DRAGON_BREATH (Particle.DRAGON_BREATH),
 	DRIP_LAVA (Particle.DRIP_LAVA),
 	DRIP_WATER (Particle.DRIP_WATER),
+	DRIPPING_HONEY (Particle.DRIPPING_HONEY),
+	DRIPPING_OBSIDIAN_TEAR (Particle.DRIPPING_OBSIDIAN_TEAR),
 	ENCHANTMENT_TABLE (Particle.ENCHANTMENT_TABLE),
 	END_ROD (Particle.END_ROD),
 	EXPLOSION_HUGE (Particle.EXPLOSION_HUGE), @Deprecated HUGE_EXPLOSION (Particle.EXPLOSION_HUGE),
@@ -38,15 +47,23 @@ public enum ParticleEffect {
 	 * Applicable data: {@link BlockData}
 	 */
 	FALLING_DUST (Particle.FALLING_DUST),
+	FALLING_HONEY (Particle.FALLING_HONEY),
+	FALLING_LAVA (Particle.FALLING_LAVA),
+	FALLING_NECTAR (Particle.FALLING_NECTAR),
+	FALLING_OBSIDIAN_TEAR (Particle.FALLING_OBSIDIAN_TEAR),
+	FALLING_WATER (Particle.FALLING_WATER),
 	FIREWORKS_SPARK (Particle.FIREWORKS_SPARK),
 	FLAME (Particle.FLAME),
-	SOUL_FIRE_FLAME (Particle.SOUL_FIRE_FLAME),
+	FLASH (Particle.FLASH),
 	HEART (Particle.HEART),
 	
 	/**
 	 * Applicable data: {@link ItemStack}
 	 */
 	ITEM_CRACK (Particle.ITEM_CRACK),
+	LANDING_HONEY (Particle.LANDING_HONEY),
+	LANDING_LAVA (Particle.LANDING_LAVA),
+	LANDING_OBSIDIAN_TEAR (Particle.LANDING_OBSIDIAN_TEAR),
 	LAVA (Particle.LAVA),
 	MOB_APPEARANCE (Particle.MOB_APPEARANCE),
 	NAUTILUS (Particle.NAUTILUS),
@@ -57,11 +74,15 @@ public enum ParticleEffect {
 	 * Applicable data: {@link DustOptions}
 	 */
 	REDSTONE (Particle.REDSTONE), @Deprecated RED_DUST (Particle.REDSTONE),
+	REVERSE_PORTAL (Particle.REVERSE_PORTAL),
 	SLIME (Particle.SLIME),
 	SMOKE_NORMAL (Particle.SMOKE_NORMAL), @Deprecated SMOKE (Particle.SMOKE_NORMAL),
 	SMOKE_LARGE (Particle.SMOKE_LARGE), @Deprecated LARGE_SMOKE (Particle.SMOKE_LARGE),
+	SNEEZE (Particle.SNEEZE),
 	SNOW_SHOVEL (Particle.SNOW_SHOVEL),
 	SNOWBALL (Particle.SNOWBALL), @Deprecated SNOWBALL_PROOF (Particle.SNOWBALL),
+	SOUL (Particle.SOUL),
+	SOUL_FIRE_FLAME (Particle.SOUL_FIRE_FLAME),
 	SPELL (Particle.SPELL),
 	SPELL_INSTANT (Particle.SPELL_INSTANT), @Deprecated INSTANT_SPELL (Particle.SPELL_INSTANT),
 	SPELL_MOB (Particle.SPELL_MOB), @Deprecated MOB_SPELL (Particle.SPELL_MOB),
@@ -76,10 +97,12 @@ public enum ParticleEffect {
 	TOWN_AURA (Particle.TOWN_AURA),
 	VILLAGER_ANGRY (Particle.VILLAGER_ANGRY), @Deprecated ANGRY_VILLAGER (Particle.VILLAGER_ANGRY),
 	VILLAGER_HAPPY (Particle.VILLAGER_HAPPY), @Deprecated HAPPY_VILLAGER (Particle.VILLAGER_HAPPY),
+	WARPED_SPORE (Particle.WARPED_SPORE),
 	WATER_BUBBLE (Particle.WATER_BUBBLE), @Deprecated BUBBLE (Particle.WATER_BUBBLE),
 	WATER_DROP (Particle.WATER_DROP),
 	WATER_SPLASH (Particle.WATER_SPLASH), @Deprecated SPLASH (Particle.WATER_SPLASH),
-	WATER_WAKE (Particle.WATER_WAKE), @Deprecated WAKE (Particle.WATER_WAKE);
+	WATER_WAKE (Particle.WATER_WAKE), @Deprecated WAKE (Particle.WATER_WAKE),
+	WHITE_ASH (Particle.WHITE_ASH);
 	
 	Particle particle;
 	Class<?> dataClass;

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -30,29 +30,34 @@ public class TempBlock {
 	});
 
 	private final Block block;
-	private BlockData newdata;
+	private BlockData newData;
 	private BlockState state;
 	private long revertTime;
 	private boolean inRevertQueue;
 	private RevertTask revertTask = null;
 
 	public TempBlock(final Block block, final Material newtype) {
-		this(block, newtype.createBlockData());
+		this(block, newtype.createBlockData(), 0);
 	}
 
 	@Deprecated
-	public TempBlock(final Block block, final Material newtype, final BlockData newdata) {
-		this(block, newdata);
+	public TempBlock(final Block block, final Material newtype, final BlockData newData) {
+		this(block, newData, 0);
+	}
+	
+	public TempBlock(final Block block, final BlockData newData) {
+		this(block, newData, 0);
 	}
 
-	public TempBlock(final Block block, final BlockData newdata) {
+	public TempBlock(final Block block, final BlockData newData, final long revertTime) {
 		this.block = block;
-		this.newdata = newdata;
+		this.newData = newData;
+		this.setRevertTime(revertTime);
 		if (instances.containsKey(block)) {
 			final TempBlock temp = instances.get(block);
-			if (!newdata.equals(temp.block.getBlockData())) {
-				temp.block.setBlockData(newdata, GeneralMethods.isLightEmitting(newdata.getMaterial()));
-				temp.newdata = newdata;
+			if (!newData.equals(temp.block.getBlockData())) {
+				temp.block.setBlockData(newData, GeneralMethods.isLightEmitting(newData.getMaterial()));
+				temp.newData = newData;
 			}
 			this.state = temp.state;
 			instances.put(block, temp);
@@ -62,7 +67,7 @@ public class TempBlock {
 				return;
 			}
 			instances.put(block, this);
-			block.setBlockData(newdata, GeneralMethods.isLightEmitting(newdata.getMaterial()));
+			block.setBlockData(newData, GeneralMethods.isLightEmitting(newData.getMaterial()));
 		}
 		if (this.state.getType() == Material.FIRE) {
 			this.state.setType(Material.AIR);
@@ -139,7 +144,7 @@ public class TempBlock {
 	}
 
 	public BlockData getBlockData() {
-		return this.newdata;
+		return this.newData;
 	}
 
 	public Location getLocation() {
@@ -163,6 +168,10 @@ public class TempBlock {
 	}
 
 	public void setRevertTime(final long revertTime) {
+		if(revertTime == 0) {
+			return;
+		}
+		
 		if (this.inRevertQueue) {
 			REVERT_QUEUE.remove(this);
 		}
@@ -194,7 +203,7 @@ public class TempBlock {
 	}
 
 	public void setType(final BlockData data) {
-		this.newdata = data;
+		this.newData = data;
 		this.block.setBlockData(data, GeneralMethods.isLightEmitting(data.getMaterial()));
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -16,6 +16,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.avatar.AvatarState;
@@ -179,7 +180,7 @@ public class OctopusForm extends WaterAbility {
 		} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && this.sourceBlock != null) {
 			this.sourceBlock.setType(Material.AIR);
 		}
-		this.source = new TempBlock(this.sourceBlock, Material.WATER, GeneralMethods.getWaterData(0));
+		this.source = new TempBlock(this.sourceBlock, GeneralMethods.getWaterData(0));
 	}
 
 	private void attack() {
@@ -253,7 +254,7 @@ public class OctopusForm extends WaterAbility {
 					this.sourceLocation = newBlock.getLocation();
 
 					if (!GeneralMethods.isSolid(newBlock)) {
-						this.source = new TempBlock(newBlock, Material.WATER, GeneralMethods.getWaterData(0));
+						this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0));
 						this.sourceBlock = newBlock;
 					} else {
 						this.remove();
@@ -266,7 +267,7 @@ public class OctopusForm extends WaterAbility {
 					this.sourceLocation = newBlock.getLocation();
 
 					if (!GeneralMethods.isSolid(newBlock)) {
-						this.source = new TempBlock(newBlock, Material.WATER, GeneralMethods.getWaterData(0));
+						this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0));
 						this.sourceBlock = newBlock;
 					} else {
 						this.remove();
@@ -282,7 +283,7 @@ public class OctopusForm extends WaterAbility {
 							this.source.revertBlock();
 						}
 						if (!GeneralMethods.isSolid(newBlock)) {
-							this.source = new TempBlock(newBlock, Material.WATER, GeneralMethods.getWaterData(0));
+							this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0));
 							this.sourceBlock = newBlock;
 						}
 					}
@@ -426,16 +427,16 @@ public class OctopusForm extends WaterAbility {
 				if (!SurgeWave.canThaw(block)) {
 					SurgeWave.thaw(block);
 				}
-				tblock.setType(Material.WATER, GeneralMethods.getWaterData(0));
+				tblock.setType(GeneralMethods.getWaterData(0));
 				this.newBlocks.add(tblock);
 			} else if (this.blocks.contains(tblock)) {
 				this.newBlocks.add(tblock);
 			}
-		} else if (this.isWaterbendable(this.player, block) || block.getType() == Material.FIRE || isAir(block.getType())) {
+		} else if (this.isWaterbendable(this.player, block) || FireAbility.isFire(block.getType()) || isAir(block.getType())) {
 			if (isWater(block) && !TempBlock.isTempBlock(block)) {
 				ParticleEffect.WATER_BUBBLE.display(block.getLocation().clone().add(0.5, 0.5, 0.5), 5, Math.random(), Math.random(), Math.random(), 0);
 			}
-			this.newBlocks.add(new TempBlock(block, Material.WATER, GeneralMethods.getWaterData(0)));
+			this.newBlocks.add(new TempBlock(block, GeneralMethods.getWaterData(0)));
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -17,6 +17,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.firebending.FireBlast;
@@ -269,7 +270,7 @@ public class SurgeWall extends WaterAbility {
 							continue;
 						} else if (WALL_BLOCKS.containsKey(block)) {
 							blocks.add(block);
-						} else if (!blocks.contains(block) && (ElementalAbility.isAir(block.getType()) || block.getType() == Material.FIRE || this.isWaterbendable(block)) && this.isTransparent(block)) {
+						} else if (!blocks.contains(block) && (ElementalAbility.isAir(block.getType()) || FireAbility.isFire(block.getType()) || this.isWaterbendable(block)) && this.isTransparent(block)) {
 							WALL_BLOCKS.put(block, this.player);
 							this.addWallBlock(block);
 							blocks.add(block);

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -18,6 +18,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.avatar.AvatarState;
@@ -299,7 +300,7 @@ public class SurgeWave extends WaterAbility {
 							final Vector vec = GeneralMethods.getOrthogonalVector(this.targetDirection, angle, i);
 							final Block block = this.location.clone().add(vec).getBlock();
 
-							if (!blocks.contains(block) && (ElementalAbility.isAir(block.getType()) || block.getType() == Material.FIRE) || this.isWaterbendable(block)) {
+							if (!blocks.contains(block) && (ElementalAbility.isAir(block.getType()) || FireAbility.isFire(block.getType())) || this.isWaterbendable(block)) {
 								blocks.add(block);
 								FireBlast.removeFireBlastsAroundPoint(block.getLocation(), 2);
 							}

--- a/src/com/projectkorra/projectkorra/waterbending/plant/PlantRegrowth.java
+++ b/src/com/projectkorra/projectkorra/waterbending/plant/PlantRegrowth.java
@@ -112,12 +112,20 @@ public class PlantRegrowth extends PlantAbility {
 		this.block = block;
 	}
 
-	public TempBlock getPlant1() {
+	public TempBlock getBottomPlant() {
 		return bottomPlant;
 	}
 
-	public void setPlant1(TempBlock plant1) {
-		this.bottomPlant = plant1;
+	public void setBottomPlant(TempBlock plant) {
+		this.bottomPlant = plant;
+	}
+	
+	public TempBlock getTopPlant() {
+		return topPlant;
+	}
+
+	public void setTopPlant(TempBlock plant) {
+		this.topPlant = plant;
 	}
 
 }

--- a/src/com/projectkorra/projectkorra/waterbending/plant/PlantRegrowth.java
+++ b/src/com/projectkorra/projectkorra/waterbending/plant/PlantRegrowth.java
@@ -4,41 +4,39 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Bisected;
 import org.bukkit.entity.Player;
 
-import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.PlantAbility;
+import com.projectkorra.projectkorra.util.TempBlock;
 
 public class PlantRegrowth extends PlantAbility {
-
-	private BlockData data;
+	
 	private long time;
 	private long regrowTime;
-	private Material type;
+	private TempBlock bottomPlant;
+	private TempBlock topPlant;
 	private Block block;
 
 	public PlantRegrowth(final Player player, final Block block) {
 		super(player);
-
+		this.block = block;
+		
 		this.regrowTime = getConfig().getLong("Abilities.Water.Plantbending.RegrowTime");
 		if (this.regrowTime != 0) {
-			this.block = block;
-			this.type = block.getType();
-			this.data = block.getBlockData();
-
-			if (block.getType() == Material.TALL_GRASS) {
-				if (block.getRelative(BlockFace.DOWN).getType() == Material.TALL_GRASS) {
-					this.block = block.getRelative(BlockFace.DOWN);
-					this.data = block.getRelative(BlockFace.DOWN).getBlockData();
-
-					block.getRelative(BlockFace.DOWN).setType(Material.AIR);
-					block.setType(Material.AIR);
+			if (block.getBlockData() instanceof Bisected) {
+				
+				Bisected bData = (Bisected) block.getBlockData();
+				
+				if(bData.getHalf() == Bisected.Half.TOP) {
+					this.topPlant = new TempBlock(block, Material.AIR);
+					this.bottomPlant = new TempBlock(block.getRelative(BlockFace.DOWN), Material.AIR);
 				} else {
-					block.setType(Material.AIR);
-					block.getRelative(BlockFace.UP).setType(Material.AIR);
+					this.bottomPlant = new TempBlock(block, Material.AIR);
+					this.topPlant = new TempBlock(block.getRelative(BlockFace.UP), Material.AIR);
 				}
+			} else {
+				this.bottomPlant = new TempBlock(block, Material.AIR);
 			}
 
 			this.time = System.currentTimeMillis() + this.regrowTime / 2 + (long) (Math.random() * this.regrowTime) / 2;
@@ -49,16 +47,8 @@ public class PlantRegrowth extends PlantAbility {
 	@Override
 	public void remove() {
 		super.remove();
-		if (ElementalAbility.isAir(this.block.getType())) {
-			this.block.setType(this.type);
-			this.block.setBlockData(this.data);
-			if (this.type == Material.TALL_GRASS) {
-				this.block.getRelative(BlockFace.UP).setType(Material.TALL_GRASS);
-			}
-
-		} else {
-			GeneralMethods.dropItems(this.block, GeneralMethods.getDrops(this.block, this.type, this.data));
-		}
+		bottomPlant.revertBlock();
+		topPlant.revertBlock();
 	}
 
 	@Override
@@ -98,14 +88,6 @@ public class PlantRegrowth extends PlantAbility {
 		return true;
 	}
 
-	public BlockData getData() {
-		return this.data;
-	}
-
-	public void setData(final BlockData data) {
-		this.data = data;
-	}
-
 	public long getTime() {
 		return this.time;
 	}
@@ -122,20 +104,20 @@ public class PlantRegrowth extends PlantAbility {
 		this.regrowTime = regrowTime;
 	}
 
-	public Material getType() {
-		return this.type;
-	}
-
-	public void setType(final Material type) {
-		this.type = type;
-	}
-
 	public Block getBlock() {
 		return this.block;
 	}
 
 	public void setBlock(final Block block) {
 		this.block = block;
+	}
+
+	public TempBlock getPlant1() {
+		return bottomPlant;
+	}
+
+	public void setPlant1(TempBlock plant1) {
+		this.bottomPlant = plant1;
 	}
 
 }


### PR DESCRIPTION
## Additions
* Adds Blue Fire SubElement.
    > *Adds related damage, cooldown, and range modifiers for configuration.
* Adds Blue Fire Passive, which changes nearby fire to blue fire within a certain radius.
* Adds Sticks, Sponges, and Chorus Fruit to cookable HeatControl items.
* Adds Smoker, BlastFurnace, and extinguished Campfires to blocks which FireBlast can light.
* Adds new TempBlock constructor which takes in a `long revertTime` parameter

## Fixes
* Fixes AvatarState buffs overriding day related buffs for firebending.

## Removals
* Removes BlazeArc dependencies for Fire Abilities which ignite the ground.
* Removes smoke particles from Fire bending to increase visibility and better emulate the show.

## Misc. Changes
* Changes API versioning to 1.16.1
* Changes PlantRegrowth to use TempBlocks.
* Changes isIgnitable to check whether fire can be placed at that location rather than solely based on flammability.
* Changes firebending abilities to use `FireAbility#playFirebendingParticles()` & `FireAbility#createTempFire()` where applicable.
* Changes `FireAbility#playFirebendingParticles()` to play blue fire particles when player has the BlueFire subelement.
