### PR TITLE
Fix deprecated calls

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1225,11 +1225,11 @@ public class GeneralMethods {
 	}
 
 	public static BlockData getLavaData(final int level) {
-		return Material.LAVA.createBlockData(d -> ((Levelled) d).setLevel((level < 0 || level > 15) ? 0 : level));
+		return Material.LAVA.createBlockData(d -> ((Levelled) d).setLevel((level < 0 || level > ((Levelled) d).getMaximumLevel()) ? 0 : level));
 	}
 
 	public static BlockData getWaterData(final int level) {
-		return Material.WATER.createBlockData(d -> ((Levelled) d).setLevel((level < 0 || level > 15) ? 0 : level));
+		return Material.WATER.createBlockData(d -> ((Levelled) d).setLevel((level < 0 || level > ((Levelled) d).getMaximumLevel()) ? 0 : level));
 	}
 
 	public static Entity getTargetedEntity(final Player player, final double range, final List<Entity> avoid) {

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -317,7 +317,7 @@ public class GeneralMethods {
 		final boolean c = xyzsolid[1] && xyzsolid[2];
 		return (a || b || c || (a && b));
 	}
-	
+
 	public static int compareArmor(Material first, Material second) {
 		return getArmorTier(first) - getArmorTier(second);
 	}
@@ -700,7 +700,7 @@ public class GeneralMethods {
 			e.printStackTrace();
 		}
 	}
-	
+
 	public static int getArmorTier(Material mat) {
 		switch (mat) {
 			case NETHERITE_HELMET:
@@ -739,7 +739,7 @@ public class GeneralMethods {
 				return 0;
 		}
 	}
-	
+
 	public static int getArmorIndex(Material mat) {
 		switch (mat) {
 			case NETHERITE_HELMET:
@@ -1225,19 +1225,11 @@ public class GeneralMethods {
 	}
 
 	public static BlockData getLavaData(final int level) {
-		final BlockData data = Material.LAVA.createBlockData();
-		if (data instanceof Levelled) {
-			((Levelled) data).setLevel(level);
-		}
-		return data;
+		return Material.LAVA.createBlockData(d -> ((Levelled) d).setLevel((level < 0 || level > 15) ? 0 : level));
 	}
 
 	public static BlockData getWaterData(final int level) {
-		final BlockData data = Material.WATER.createBlockData();
-		if (data instanceof Levelled) {
-			((Levelled) data).setLevel(level);
-		}
-		return data;
+		return Material.WATER.createBlockData(d -> ((Levelled) d).setLevel((level < 0 || level > 15) ? 0 : level));
 	}
 
 	public static Entity getTargetedEntity(final Player player, final double range, final List<Entity> avoid) {
@@ -1419,7 +1411,7 @@ public class GeneralMethods {
 	public static boolean hasSpirits() {
 		return Bukkit.getServer().getPluginManager().getPlugin("ProjectKorraSpirits") != null;
 	}
-	
+
 	public static boolean isArmor(Material mat) {
 		switch (mat) {
 			case NETHERITE_HELMET:
@@ -1749,14 +1741,14 @@ public class GeneralMethods {
 		}
 		return false;
 	}
-	
+
 	public static boolean isSameArmor(Material a, Material b) {
 		int ai = getArmorIndex(a), bi = getArmorIndex(b);
-		
+
 		if (ai == -1 || bi == -1) {
 			return false;
 		}
-		
+
 		return ai == bi;
 	}
 
@@ -2136,7 +2128,7 @@ public class GeneralMethods {
 					}  catch (Exception e) {
 						continue;
 					}
-					
+
 				}
 			}
 		} catch (final IOException e) {

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -1,8 +1,5 @@
 package com.projectkorra.projectkorra.earthbending;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -19,9 +16,6 @@ import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 
 public class Tremorsense extends EarthAbility {
-
-	@Deprecated
-	private static final Map<Block, Player> BLOCKS = new ConcurrentHashMap<Block, Player>();
 
 	private byte lightThreshold;
 	@Attribute("Depth")
@@ -108,11 +102,11 @@ public class Tremorsense extends EarthAbility {
 		
 		if (isBendable && this.block == null) {
 			this.block = standBlock;
-			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE, (byte) 1);
+			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE.createBlockData());
 		} else if (isBendable && !this.block.equals(standBlock)) {
 			this.revertGlowBlock();
 			this.block = standBlock;
-			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE, (byte) 1);
+			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE.createBlockData());
 		} else if (this.block == null) {
 			return;
 		} else if (!this.player.getWorld().equals(this.block.getWorld())) {
@@ -133,7 +127,7 @@ public class Tremorsense extends EarthAbility {
 
 	public void revertGlowBlock() {
 		if (this.block != null) {
-			this.player.sendBlockChange(this.block.getLocation(), this.block.getType(), this.block.getData());
+			this.player.sendBlockChange(this.block.getLocation(), this.block.getBlockData());
 		}
 	}
 
@@ -170,12 +164,6 @@ public class Tremorsense extends EarthAbility {
 		}
 
 		return false;
-	}
-
-	@Deprecated
-	/** No longer used; will be removed in the next version. */
-	public static Map<Block, Player> getBlocks() {
-		return BLOCKS;
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaFlow.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaFlow.java
@@ -415,7 +415,7 @@ public class LavaFlow extends LavaAbility {
 				block.setType(Material.LAVA);
 				block.setBlockData(GeneralMethods.getLavaData(0));
 			} else {
-				tblock = new TempBlock(block, Material.LAVA, GeneralMethods.getLavaData(0));
+				tblock = new TempBlock(block, Material.LAVA);
 			}
 
 			if (tblock != null) {

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
@@ -215,7 +215,7 @@ public class LavaSurge extends LavaAbility {
 				playEarthbendingSound(b.getLocation());
 
 				for (int i = 0; i < 2; i++) {
-					final TempBlock tb = new TempBlock(b, Material.LAVA, GeneralMethods.getLavaData(0));
+					final TempBlock tb = new TempBlock(b, Material.LAVA);
 					this.fractureTempBlocks.add(tb);
 				}
 			}

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWall.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWall.java
@@ -233,7 +233,7 @@ public class LavaSurgeWall extends LavaAbility {
 	}
 
 	private void addWallBlock(final Block block) {
-		new TempBlock(block, Material.LAVA, GeneralMethods.getLavaData(0));
+		new TempBlock(block, Material.LAVA);
 	}
 
 	private void breakBlock() {
@@ -273,7 +273,7 @@ public class LavaSurgeWall extends LavaAbility {
 			return;
 		}
 		if (!TempBlock.isTempBlock(block)) {
-			new TempBlock(block, Material.LAVA, GeneralMethods.getLavaData(0));
+			new TempBlock(block, Material.LAVA);
 			AFFECTED_BLOCKS.put(block, block);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
@@ -253,7 +253,7 @@ public class LavaSurgeWave extends LavaAbility {
 		if (GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 			return;
 		} else if (!TempBlock.isTempBlock(block)) {
-			new TempBlock(block, Material.LAVA, GeneralMethods.getLavaData(0));
+			new TempBlock(block, Material.LAVA);
 			this.waveBlocks.put(block, block);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
@@ -140,7 +140,7 @@ public class TorrentWave extends WaterAbility {
 				}
 
 				if (isTransparent(this.player, block)) {
-					final TempBlock tempBlock = new TempBlock(block, Material.WATER, GeneralMethods.getWaterData(0));
+					final TempBlock tempBlock = new TempBlock(block, Material.WATER);
 					this.blocks.add(tempBlock);
 					torrentBlocks.add(block);
 				} else {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -311,9 +311,9 @@ public class WaterManipulation extends WaterAbility {
 				}
 				if (this.trail != null) {
 					this.trail2 = this.trail;
-					this.trail2.setType(Material.WATER, GeneralMethods.getWaterData(6));
+					this.trail2.setType(GeneralMethods.getWaterData(6));
 				}
-				this.trail = new TempBlock(this.sourceBlock, Material.WATER, GeneralMethods.getWaterData(7));
+				this.trail = new TempBlock(this.sourceBlock, GeneralMethods.getWaterData(7));
 				this.sourceBlock = block;
 
 				if (this.location.distanceSquared(this.targetDestination) <= 1 || this.location.distanceSquared(this.firstDestination) > this.range * this.range) {
@@ -366,7 +366,7 @@ public class WaterManipulation extends WaterAbility {
 			if (PhaseChange.getFrozenBlocksAsBlock().contains(block)) {
 				PhaseChange.getFrozenBlocksAsBlock().remove(block);
 			}
-			new TempBlock(block, Material.WATER, GeneralMethods.getWaterData(0));
+			new TempBlock(block, Material.WATER);
 		} else {
 			if (isWater(block) && !AFFECTED_BLOCKS.containsKey(block)) {
 				ParticleEffect.WATER_BUBBLE.display(block.getLocation().clone().add(.5, .5, .5), 5, Math.random(), Math.random(), Math.random(), 0);
@@ -500,7 +500,7 @@ public class WaterManipulation extends WaterAbility {
 
 			if (isTransparent(player, block) && isTransparent(player, eyeLoc.getBlock())) {
 				if (getTargetLocation(player, range).distanceSquared(block.getLocation()) > 1) {
-					final TempBlock tb = new TempBlock(block, Material.WATER, GeneralMethods.getWaterData(0));
+					final TempBlock tb = new TempBlock(block, Material.WATER);
 
 					final WaterManipulation waterManip = new WaterManipulation(player, block);
 					waterManip.moveWater();

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpout.java
@@ -111,7 +111,7 @@ public class WaterSpout extends WaterAbility {
 
 			final Block block = loc.getBlock();
 			if ((!TempBlock.isTempBlock(block)) && (ElementalAbility.isAir(block.getType()) || !GeneralMethods.isSolid(block))) {
-				this.blocks.add(new TempBlock(block, Material.WATER, GeneralMethods.getWaterData(7)));
+				this.blocks.add(new TempBlock(block, GeneralMethods.getWaterData(7)));
 				AFFECTED_BLOCKS.put(block, block);
 			}
 		}
@@ -157,7 +157,7 @@ public class WaterSpout extends WaterAbility {
 					block = location.clone().add(0, i, 0).getBlock();
 
 					if (!TempBlock.isTempBlock(block)) {
-						this.blocks.add(new TempBlock(block, Material.WATER, GeneralMethods.getWaterData(0)));
+						this.blocks.add(new TempBlock(block, Material.WATER));
 						AFFECTED_BLOCKS.put(block, block);
 					}
 					this.rotateParticles(block);
@@ -286,7 +286,7 @@ public class WaterSpout extends WaterAbility {
 
 					if (!TempBlock.isTempBlock(blocki)) {
 						this.revertBaseBlock();
-						this.baseBlock = new TempBlock(blocki, Material.WATER, GeneralMethods.getWaterData(0));
+						this.baseBlock = new TempBlock(blocki, Material.WATER);
 					}
 
 					this.base = blocki;

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -11,7 +11,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -305,7 +304,7 @@ public class WaterSpoutWave extends WaterAbility {
 				for (final Block block : GeneralMethods.getBlocksAroundPoint(this.player.getLocation().add(0, -1, 0), this.waveRadius)) {
 					if (ElementalAbility.isAir(block.getType()) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 						if (this.iceWave) {
-							this.createBlockDelay(block, Material.ICE, Material.ICE.createBlockData(), 2L);
+							this.createBlockDelay(block, Material.ICE, 2L);
 						} else {
 							this.createBlock(block, Material.WATER);
 						}
@@ -369,11 +368,11 @@ public class WaterSpoutWave extends WaterAbility {
 		}
 	}
 
-	public void createBlockDelay(final Block block, final Material mat, final BlockData data, final long delay) {
+	public void createBlockDelay(final Block block, final Material mat, final long delay) {
 		final BukkitRunnable br = new BukkitRunnable() {
 			@Override
 			public void run() {
-				WaterSpoutWave.this.createBlock(block, mat, data);
+				WaterSpoutWave.this.createBlock(block, mat);
 			}
 		};
 		br.runTaskLater(ProjectKorra.plugin, delay);
@@ -381,11 +380,7 @@ public class WaterSpoutWave extends WaterAbility {
 	}
 
 	public void createBlock(final Block block, final Material mat) {
-		this.createBlock(block, mat, mat.createBlockData());
-	}
-
-	public void createBlock(final Block block, final Material mat, final BlockData data) {
-		this.affectedBlocks.put(block, new TempBlock(block, mat, data));
+		this.affectedBlocks.put(block, new TempBlock(block, mat));
 	}
 
 	public void revertBlocks() {

--- a/src/com/projectkorra/projectkorra/waterbending/combo/IceBullet.java
+++ b/src/com/projectkorra/projectkorra/waterbending/combo/IceBullet.java
@@ -196,7 +196,7 @@ public class IceBullet extends IceAbility implements ComboAbility {
 	}
 
 	public void createBlock(final Block block, final Material mat, final BlockData data) {
-		this.affectedBlocks.put(block, new TempBlock(block, mat, data));
+		this.affectedBlocks.put(block, new TempBlock(block, data));
 	}
 
 	public void drawWaterCircle(final Location loc, final double theta, final double increment, final double radius) {

--- a/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
+++ b/src/com/projectkorra/projectkorra/waterbending/healing/HealingWaters.java
@@ -182,7 +182,7 @@ public class HealingWaters extends HealingAbility {
 	}
 
 	private void giveHP(final Player player) {
-		if (!player.isDead() && player.getHealth() < player.getMaxHealth()) {
+		if (!player.isDead() && player.getHealth() < player.getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH).getValue()) {
 			this.applyHealing(player);
 		} else {
 			this.healing = false;
@@ -199,7 +199,7 @@ public class HealingWaters extends HealingAbility {
 	}
 
 	private void giveHP(final LivingEntity livingEntity) {
-		if (!livingEntity.isDead() && livingEntity.getHealth() < livingEntity.getMaxHealth()) {
+		if (!livingEntity.isDead() && livingEntity.getHealth() < livingEntity.getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH).getValue()) {
 			this.applyHealing(livingEntity);
 		} else {
 			this.healing = false;
@@ -222,7 +222,7 @@ public class HealingWaters extends HealingAbility {
 	}
 
 	private void applyHealing(final LivingEntity livingEntity) {
-		if (livingEntity.getHealth() < livingEntity.getMaxHealth()) {
+		if (livingEntity.getHealth() < livingEntity.getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH).getValue()) {
 			livingEntity.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 30, this.potionPotency));
 			AirAbility.breakBreathbendingHold(livingEntity);
 			this.healing = true;

--- a/src/com/projectkorra/projectkorra/waterbending/ice/PhaseChange.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/PhaseChange.java
@@ -379,11 +379,10 @@ public class PhaseChange extends IceAbility {
 					final Snow snow = (Snow) b.getBlockData();
 					if (snow.getLayers() == snow.getMinimumLayers()) {
 						tb.revertBlock();
-						new TempBlock(b, Material.AIR).setRevertTime(120 * 1000L);
+						new TempBlock(b, Material.AIR.createBlockData(), 120 * 1000L);
 					} else {
 						tb.revertBlock();
-						snow.setLayers(snow.getLayers() - 1);
-						new TempBlock(b, Material.SNOW, snow).setRevertTime(120 * 1000L);
+						new TempBlock(b, Material.SNOW.createBlockData(d -> ((Snow) d).setLayers(snow.getLayers() - 1)), 120 * 1000L);
 					}
 				}
 			}
@@ -398,17 +397,17 @@ public class PhaseChange extends IceAbility {
 				b.setType(Material.WATER);
 				b.setBlockData(GeneralMethods.getWaterData(0));
 			} else {
-				new TempBlock(b, Material.WATER, GeneralMethods.getWaterData(0));
+				new TempBlock(b, Material.WATER);
 			}
 			this.melted_blocks.add(b);
 		} else if (b.getType() == Material.SNOW_BLOCK || b.getType() == Material.SNOW) {
 			if (b.getBlockData() instanceof Snow) {
 				final Snow snow = (Snow) b.getBlockData();
 				if (snow.getLayers() == snow.getMinimumLayers()) {
-					new TempBlock(b, Material.AIR).setRevertTime(120 * 1000L);
+					new TempBlock(b, Material.AIR.createBlockData(), 120 * 1000L);
 				} else {
 					snow.setLayers(snow.getLayers() - 1);
-					new TempBlock(b, Material.SNOW, snow).setRevertTime(120 * 1000L);
+					new TempBlock(b, Material.SNOW.createBlockData(d -> ((Snow) d).setLayers(snow.getLayers() - 1)), 120 * 1000L);
 				}
 			}
 

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -233,7 +233,7 @@ public class WaterArms extends WaterAbility {
 		}
 
 		if (!(this.getRightHandPos().getBlock().getLocation().equals(r1.getBlock().getLocation()))) {
-			this.addBlock(r1.getBlock(), Material.WATER, GeneralMethods.getWaterData(3), 100);
+			this.addBlock(r1.getBlock(), GeneralMethods.getWaterData(3), 100);
 			newBlocks.add(r1.getBlock());
 		}
 
@@ -244,7 +244,7 @@ public class WaterArms extends WaterAbility {
 			return false;
 		}
 
-		this.addBlock(r2.getBlock(), Material.WATER, GeneralMethods.getWaterData(0), 100);
+		this.addBlock(r2.getBlock(), Material.WATER.createBlockData(), 100);
 		newBlocks.add(r2.getBlock());
 
 		for (int j = 1; j <= this.initLength; j++) {
@@ -257,9 +257,9 @@ public class WaterArms extends WaterAbility {
 
 			newBlocks.add(r3.getBlock());
 			if (j >= 1 && this.selectedSlot == this.freezeSlot && this.bPlayer.canIcebend()) {
-				this.addBlock(r3.getBlock(), Material.ICE, Material.ICE.createBlockData(), 100);
+				this.addBlock(r3.getBlock(), Material.ICE.createBlockData(), 100);
 			} else {
-				this.addBlock(r3.getBlock(), Material.WATER, GeneralMethods.getWaterData(0), 100);
+				this.addBlock(r3.getBlock(), Material.WATER.createBlockData(), 100);
 			}
 		}
 
@@ -288,7 +288,7 @@ public class WaterArms extends WaterAbility {
 		}
 
 		if (!(this.getLeftHandPos().getBlock().getLocation().equals(l1.getBlock().getLocation()))) {
-			this.addBlock(l1.getBlock(), Material.WATER, GeneralMethods.getWaterData(3), 100);
+			this.addBlock(l1.getBlock(), GeneralMethods.getWaterData(3), 100);
 			newBlocks.add(l1.getBlock());
 		}
 
@@ -299,7 +299,7 @@ public class WaterArms extends WaterAbility {
 			return false;
 		}
 
-		this.addBlock(l2.getBlock(), Material.WATER, GeneralMethods.getWaterData(0), 100);
+		this.addBlock(l2.getBlock(), Material.WATER.createBlockData(), 100);
 		newBlocks.add(l2.getBlock());
 
 		for (int j = 1; j <= this.initLength; j++) {
@@ -312,9 +312,9 @@ public class WaterArms extends WaterAbility {
 
 			newBlocks.add(l3.getBlock());
 			if (j >= 1 && this.selectedSlot == this.freezeSlot && this.bPlayer.canIcebend()) {
-				this.addBlock(l3.getBlock(), Material.ICE, Material.ICE.createBlockData(), 100);
+				this.addBlock(l3.getBlock(), Material.ICE.createBlockData(), 100);
 			} else {
-				this.addBlock(l3.getBlock(), Material.WATER, GeneralMethods.getWaterData(0), 100);
+				this.addBlock(l3.getBlock(), Material.WATER.createBlockData(), 100);
 			}
 		}
 
@@ -324,18 +324,18 @@ public class WaterArms extends WaterAbility {
 		return true;
 	}
 
-	public void addBlock(final Block b, final Material m, final BlockData data, final long revertTime) {
+	public void addBlock(final Block b, final BlockData data, final long revertTime) {
 		if (TempBlock.isTempBlock(b)) {
 			final TempBlock tb = TempBlock.get(b);
 
 			if (this.right.contains(b) || this.left.contains(b)) {
-				tb.setType(m, data);
+				tb.setType(data);
 				tb.setRevertTime(revertTime);
 			} else {
 				this.external.add(tb);
 			}
 		} else {
-			new TempBlock(b, m, data).setRevertTime(revertTime);
+			new TempBlock(b, data, revertTime);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -262,7 +262,7 @@ public class WaterArmsWhip extends WaterAbility {
 
 				final int j = (int) Math.ceil(8 / (Math.pow(i, 1 / 3)));
 				this.waterArms.addToArm(l2.getBlock(), this.arm);
-				this.waterArms.addBlock(l2.getBlock(), Material.WATER, GeneralMethods.getWaterData(j), 40);
+				this.waterArms.addBlock(l2.getBlock(), GeneralMethods.getWaterData(j), 40);
 
 				if (i == this.activeLength) {
 					this.end = l2.clone();
@@ -282,7 +282,7 @@ public class WaterArmsWhip extends WaterAbility {
 					}
 
 					this.waterArms.addToArm(this.end.getBlock(), this.arm);
-					this.waterArms.addBlock(this.end.getBlock(), Material.WATER, GeneralMethods.getWaterData(5), 40);
+					this.waterArms.addBlock(this.end.getBlock(), GeneralMethods.getWaterData(5), 40);
 					this.performAction(this.end);
 				} else {
 					this.performAction(l2);

--- a/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
+++ b/src/com/projectkorra/projectkorra/waterbending/util/WaterReturn.java
@@ -44,7 +44,7 @@ public class WaterReturn extends WaterAbility {
 
 		if (this.bPlayer.canBendIgnoreBindsCooldowns(this)) {
 			if (isTransparent(player, block) && ((TempBlock.isTempBlock(block) && block.isLiquid()) || !block.isLiquid()) && this.hasEmptyWaterBottle()) {
-				this.block = new TempBlock(block, Material.WATER, GeneralMethods.getWaterData(0));
+				this.block = new TempBlock(block, Material.WATER);
 			}
 		}
 		this.start();
@@ -84,7 +84,7 @@ public class WaterReturn extends WaterAbility {
 		final Block newblock = this.location.getBlock();
 		if (isTransparent(this.player, newblock) && !newblock.isLiquid()) {
 			this.block.revertBlock();
-			this.block = new TempBlock(newblock, Material.WATER, GeneralMethods.getWaterData(0));
+			this.block = new TempBlock(newblock, Material.WATER);
 		} else if (isTransparent(this.player, newblock)) {
 			if (isWater(newblock)) {
 				ParticleEffect.WATER_BUBBLE.display(newblock.getLocation().clone().add(.5, .5, .5), 5, Math.random(), Math.random(), Math.random(), 0);

--- a/src/com/projectkorra/projectkorra/waterbending/util/WaterSourceGrabber.java
+++ b/src/com/projectkorra/projectkorra/waterbending/util/WaterSourceGrabber.java
@@ -43,7 +43,7 @@ public class WaterSourceGrabber {
 		this.player = player;
 		this.animimationSpeed = animationSpeed;
 		this.material = Material.WATER;
-		this.data = GeneralMethods.getWaterData(0);
+		this.data = Material.WATER.createBlockData();
 		this.currentLoc = origin.clone();
 		this.state = AnimationState.RISING;
 		this.affectedBlocks = new ConcurrentHashMap<>();
@@ -63,7 +63,7 @@ public class WaterSourceGrabber {
 				return;
 			}
 
-			this.createBlock(block, this.material, this.data);
+			this.createBlock(block, this.data);
 			if (Math.abs(locDiff) < 1) {
 				this.state = AnimationState.TOWARD;
 			}
@@ -80,7 +80,7 @@ public class WaterSourceGrabber {
 				return;
 			}
 
-			this.createBlock(block, this.material, this.data);
+			this.createBlock(block, this.data);
 			if (this.currentLoc.distanceSquared(eyeLoc) < 1.2) {
 				this.state = AnimationState.FINISHED;
 				this.revertBlocks();
@@ -106,11 +106,11 @@ public class WaterSourceGrabber {
 	}
 
 	public void createBlock(final Block block, final Material mat) {
-		this.createBlock(block, mat, mat.createBlockData());
+		this.createBlock(block, mat.createBlockData());
 	}
 
-	public void createBlock(final Block block, final Material mat, final BlockData data) {
-		this.affectedBlocks.put(block, new TempBlock(block, mat, data));
+	public void createBlock(final Block block, final BlockData data) {
+		this.affectedBlocks.put(block, new TempBlock(block, data));
 	}
 
 	public Player getPlayer() {


### PR DESCRIPTION
Update some deprecated calls
## Fixes
* Fixes a bug which caused the server to load the legacy material API the first time a player used tremorsense's passive.
## Improvements
* Added boundaries to Levelled block data in GeneralMethods.getWaterData and GeneralMethods.getLavaData to avoid future bugs
    
