### PR TITLE
Add bending board

### DIFF
--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.event.PlayerStanceChangeEvent;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -858,11 +859,17 @@ public class BendingPlayer {
 
 	/**
 	 * Sets the player's {@link ChiAbility Chi stance}
+	 * Also update any previews
 	 *
 	 * @param stance The player's new stance object
 	 */
 	public void setStance(final ChiAbility stance) {
+		final String oldStance = (this.stance == null) ? "" : this.stance.getName();
+		final String newStance = (stance == null) ? "" : stance.getName();
 		this.stance = stance;
+		GeneralMethods.displayMovePreview(player);
+		final PlayerStanceChangeEvent event = new PlayerStanceChangeEvent(Bukkit.getPlayer(this.uuid), oldStance, newStance);
+		Bukkit.getServer().getPluginManager().callEvent(event);
 	}
 
 	/**

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1866,7 +1866,6 @@ public class GeneralMethods {
 		ConfigManager.defaultConfig.reload();
 		ConfigManager.languageConfig.reload();
 		ConfigManager.presetConfig.reload();
-		ConfigManager.boardConfig.reload();
 		Preset.loadExternalPresets();
 		new MultiAbilityManager();
 		new ComboManager();

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1867,7 +1867,6 @@ public class GeneralMethods {
 		ConfigManager.languageConfig.reload();
 		ConfigManager.presetConfig.reload();
 		ConfigManager.boardConfig.reload();
-		BendingBoardManager.reload();
 		Preset.loadExternalPresets();
 		new MultiAbilityManager();
 		new ComboManager();
@@ -1891,6 +1890,7 @@ public class GeneralMethods {
 			GeneralMethods.createBendingPlayer(player.getUniqueId(), player.getName());
 			PassiveManager.registerPassives(player);
 		}
+		BendingBoardManager.reload();
 		plugin.updater.checkUpdate();
 		ProjectKorra.log.info("Reload complete");
 	}

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -109,6 +109,7 @@ import com.projectkorra.projectkorra.airbending.AirShield;
 import com.projectkorra.projectkorra.airbending.AirSpout;
 import com.projectkorra.projectkorra.airbending.AirSuction;
 import com.projectkorra.projectkorra.airbending.AirSwipe;
+import com.projectkorra.projectkorra.board.BendingBoardManager;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.earthbending.EarthBlast;
 import com.projectkorra.projectkorra.earthbending.passive.EarthPassive;
@@ -1751,6 +1752,8 @@ public class GeneralMethods {
 		ConfigManager.defaultConfig.reload();
 		ConfigManager.languageConfig.reload();
 		ConfigManager.presetConfig.reload();
+		ConfigManager.boardConfig.reload();
+		BendingBoardManager.reload();
 		Preset.loadExternalPresets();
 		new MultiAbilityManager();
 		new ComboManager();

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1948,7 +1948,7 @@ public class PKListener implements Listener {
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 		if (bPlayer == null) return;
 
-		if (event.getResult() == PlayerChangeElementEvent.Result.REMOVE || event.getResult() == PlayerChangeElementEvent.Result.PERMAREMOVE) {
+		if (event.getResult() == PlayerChangeElementEvent.Result.CHOOSE || event.getResult() == PlayerChangeElementEvent.Result.REMOVE || event.getResult() == PlayerChangeElementEvent.Result.PERMAREMOVE) {
 			BendingBoardManager.updateAllSlots(player);
 		}
 	}
@@ -1959,7 +1959,7 @@ public class PKListener implements Listener {
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 		if (bPlayer == null) return;
 
-		if (event.getResult() == PlayerChangeSubElementEvent.Result.REMOVE || event.getResult() == PlayerChangeSubElementEvent.Result.PERMAREMOVE) {
+		if (event.getResult() == PlayerChangeSubElementEvent.Result.CHOOSE || event.getResult() == PlayerChangeSubElementEvent.Result.REMOVE || event.getResult() == PlayerChangeSubElementEvent.Result.PERMAREMOVE) {
 			BendingBoardManager.updateAllSlots(player);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -138,7 +138,15 @@ import com.projectkorra.projectkorra.earthbending.metal.MetalClips;
 import com.projectkorra.projectkorra.earthbending.passive.DensityShift;
 import com.projectkorra.projectkorra.earthbending.passive.EarthPassive;
 import com.projectkorra.projectkorra.earthbending.passive.FerroControl;
-import com.projectkorra.projectkorra.event.*;
+import com.projectkorra.projectkorra.event.BendingPlayerCreationEvent;
+import com.projectkorra.projectkorra.event.EntityBendingDeathEvent;
+import com.projectkorra.projectkorra.event.HorizontalVelocityChangeEvent;
+import com.projectkorra.projectkorra.event.PlayerBindChangeEvent;
+import com.projectkorra.projectkorra.event.PlayerChangeElementEvent;
+import com.projectkorra.projectkorra.event.PlayerChangeSubElementEvent;
+import com.projectkorra.projectkorra.event.PlayerCooldownChangeEvent;
+import com.projectkorra.projectkorra.event.PlayerJumpEvent;
+import com.projectkorra.projectkorra.event.PlayerStanceChangeEvent;
 import com.projectkorra.projectkorra.firebending.Blaze;
 import com.projectkorra.projectkorra.firebending.BlazeRing;
 import com.projectkorra.projectkorra.firebending.FireBlast;
@@ -1906,26 +1914,26 @@ public class PKListener implements Listener {
 				event.setCancelled(true);
 			}
 		}
-		
+
 		if (event.isCancelled()) {
 			return;
 		}
-		
+
 		if (event.getEntity() instanceof LivingEntity) {
 			LivingEntity lent = (LivingEntity) event.getEntity();
-			
+
 			if (TempArmor.hasTempArmor(lent)) {
 				TempArmor armor = TempArmor.getVisibleTempArmor(lent);
 				ItemStack is = event.getItem().getItemStack();
 				int index = GeneralMethods.getArmorIndex(is.getType());
-				
+
 				if (index == -1) {
 					return;
 				}
-				
+
 				event.setCancelled(true);
 				ItemStack prev = armor.getOldArmor()[index];
-				
+
 				if (GeneralMethods.compareArmor(is.getType(), prev.getType()) > 0) {
 					event.getEntity().getWorld().dropItemNaturally(event.getEntity().getLocation(), prev);
 					armor.getOldArmor()[index] = is;
@@ -2007,6 +2015,18 @@ public class PKListener implements Listener {
 		final Player player = event.getPlayer();
 		if (player == null) return;
 		BendingBoardManager.updateBoard(player, event.getAbility(), event.getResult().equals(PlayerCooldownChangeEvent.Result.ADDED), 0);
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onPlayerStanceChange(final PlayerStanceChangeEvent event) {
+		final Player player = event.getPlayer();
+		if (player == null) return;
+		if (!event.getOldStance().isEmpty()) {
+			BendingBoardManager.updateBoard(player, event.getOldStance(), false, 0);
+		}
+		if (!event.getNewStance().isEmpty()) {
+			BendingBoardManager.updateBoard(player, event.getNewStance(), false, 0);
+		}
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1324,6 +1324,8 @@ public class PKListener implements Listener {
 		final Player player = event.getPlayer();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
+		BendingBoardManager.clean(player);
+
 		if (ProjectKorra.isStatisticsEnabled()) {
 			Manager.getManager(StatisticsManager.class).store(player.getUniqueId());
 		}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1554,9 +1554,14 @@ public class PKListener implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onPlayerSlotChange(final PlayerItemHeldEvent event) {
 		final Player player = event.getPlayer();
+		if (!MultiAbilityManager.canChangeSlot(player, event.getNewSlot())) {
+			event.setCancelled(true);
+			return;
+		}
+
 		final int slot = event.getNewSlot() + 1;
 		GeneralMethods.displayMovePreview(player, slot);
 		BendingBoardManager.changeActiveSlot(player, event.getPreviousSlot(), event.getNewSlot());

--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -64,7 +64,6 @@ public class ProjectKorra extends JavaPlugin {
 		new Commands(this);
 		new MultiAbilityManager();
 		new ComboManager();
-		BendingBoardManager.setup();
 		collisionManager = new CollisionManager();
 		collisionInitializer = new CollisionInitializer(collisionManager);
 		CoreAbility.registerAbilities();
@@ -79,6 +78,7 @@ public class ProjectKorra extends JavaPlugin {
 		}
 
 		Manager.startup();
+		BendingBoardManager.setup();
 
 		this.getServer().getPluginManager().registerEvents(new PKListener(this), this);
 		this.getServer().getScheduler().scheduleSyncRepeatingTask(this, new BendingManager(), 0, 1);
@@ -157,7 +157,6 @@ public class ProjectKorra extends JavaPlugin {
 
 	@Override
 	public void onDisable() {
-		BendingBoardManager.saveChanges();
 		this.revertChecker.cancel();
 		GeneralMethods.stopBending();
 		for (final Player player : this.getServer().getOnlinePlayers()) {

--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -22,6 +22,7 @@ import com.projectkorra.projectkorra.ability.util.ComboManager;
 import com.projectkorra.projectkorra.ability.util.MultiAbilityManager;
 import com.projectkorra.projectkorra.ability.util.PassiveManager;
 import com.projectkorra.projectkorra.airbending.util.AirbendingManager;
+import com.projectkorra.projectkorra.board.BendingBoardManager;
 import com.projectkorra.projectkorra.chiblocking.util.ChiblockingManager;
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
@@ -63,6 +64,7 @@ public class ProjectKorra extends JavaPlugin {
 		new Commands(this);
 		new MultiAbilityManager();
 		new ComboManager();
+		BendingBoardManager.setup();
 		collisionManager = new CollisionManager();
 		collisionInitializer = new CollisionInitializer(collisionManager);
 		CoreAbility.registerAbilities();
@@ -155,6 +157,7 @@ public class ProjectKorra extends JavaPlugin {
 
 	@Override
 	public void onDisable() {
+		BendingBoardManager.saveChanges();
 		this.revertChecker.cancel();
 		GeneralMethods.stopBending();
 		for (final Player player : this.getServer().getOnlinePlayers()) {

--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -828,7 +828,7 @@ public abstract class CoreAbility implements Ability {
 
 	public String getMovePreview(final Player player) {
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-		String displayedMessage = getMovePreviewWithoutCooldownTimer(player);
+		String displayedMessage = getMovePreviewWithoutCooldownTimer(player, false);
 		if (bPlayer.isOnCooldown(this)) {
 			final long cooldown = bPlayer.getCooldown(this.getName()) - System.currentTimeMillis();
 			displayedMessage += this.getElement().getColor() + " - " + TimeUtil.formatTime(cooldown);
@@ -837,10 +837,10 @@ public abstract class CoreAbility implements Ability {
 		return displayedMessage;
 	}
 
-	public String getMovePreviewWithoutCooldownTimer(final Player player) {
+	public String getMovePreviewWithoutCooldownTimer(final Player player, boolean forceCooldown) {
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 		String displayedMessage = "";
-		if (bPlayer.isOnCooldown(this)) {
+		if (forceCooldown || bPlayer.isOnCooldown(this)) {
 			displayedMessage = this.getElement().getColor() + "" + ChatColor.STRIKETHROUGH + this.getName();
 		} else {
 			if (bPlayer.getStance() != null && bPlayer.getStance().getName().equals(this.getName())) {

--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -33,7 +33,6 @@ public class MultiAbilityManager {
 		waterArms.add(new MultiAbilityInfoSub("Freeze", Element.ICE));
 		waterArms.add(new MultiAbilityInfoSub("Spear", Element.ICE));
 		multiAbilityList.add(new MultiAbilityInfo("WaterArms", waterArms));
-		manage();
 	}
 
 	/**
@@ -144,15 +143,6 @@ public class MultiAbilityManager {
 		return false;
 	}
 
-	public static void manage() {
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				scrollHotBarSlots();
-			}
-		}.runTaskTimer(ProjectKorra.plugin, 0, 1);
-	}
-
 	/**
 	 * Clears all MultiAbility data for a player. Called on player quit event.
 	 *
@@ -176,24 +166,17 @@ public class MultiAbilityManager {
 	/**
 	 * Keeps track of the player's selected slot while a MultiAbility is active.
 	 */
-	public static void scrollHotBarSlots() {
-		if (!playerAbilities.isEmpty()) {
-			for (final Player player : playerAbilities.keySet()) {
-				final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-				if (bPlayer == null) {
-					continue;
-				}
-				if (playerBoundAbility.containsKey(player)) {
-					if (bPlayer.getBoundAbility() == null) {
-						if (multiAbilityList.contains(getMultiAbility(playerBoundAbility.get(player)))) {
-							if (player.getInventory().getHeldItemSlot() >= getMultiAbility(playerBoundAbility.get(player)).getAbilities().size()) {
-								player.getInventory().setHeldItemSlot(getMultiAbility(playerBoundAbility.get(player)).getAbilities().size() - 1);
-							}
-						}
-					}
-				}
+	public static boolean canChangeSlot(final Player player, int slot) {
+		if (playerAbilities.isEmpty()) {
+			return true;
+		}
+		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+		if (bPlayer != null) {
+			if (bPlayer.getBoundAbility() == null && multiAbilityList.contains(getMultiAbility(playerBoundAbility.getOrDefault(player, "")))) {
+				return slot < getMultiAbility(playerBoundAbility.get(player)).getAbilities().size();
 			}
 		}
+		return true;
 	}
 
 	/**

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -50,9 +50,10 @@ public class BendingBoardInstance {
 		if (name == null || name.isEmpty()) {
 			sb.append(ChatColor.GRAY).append("-- Slot ").append(slot).append(" --");
 		} else {
-			CoreAbility coreAbility = CoreAbility.getAbility(name);
-			if (coreAbility == null || coreAbility instanceof ComboAbility) {
-				sb.append(ChatColor.GRAY).append("-- Slot ").append(slot).append(" --");
+			CoreAbility coreAbility = CoreAbility.getAbility(ChatColor.stripColor(name));
+			if (coreAbility == null) { // MultiAbility
+				if (cooldown || bendingPlayer.isOnCooldown(name)) sb.append(ChatColor.STRIKETHROUGH);
+				sb.append(name);
 			} else {
 				sb.append(coreAbility.getElement().getColor());
 				if (cooldown || bendingPlayer.isOnCooldown(coreAbility)) sb.append(ChatColor.STRIKETHROUGH);
@@ -80,6 +81,9 @@ public class BendingBoardInstance {
 	}
 
 	public void setActiveSlot(int oldSlot, int newSlot) {
+		if (selectedSlot != oldSlot) {
+			oldSlot = selectedSlot; // Fixes bug when slot is set using setHeldItemSlot
+		}
 		selectedSlot = newSlot;
 		setSlot(oldSlot, bendingPlayer.getAbilities().getOrDefault(oldSlot, ""), false);
 		setSlot(newSlot, bendingPlayer.getAbilities().getOrDefault(newSlot, ""), false);

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -1,7 +1,6 @@
 package com.projectkorra.projectkorra.board;
 
 import com.projectkorra.projectkorra.BendingPlayer;
-import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -25,8 +24,8 @@ public class BendingBoardInstance {
 	private final Objective bendingSlots;
 	private int selectedSlot;
 
-	public BendingBoardInstance(final Player player) {
-		bendingPlayer = BendingPlayer.getBendingPlayer(player);
+	public BendingBoardInstance(final Player player, final BendingPlayer bPlayer) {
+		bendingPlayer = bPlayer;
 		selectedSlot = player.getInventory().getHeldItemSlot() + 1;
 
 		bendingBoard = Bukkit.getScoreboardManager().getNewScoreboard();

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -1,0 +1,109 @@
+package com.projectkorra.projectkorra.board;
+
+import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.ability.ComboAbility;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+
+import java.util.*;
+
+/**
+ * Represents a player's scoreboard for bending purposes
+ */
+public class BendingBoardInstance {
+	private final String[] cachedSlots = new String[10];
+	private final Set<String> combos = new HashSet<>();
+
+	private final BendingPlayer bendingPlayer;
+
+	private final Scoreboard bendingBoard;
+	private final Objective bendingSlots;
+	private int selectedSlot;
+
+	public BendingBoardInstance(final Player player) {
+		bendingPlayer = BendingPlayer.getBendingPlayer(player);
+		selectedSlot = player.getInventory().getHeldItemSlot() + 1;
+
+		bendingBoard = Bukkit.getScoreboardManager().getNewScoreboard();
+		bendingSlots = bendingBoard.registerNewObjective("Board Slots", "dummy", ChatColor.BOLD + "Slots");
+		bendingSlots.setDisplaySlot(DisplaySlot.SIDEBAR);
+		player.setScoreboard(bendingBoard);
+
+		Arrays.fill(cachedSlots, "");
+		updateAll();
+	}
+
+	public void disableScoreboard() {
+		bendingBoard.clearSlot(DisplaySlot.SIDEBAR);
+		bendingSlots.unregister();
+		bendingPlayer.getPlayer().setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+	}
+
+	private void setSlot(int slot, String name, boolean cooldown) {
+		if (slot < 1 || slot > 9 || !bendingPlayer.getPlayer().getScoreboard().equals(bendingBoard)) return;
+		StringBuilder sb = new StringBuilder(slot == selectedSlot ? ">" : "  ");
+		if (name == null || name.isEmpty()) {
+			sb.append(ChatColor.GRAY).append("-- Slot ").append(slot).append(" --");
+		} else {
+			CoreAbility coreAbility = CoreAbility.getAbility(name);
+			if (coreAbility == null || coreAbility instanceof ComboAbility) {
+				sb.append(ChatColor.GRAY).append("-- Slot ").append(slot).append(" --");
+			} else {
+				sb.append(coreAbility.getElement().getColor());
+				if (cooldown || bendingPlayer.isOnCooldown(coreAbility)) sb.append(ChatColor.STRIKETHROUGH);
+				sb.append(coreAbility.getName());
+			}
+		}
+		sb.append(String.join("", Collections.nCopies(slot, ChatColor.RESET.toString())));
+
+		if (!cachedSlots[slot].equals(sb.toString())) {
+			bendingBoard.resetScores(cachedSlots[slot]);
+		}
+		cachedSlots[slot] = sb.toString();
+		bendingSlots.getScore(sb.toString()).setScore(-slot);
+	}
+
+	public void updateAll() {
+		final Map<Integer, String> boundAbilities = new HashMap<>(bendingPlayer.getAbilities());
+		for (int i = 1; i <= 9; i++) {
+			setSlot(i, boundAbilities.getOrDefault(i, ""), false);
+		}
+	}
+
+	public void clearSlot(int slot) {
+		setSlot(slot, null, false);
+	}
+
+	public void setActiveSlot(int oldSlot, int newSlot) {
+		selectedSlot = newSlot;
+		setSlot(oldSlot, bendingPlayer.getAbilities().getOrDefault(oldSlot, ""), false);
+		setSlot(newSlot, bendingPlayer.getAbilities().getOrDefault(newSlot, ""), false);
+	}
+
+	public void setAbility(String name, boolean cooldown) {
+		final Map<Integer, String> boundAbilities = bendingPlayer.getAbilities();
+		boundAbilities.keySet().stream().filter(key -> name.equals(boundAbilities.get(key))).forEach(slot -> setSlot(slot, name, cooldown));
+	}
+
+	public void updateCombo(String text, boolean show) {
+		if (show) {
+			if (combos.isEmpty()) {
+				bendingSlots.getScore("  -----------  ").setScore(-10);
+			}
+			combos.add(text);
+			bendingSlots.getScore(text).setScore(-10);
+
+		} else {
+			combos.remove(text);
+			bendingBoard.resetScores(text);
+			if (combos.isEmpty()) {
+				bendingBoard.resetScores("  -----------  ");
+			}
+		}
+	}
+}

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -9,7 +9,12 @@ import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Scoreboard;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents a player's scoreboard for bending purposes
@@ -54,9 +59,7 @@ public class BendingBoardInstance {
 				if (cooldown || bendingPlayer.isOnCooldown(name)) sb.append(ChatColor.STRIKETHROUGH);
 				sb.append(name);
 			} else {
-				sb.append(coreAbility.getElement().getColor());
-				if (cooldown || bendingPlayer.isOnCooldown(coreAbility)) sb.append(ChatColor.STRIKETHROUGH);
-				sb.append(coreAbility.getName());
+				sb.append(coreAbility.getMovePreviewWithoutCooldownTimer(bendingPlayer.getPlayer(), cooldown));
 			}
 		}
 		sb.append(String.join("", Collections.nCopies(slot, ChatColor.RESET.toString())));

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -21,16 +21,18 @@ import java.util.Set;
  */
 public class BendingBoardInstance {
 	private final String[] cachedSlots = new String[10];
-	private final Set<String> combos = new HashSet<>();
+	private final Set<String> misc = new HashSet<>(); // Stores scoreboard scores for combos and misc abilities
 
+	private final Player player;
 	private final BendingPlayer bendingPlayer;
 
 	private final Scoreboard bendingBoard;
 	private final Objective bendingSlots;
 	private int selectedSlot;
 
-	public BendingBoardInstance(final Player player, final BendingPlayer bPlayer) {
+	public BendingBoardInstance(final BendingPlayer bPlayer) {
 		bendingPlayer = bPlayer;
+		player = bPlayer.getPlayer();
 		selectedSlot = player.getInventory().getHeldItemSlot() + 1;
 
 		bendingBoard = Bukkit.getScoreboardManager().getNewScoreboard();
@@ -45,11 +47,11 @@ public class BendingBoardInstance {
 	public void disableScoreboard() {
 		bendingBoard.clearSlot(DisplaySlot.SIDEBAR);
 		bendingSlots.unregister();
-		bendingPlayer.getPlayer().setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+		player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
 	}
 
 	private void setSlot(int slot, String name, boolean cooldown) {
-		if (slot < 1 || slot > 9 || !bendingPlayer.getPlayer().getScoreboard().equals(bendingBoard)) return;
+		if (slot < 1 || slot > 9 || !player.getScoreboard().equals(bendingBoard)) return;
 		StringBuilder sb = new StringBuilder(slot == selectedSlot ? ">" : "  ");
 		if (name == null || name.isEmpty()) {
 			sb.append(ChatColor.GRAY).append("-- Slot ").append(slot).append(" --");
@@ -59,7 +61,7 @@ public class BendingBoardInstance {
 				if (cooldown || bendingPlayer.isOnCooldown(name)) sb.append(ChatColor.STRIKETHROUGH);
 				sb.append(name);
 			} else {
-				sb.append(coreAbility.getMovePreviewWithoutCooldownTimer(bendingPlayer.getPlayer(), cooldown));
+				sb.append(coreAbility.getMovePreviewWithoutCooldownTimer(player, cooldown));
 			}
 		}
 		sb.append(String.join("", Collections.nCopies(slot, ChatColor.RESET.toString())));
@@ -96,18 +98,18 @@ public class BendingBoardInstance {
 		boundAbilities.keySet().stream().filter(key -> name.equals(boundAbilities.get(key))).forEach(slot -> setSlot(slot, name, cooldown));
 	}
 
-	public void updateCombo(String text, boolean show) {
+	public void updateMisc(String text, boolean show, boolean isCombo) {
 		if (show) {
-			if (combos.isEmpty()) {
+			if (misc.isEmpty()) {
 				bendingSlots.getScore("  -----------  ").setScore(-10);
 			}
-			combos.add(text);
-			bendingSlots.getScore(text).setScore(-10);
+			misc.add(text);
+			bendingSlots.getScore(text).setScore(isCombo ? -10 : -11);
 
 		} else {
-			combos.remove(text);
+			misc.remove(text);
 			bendingBoard.resetScores(text);
-			if (combos.isEmpty()) {
+			if (misc.isEmpty()) {
 				bendingBoard.resetScores("  -----------  ");
 			}
 		}

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -1,0 +1,130 @@
+package com.projectkorra.projectkorra.board;
+
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.ability.util.ComboManager;
+import com.projectkorra.projectkorra.configuration.ConfigManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Manages every individual {@link BendingBoardInstance}
+ */
+public class BendingBoardManager {
+	private static final Set<String> disabledWorlds = new HashSet<>();
+	private static final Set<UUID> disabledPlayers = new HashSet<>();
+	private static final Map<Player, BendingBoardInstance> scoreboardPlayers = new ConcurrentHashMap<>();
+
+	private static boolean enabled;
+
+	public static void setup() {
+		enabled = ConfigManager.boardConfig.get().getBoolean("Enable");
+		disabledPlayers.clear();
+		scoreboardPlayers.clear();
+		disabledWorlds.addAll(ConfigManager.defaultConfig.get().getStringList("Properties.DisabledWorlds"));
+		for (String s : ConfigManager.boardConfig.get().getStringList("DisabledPlayers")) {
+			disabledPlayers.add(UUID.fromString(s));
+		}
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			canUseScoreboard(player);
+		}
+	}
+
+	public static void reload() {
+		for (BendingBoardInstance pBoard : scoreboardPlayers.values()) {
+			pBoard.disableScoreboard();
+		}
+		setup();
+	}
+
+	/**
+	 * Force toggle the scoreboard for when a player changes worlds (for example when teleporting to a world where bending is disabled)
+	 * @param player
+	 */
+	public static void forceToggleScoreboard(Player player) {
+		if (disabledWorlds.contains(player.getWorld().getName())) {
+			if (scoreboardPlayers.containsKey(player)) {
+				scoreboardPlayers.get(player).disableScoreboard();
+				scoreboardPlayers.remove(player);
+			}
+		} else {
+			canUseScoreboard(player);
+		}
+	}
+
+	public static void toggleScoreboard(Player player) {
+		if (!enabled || disabledWorlds.contains(player.getWorld().getName())) {
+			GeneralMethods.sendBrandingMessage(player, ChatColor.RED + ConfigManager.languageConfig.get().getString("Commands.Board.Disabled"));
+			return;
+		}
+
+		if (scoreboardPlayers.containsKey(player)) {
+			scoreboardPlayers.get(player).disableScoreboard();
+			disabledPlayers.add(player.getUniqueId());
+			scoreboardPlayers.remove(player);
+			GeneralMethods.sendBrandingMessage(player, ChatColor.RED + ConfigManager.languageConfig.get().getString("Commands.Board.ToggledOff"));
+		} else {
+			disabledPlayers.remove(player.getUniqueId());
+			canUseScoreboard(player);
+			GeneralMethods.sendBrandingMessage(player, ChatColor.GREEN + ConfigManager.languageConfig.get().getString("Commands.Board.ToggledOn"));
+		}
+	}
+
+	/**
+	 * Checks if a player can use the bending board and creates a BendingBoardInstance if possible.
+	 * @param player the player to check
+	 * @return true if player can use the bending board, false otherwise
+	 */
+	public static boolean canUseScoreboard(Player player) {
+		if (!enabled || disabledPlayers.contains(player.getUniqueId()) || disabledWorlds.contains(player.getWorld().getName())) {
+			return false;
+		}
+		if (!scoreboardPlayers.containsKey(player)) {
+			scoreboardPlayers.put(player, new BendingBoardInstance(player));
+		}
+		return true;
+	}
+
+	public static void updateAllSlots(Player player) {
+		if (canUseScoreboard(player)) {
+			scoreboardPlayers.get(player).updateAll();
+		}
+	}
+
+	public static void updateBoard(Player player, String abilityName, boolean cooldown, int slot) {
+		if (canUseScoreboard(player)) {
+			if (abilityName == null || abilityName.isEmpty()) {
+				scoreboardPlayers.get(player).clearSlot(slot);
+				return;
+			}
+
+			CoreAbility coreAbility = CoreAbility.getAbility(abilityName);
+			if (coreAbility != null && ComboManager.getComboAbilities().containsKey(abilityName)) {
+				scoreboardPlayers.get(player).updateCombo("  " + coreAbility.getElement().getColor() + ChatColor.STRIKETHROUGH + abilityName, cooldown);
+				return;
+			}
+			scoreboardPlayers.get(player).setAbility(abilityName, cooldown);
+		}
+	}
+
+	public static void changeActiveSlot(Player player, int oldSlot, int newSlot) {
+		if (oldSlot == newSlot) return;
+
+		if (canUseScoreboard(player)) {
+			scoreboardPlayers.get(player).setActiveSlot(++oldSlot, ++newSlot);
+		}
+	}
+
+	public static void saveChanges() {
+		ConfigManager.boardConfig.get().set("DisabledPlayers", disabledPlayers.stream().map(UUID::toString).collect(Collectors.toList()));
+		ConfigManager.boardConfig.save();
+	}
+}

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.board;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager;
+import com.projectkorra.projectkorra.ability.util.MultiAbilityManager;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -105,7 +106,10 @@ public class BendingBoardManager {
 				scoreboardPlayers.get(player).clearSlot(slot);
 				return;
 			}
-
+			if (MultiAbilityManager.hasMultiAbilityBound(player)) {
+				scoreboardPlayers.get(player).updateAll();
+				return;
+			}
 			CoreAbility coreAbility = CoreAbility.getAbility(abilityName);
 			if (coreAbility != null && ComboManager.getComboAbilities().containsKey(abilityName)) {
 				scoreboardPlayers.get(player).updateCombo("  " + coreAbility.getElement().getColor() + ChatColor.STRIKETHROUGH + abilityName, cooldown);
@@ -116,8 +120,6 @@ public class BendingBoardManager {
 	}
 
 	public static void changeActiveSlot(Player player, int oldSlot, int newSlot) {
-		if (oldSlot == newSlot) return;
-
 		if (canUseScoreboard(player)) {
 			scoreboardPlayers.get(player).setActiveSlot(++oldSlot, ++newSlot);
 		}

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -16,7 +16,11 @@ import org.bukkit.scheduler.BukkitRunnable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -51,7 +51,7 @@ public class BendingBoardManager {
 
 	private static void initialize() {
 		loadDisabledPlayers();
-		enabled = ConfigManager.boardConfig.get().getBoolean("Enable");
+		enabled = ConfigManager.defaultConfig.get().getBoolean("Properties.BendingBoard");
 		disabledWorlds.addAll(ConfigManager.defaultConfig.get().getStringList("Properties.DisabledWorlds"));
 	}
 

--- a/src/com/projectkorra/projectkorra/chiblocking/AcrobatStance.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/AcrobatStance.java
@@ -7,7 +7,6 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 import com.projectkorra.projectkorra.Element;
-import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.ChiAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 
@@ -48,7 +47,6 @@ public class AcrobatStance extends ChiAbility {
 		}
 		this.start();
 		this.bPlayer.setStance(this);
-		GeneralMethods.displayMovePreview(player);
 		player.playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_HURT, 0.5F, 2F);
 	}
 
@@ -75,7 +73,6 @@ public class AcrobatStance extends ChiAbility {
 		super.remove();
 		this.bPlayer.addCooldown(this);
 		this.bPlayer.setStance(null);
-		GeneralMethods.displayMovePreview(this.player);
 		this.player.playSound(this.player.getLocation(), Sound.ENTITY_ENDER_DRAGON_SHOOT, 0.5F, 2F);
 		this.player.removePotionEffect(PotionEffectType.SPEED);
 		this.player.removePotionEffect(PotionEffectType.JUMP);

--- a/src/com/projectkorra/projectkorra/chiblocking/WarriorStance.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/WarriorStance.java
@@ -7,7 +7,6 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 import com.projectkorra.projectkorra.Element;
-import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.ChiAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 
@@ -42,7 +41,6 @@ public class WarriorStance extends ChiAbility {
 		}
 		this.start();
 		this.bPlayer.setStance(this);
-		GeneralMethods.displayMovePreview(player);
 		player.playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_HURT, 0.5F, 2F);
 	}
 
@@ -70,7 +68,6 @@ public class WarriorStance extends ChiAbility {
 		this.bPlayer.addCooldown(this);
 		this.bPlayer.setStance(null);
 		if (this.player != null) {
-			GeneralMethods.displayMovePreview(this.player);
 			this.player.playSound(this.player.getLocation(), Sound.ENTITY_ENDER_DRAGON_SHOOT, 0.5F, 2F);
 			this.player.removePotionEffect(PotionEffectType.DAMAGE_RESISTANCE);
 			this.player.removePotionEffect(PotionEffectType.INCREASE_DAMAGE);

--- a/src/com/projectkorra/projectkorra/command/BoardCommand.java
+++ b/src/com/projectkorra/projectkorra/command/BoardCommand.java
@@ -1,0 +1,27 @@
+package com.projectkorra.projectkorra.command;
+
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.projectkorra.projectkorra.board.BendingBoardManager;
+import com.projectkorra.projectkorra.configuration.ConfigManager;
+
+/**
+ * Executor for /bending board. Extends {@link PKCommand}.
+ */
+public class BoardCommand extends PKCommand {
+
+	public BoardCommand() {
+		super("board", "/bending board", ConfigManager.languageConfig.get().getString("Commands.Board.Description"), new String[]{ "bendingboard", "board", "bb" });
+	}
+
+	@Override
+	public void execute(final CommandSender sender, final List<String> args) {
+		if (!this.hasPermission(sender) || !this.isPlayer(sender) || !this.correctLength(sender, args.size(), 0, 0)) {
+			return;
+		}
+		BendingBoardManager.toggleScoreboard((Player) sender);
+	}
+}

--- a/src/com/projectkorra/projectkorra/command/Commands.java
+++ b/src/com/projectkorra/projectkorra/command/Commands.java
@@ -80,6 +80,7 @@ public class Commands {
 		new AddCommand();
 		new BindCommand();
 		new CheckCommand();
+		new BoardCommand();
 		new ChooseCommand();
 		new ClearCommand();
 		new CopyCommand();

--- a/src/com/projectkorra/projectkorra/command/CopyCommand.java
+++ b/src/com/projectkorra/projectkorra/command/CopyCommand.java
@@ -13,6 +13,7 @@ import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.board.BendingBoardManager;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 
 public class CopyCommand extends PKCommand {
@@ -107,6 +108,7 @@ public class CopyCommand extends PKCommand {
 			}
 		}
 		target.setAbilities(abilities);
+		BendingBoardManager.updateAllSlots(player2);
 		return boundAll;
 	}
 

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -47,7 +47,6 @@ public class ConfigManager {
 			config = boardConfig.get();
 
 			config.addDefault("Enable", false);
-			config.addDefault("DisabledPlayers", new String[]{});
 
 			boardConfig.save();
 		} else if (type == ConfigType.LANGUAGE) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -47,7 +47,6 @@ public class ConfigManager {
 			config = boardConfig.get();
 
 			config.addDefault("Enable", false);
-			config.addDefault("TrackedAbilities", new String[]{"PhaseChangeMelt"});
 
 			boardConfig.save();
 		} else if (type == ConfigType.LANGUAGE) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -11,17 +11,14 @@ public class ConfigManager {
 	public static Config presetConfig;
 	public static Config defaultConfig;
 	public static Config languageConfig;
-	public static Config boardConfig;
 
 	public ConfigManager() {
 		presetConfig = new Config(new File("presets.yml"));
 		defaultConfig = new Config(new File("config.yml"));
 		languageConfig = new Config(new File("language.yml"));
-		boardConfig = new Config(new File("board.yml"));
 		configCheck(ConfigType.DEFAULT);
 		configCheck(ConfigType.LANGUAGE);
 		configCheck(ConfigType.PRESETS);
-		configCheck(ConfigType.BOARD);
 	}
 
 	public static void configCheck(final ConfigType type) {
@@ -43,12 +40,6 @@ public class ConfigManager {
 			config.addDefault("Example", abilities);
 
 			presetConfig.save();
-		} else if (type == ConfigType.BOARD) {
-			config = boardConfig.get();
-
-			config.addDefault("Enable", false);
-
-			boardConfig.save();
 		} else if (type == ConfigType.LANGUAGE) {
 			config = languageConfig.get();
 
@@ -570,6 +561,7 @@ public class ConfigManager {
 			config.addDefault("Properties.UpdateChecker", true);
 			config.addDefault("Properties.Statistics", true);
 			config.addDefault("Properties.DatabaseCooldowns", true);
+			config.addDefault("Properties.BendingBoard", true);
 			config.addDefault("Properties.BendingPreview", true);
 			config.addDefault("Properties.BendingAffectFallingSand.Normal", true);
 			config.addDefault("Properties.BendingAffectFallingSand.NormalStrengthMultiplier", 1.0);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -47,6 +47,7 @@ public class ConfigManager {
 			config = boardConfig.get();
 
 			config.addDefault("Enable", false);
+			config.addDefault("TrackedAbilities", new String[]{"PhaseChangeMelt"});
 
 			boardConfig.save();
 		} else if (type == ConfigType.LANGUAGE) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -11,14 +11,17 @@ public class ConfigManager {
 	public static Config presetConfig;
 	public static Config defaultConfig;
 	public static Config languageConfig;
+	public static Config boardConfig;
 
 	public ConfigManager() {
 		presetConfig = new Config(new File("presets.yml"));
 		defaultConfig = new Config(new File("config.yml"));
 		languageConfig = new Config(new File("language.yml"));
+		boardConfig = new Config(new File("board.yml"));
 		configCheck(ConfigType.DEFAULT);
 		configCheck(ConfigType.LANGUAGE);
 		configCheck(ConfigType.PRESETS);
+		configCheck(ConfigType.BOARD);
 	}
 
 	public static void configCheck(final ConfigType type) {
@@ -40,6 +43,13 @@ public class ConfigManager {
 			config.addDefault("Example", abilities);
 
 			presetConfig.save();
+		} else if (type == ConfigType.BOARD) {
+			config = boardConfig.get();
+
+			config.addDefault("Enable", false);
+			config.addDefault("DisabledPlayers", new String[]{});
+
+			boardConfig.save();
 		} else if (type == ConfigType.LANGUAGE) {
 			config = languageConfig.get();
 
@@ -179,6 +189,11 @@ public class ConfigManager {
 
 			config.addDefault("Commands.Debug.Description", "Outputs information on the current ProjectKorra installation to /plugins/ProjectKorra/debug.txt");
 			config.addDefault("Commands.Debug.SuccessfullyExported", "Debug File Created as debug.txt in the ProjectKorra plugin folder.\nPut contents on pastie.org and create a bug report  on the ProjectKorra forum if you need to.");
+
+			config.addDefault("Commands.Board.Description", "Toggle bending board visibility.");
+			config.addDefault("Commands.Board.Disabled", "Bending board is disabled.");
+			config.addDefault("Commands.Board.ToggledOn", "You have made your bending board visible again.");
+			config.addDefault("Commands.Board.ToggledOff", "You have hidden your bending board.");
 
 			config.addDefault("Commands.Copy.Description", "This command will allow the user to copy the binds of another player either for himself or assign them to <Player> if specified.");
 			config.addDefault("Commands.Copy.PlayerNotFound", "Couldn't find player.");
@@ -653,7 +668,7 @@ public class ConfigManager {
 			config.addDefault("Properties.Fire.BlueFire.DamageFactor", 1.1);
 			config.addDefault("Properties.Fire.BlueFire.CooldownFactor", .9);
 			config.addDefault("Properties.Fire.BlueFire.RangeFactor", 1.2);
-			
+
 			config.addDefault("Properties.Chi.CanBendWithWeapons", true);
 
 			final ArrayList<String> disabledWorlds = new ArrayList<String>();

--- a/src/com/projectkorra/projectkorra/configuration/ConfigType.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigType.java
@@ -12,8 +12,7 @@ public class ConfigType {
 	public static final ConfigType DEFAULT = new ConfigType("Default");
 	public static final ConfigType PRESETS = new ConfigType("Presets");
 	public static final ConfigType LANGUAGE = new ConfigType("Language");
-	public static final ConfigType BOARD = new ConfigType("Board");
-	public static final ConfigType[] CORE_TYPES = { DEFAULT, PRESETS, LANGUAGE, BOARD };
+	public static final ConfigType[] CORE_TYPES = { DEFAULT, PRESETS, LANGUAGE };
 
 	private final String string;
 

--- a/src/com/projectkorra/projectkorra/configuration/ConfigType.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigType.java
@@ -12,7 +12,8 @@ public class ConfigType {
 	public static final ConfigType DEFAULT = new ConfigType("Default");
 	public static final ConfigType PRESETS = new ConfigType("Presets");
 	public static final ConfigType LANGUAGE = new ConfigType("Language");
-	public static final ConfigType[] CORE_TYPES = { DEFAULT, PRESETS, LANGUAGE };
+	public static final ConfigType BOARD = new ConfigType("Board");
+	public static final ConfigType[] CORE_TYPES = { DEFAULT, PRESETS, LANGUAGE, BOARD };
 
 	private final String string;
 

--- a/src/com/projectkorra/projectkorra/event/PlayerStanceChangeEvent.java
+++ b/src/com/projectkorra/projectkorra/event/PlayerStanceChangeEvent.java
@@ -1,0 +1,41 @@
+package com.projectkorra.projectkorra.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerStanceChangeEvent extends Event {
+
+	private static final HandlerList HANDLERS = new HandlerList();
+
+	private final Player player;
+	private final String oldStance;
+	private final String newStance;
+
+	public PlayerStanceChangeEvent(final Player player, final String oldStance, final String newStance) {
+		this.player = player;
+		this.oldStance = oldStance;
+		this.newStance = newStance;
+	}
+
+	public Player getPlayer() {
+		return this.player;
+	}
+
+	public String getOldStance() {
+		return this.oldStance;
+	}
+
+	public String getNewStance() {
+		return this.newStance;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+}

--- a/src/com/projectkorra/projectkorra/object/Preset.java
+++ b/src/com/projectkorra/projectkorra/object/Preset.java
@@ -148,7 +148,6 @@ public class Preset {
 		}
 		bPlayer.setAbilities(abilities);
 		BendingBoardManager.updateAllSlots(player);
-		System.out.println("board "+player.getName()+" "+abilities.entrySet().toString());
 		return boundAll;
 	}
 

--- a/src/com/projectkorra/projectkorra/object/Preset.java
+++ b/src/com/projectkorra/projectkorra/object/Preset.java
@@ -17,6 +17,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.board.BendingBoardManager;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.storage.DBConnection;
 
@@ -146,6 +147,8 @@ public class Preset {
 			}
 		}
 		bPlayer.setAbilities(abilities);
+		BendingBoardManager.updateAllSlots(player);
+		System.out.println("board "+player.getName()+" "+abilities.entrySet().toString());
 		return boundAll;
 	}
 
@@ -256,6 +259,7 @@ public class Preset {
 				}
 			}
 			bPlayer.setAbilities(abilities);
+			BendingBoardManager.updateAllSlots(player);
 			return boundAll;
 		}
 		return false;

--- a/src/com/projectkorra/projectkorra/storage/DBConnection.java
+++ b/src/com/projectkorra/projectkorra/storage/DBConnection.java
@@ -68,6 +68,11 @@ public class DBConnection {
 				final String query = "CREATE TABLE `pk_cooldowns` (uuid VARCHAR(36) NOT NULL, cooldown_id INTEGER NOT NULL, value BIGINT, PRIMARY KEY (uuid, cooldown_id));";
 				sql.modifyQuery(query, false);
 			}
+			if (!sql.tableExists("pk_board")) {
+				ProjectKorra.log.info("Creating pk_board table");
+				final String query = "CREATE TABLE `pk_board` (uuid VARCHAR(36) NOT NULL, enabled BOOLEAN NOT NULL, PRIMARY KEY (uuid));";
+				sql.modifyQuery(query, false);
+			}
 		} else {
 			sql = new SQLite(ProjectKorra.log, "Establishing SQLite Connection.", "projectkorra.db", ProjectKorra.plugin.getDataFolder().getAbsolutePath());
 			if (((SQLite) sql).open() == null) {
@@ -110,6 +115,11 @@ public class DBConnection {
 			if (!sql.tableExists("pk_cooldowns")) {
 				ProjectKorra.log.info("Creating pk_cooldowns table");
 				final String query = "CREATE TABLE `pk_cooldowns` (uuid TEXT(36) NOT NULL, cooldown_id INTEGER NOT NULL, value BIGINT, PRIMARY KEY (uuid, cooldown_id));";
+				sql.modifyQuery(query, false);
+			}
+			if (!sql.tableExists("pk_board")) {
+				ProjectKorra.log.info("Creating pk_board table");
+				final String query = "CREATE TABLE `pk_board` (uuid TEXT(36) NOT NULL, enabled INTEGER NOT NULL, PRIMARY KEY (uuid));";
 				sql.modifyQuery(query, false);
 			}
 		}

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -43,6 +43,7 @@ permissions:
     default: true
     description: Grants access to most abilities and basic commands.
     children:
+      bending.command.board: true
       bending.command.bind: true
       bending.command.display: true
       bending.command.toggle: true


### PR DESCRIPTION
## Additions
* Adds bending board, feature is disabled by default
### Feature Details
* Serverwide option to enable/disable board.
* Players can use BoardCommand to toggle visibility for themselves.
* Creates a new board.yml config file with an option to enable the board. It stores a lists of players that have turned the board off.
* Bending Board respects worlds where bending is disabled. It also supports binds set by Presets or CopyCommand.

Things to add in the future: Add support for MultiAbilities' binds
