### PR TITLE
Various config options

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1585,7 +1585,7 @@ public class PKListener implements Listener {
 		final int slot = event.getNewSlot() + 1;
 		GeneralMethods.displayMovePreview(player, slot);
 
-		if (!ConfigManager.defaultConfig.get().getBoolean("Properties.BendingPreview")) {
+		if (ConfigManager.defaultConfig.get().getBoolean("Abilities.Water.WaterArms.DisplayBoundMsg")) {
 			final WaterArms waterArms = CoreAbility.getAbility(player, WaterArms.class);
 			if (waterArms != null) {
 				waterArms.displayBoundMsg(event.getNewSlot() + 1);

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1591,8 +1591,8 @@ public class PKListener implements Listener {
 		if (ConfigManager.defaultConfig.get().getBoolean("Abilities.Water.WaterArms.DisplayBoundMsg")) {
 			final WaterArms waterArms = CoreAbility.getAbility(player, WaterArms.class);
 			if (waterArms != null) {
-					waterArms.displayBoundMsg(event.getNewSlot() + 1);
-					return;
+				waterArms.displayBoundMsg(event.getNewSlot() + 1);
+				return;
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1583,13 +1583,16 @@ public class PKListener implements Listener {
 	public void onPlayerSlotChange(final PlayerItemHeldEvent event) {
 		final Player player = event.getPlayer();
 		final int slot = event.getNewSlot() + 1;
-		GeneralMethods.displayMovePreview(player, slot);
 
+		if (ConfigManager.defaultConfig.get().getBoolean("Properties.BendingPreview")) {
+			GeneralMethods.displayMovePreview(player, slot);
+		}
+		
 		if (ConfigManager.defaultConfig.get().getBoolean("Abilities.Water.WaterArms.DisplayBoundMsg")) {
 			final WaterArms waterArms = CoreAbility.getAbility(player, WaterArms.class);
 			if (waterArms != null) {
-				waterArms.displayBoundMsg(event.getNewSlot() + 1);
-				return;
+					waterArms.displayBoundMsg(event.getNewSlot() + 1);
+					return;
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -42,6 +42,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 	private Vector direction;
 	private ArrayList<Entity> affectedEntities;
 	private ArrayList<BukkitRunnable> tasks;
+	private double hitRadius;
 
 	public AirSweep(final Player player) {
 		super(player);
@@ -62,6 +63,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 		this.speed = getConfig().getDouble("Abilities.Air.AirSweep.Speed");
 		this.knockback = getConfig().getDouble("Abilities.Air.AirSweep.Knockback");
 		this.cooldown = getConfig().getLong("Abilities.Air.AirSweep.Cooldown");
+		this.hitRadius = getConfig().getDouble("Abilities.Air.AirSweep.HitRadius");
 
 		if (this.bPlayer.isAvatarState()) {
 			this.cooldown = 0;
@@ -188,7 +190,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 				}
 			}
 			if (i % 3 == 0) {
-				for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(loc, 2.5)) {
+				for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(loc, hitRadius)) {
 					if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation())) {
 						this.remove();
 						return;

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -63,7 +63,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 		this.speed = getConfig().getDouble("Abilities.Air.AirSweep.Speed");
 		this.knockback = getConfig().getDouble("Abilities.Air.AirSweep.Knockback");
 		this.cooldown = getConfig().getLong("Abilities.Air.AirSweep.Cooldown");
-		this.hitRadius = getConfig().getDouble("Abilities.Air.AirSweep.Radius");
+		this.radius = getConfig().getDouble("Abilities.Air.AirSweep.Radius");
 
 		if (this.bPlayer.isAvatarState()) {
 			this.cooldown = 0;

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -42,7 +42,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 	private Vector direction;
 	private ArrayList<Entity> affectedEntities;
 	private ArrayList<BukkitRunnable> tasks;
-	private double hitRadius;
+	private double radius;
 
 	public AirSweep(final Player player) {
 		super(player);
@@ -63,7 +63,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 		this.speed = getConfig().getDouble("Abilities.Air.AirSweep.Speed");
 		this.knockback = getConfig().getDouble("Abilities.Air.AirSweep.Knockback");
 		this.cooldown = getConfig().getLong("Abilities.Air.AirSweep.Cooldown");
-		this.hitRadius = getConfig().getDouble("Abilities.Air.AirSweep.HitRadius");
+		this.hitRadius = getConfig().getDouble("Abilities.Air.AirSweep.Radius");
 
 		if (this.bPlayer.isAvatarState()) {
 			this.cooldown = 0;
@@ -190,7 +190,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 				}
 			}
 			if (i % 3 == 0) {
-				for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(loc, hitRadius)) {
+				for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(loc, radius)) {
 					if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation())) {
 						this.remove();
 						return;

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -943,7 +943,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Air.AirSweep.Damage", 3);
 			config.addDefault("Abilities.Air.AirSweep.Knockback", 3.5);
 			config.addDefault("Abilities.Air.AirSweep.Cooldown", 6000);
-			config.addDefault("Abilities.Air.AirSweep.HitRadius", 1);
+			config.addDefault("Abilities.Air.AirSweep.Radius", 1);
 
 			config.addDefault("Abilities.Water.Passive.FastSwim.Enabled", true);
 			config.addDefault("Abilities.Water.Passive.FastSwim.Cooldown", 0);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -943,6 +943,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Air.AirSweep.Damage", 3);
 			config.addDefault("Abilities.Air.AirSweep.Knockback", 3.5);
 			config.addDefault("Abilities.Air.AirSweep.Cooldown", 6000);
+			config.addDefault("Abilities.Air.AirSweep.HitRadius", 1.5);
 
 			config.addDefault("Abilities.Water.Passive.FastSwim.Enabled", true);
 			config.addDefault("Abilities.Water.Passive.FastSwim.Cooldown", 0);
@@ -1071,6 +1072,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.Plantbending.RegrowTime", 180000);
 
 			config.addDefault("Abilities.Water.WaterArms.Enabled", true);
+			config.addDefault("Abilities.Water.WaterArms.DisplayBoundMsg", false);
 
 			config.addDefault("Abilities.Water.WaterArms.Arms.InitialLength", 4);
 			config.addDefault("Abilities.Water.WaterArms.Arms.SourceGrabRange", 12);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -943,7 +943,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Air.AirSweep.Damage", 3);
 			config.addDefault("Abilities.Air.AirSweep.Knockback", 3.5);
 			config.addDefault("Abilities.Air.AirSweep.Cooldown", 6000);
-			config.addDefault("Abilities.Air.AirSweep.HitRadius", 1.5);
+			config.addDefault("Abilities.Air.AirSweep.HitRadius", 1);
 
 			config.addDefault("Abilities.Water.Passive.FastSwim.Enabled", true);
 			config.addDefault("Abilities.Water.Passive.FastSwim.Cooldown", 0);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -949,6 +949,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.Passive.FastSwim.Cooldown", 0);
 			config.addDefault("Abilities.Water.Passive.FastSwim.Duration", 0);
 			config.addDefault("Abilities.Water.Passive.FastSwim.SpeedFactor", 0.7);
+			config.addDefault("Abilities.Water.Passive.FastSwim.AllowWaterArms", false);
 			config.addDefault("Abilities.Water.Passive.Hydrosink.Enabled", true);
 
 			config.addDefault("Abilities.Water.Bloodbending.Enabled", true);

--- a/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
+++ b/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
@@ -9,7 +9,6 @@ import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.earthbending.EarthArmor;
 import com.projectkorra.projectkorra.waterbending.WaterSpout;
-import com.projectkorra.projectkorra.waterbending.multiabilities.WaterArms;
 
 public class FastSwim extends WaterAbility implements PassiveAbility {
 
@@ -36,7 +35,7 @@ public class FastSwim extends WaterAbility implements PassiveAbility {
 
 	@Override
 	public void progress() {
-		if (!this.bPlayer.canUsePassive(this) || !this.bPlayer.canBendPassive(this) || CoreAbility.hasAbility(this.player, WaterSpout.class) || CoreAbility.hasAbility(this.player, EarthArmor.class) || CoreAbility.hasAbility(this.player, WaterArms.class)) {
+		if (!this.bPlayer.canUsePassive(this) || !this.bPlayer.canBendPassive(this) || CoreAbility.hasAbility(this.player, WaterSpout.class) || CoreAbility.hasAbility(this.player, EarthArmor.class)) {
 			this.remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
+++ b/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
@@ -9,12 +9,14 @@ import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.earthbending.EarthArmor;
 import com.projectkorra.projectkorra.waterbending.WaterSpout;
+import com.projectkorra.projectkorra.waterbending.multiabilities.WaterArms;
 
 public class FastSwim extends WaterAbility implements PassiveAbility {
 
 	private long cooldown;
 	private double swimSpeed;
 	private long duration;
+	private boolean allowWaterArms;
 
 	public FastSwim(final Player player) {
 		super(player);
@@ -29,6 +31,7 @@ public class FastSwim extends WaterAbility implements PassiveAbility {
 		this.cooldown = ConfigManager.getConfig().getLong("Abilities.Water.Passive.FastSwim.Cooldown");
 		this.swimSpeed = ConfigManager.getConfig().getDouble("Abilities.Water.Passive.FastSwim.SpeedFactor");
 		this.duration = ConfigManager.getConfig().getLong("Abilities.Water.Passive.FastSwim.Duration");
+		this.allowWaterArms = ConfigManager.getConfig().getBoolean("Abilities.Water.Passive.FastSwim.AllowWaterArms");
 
 		this.start();
 	}
@@ -36,6 +39,11 @@ public class FastSwim extends WaterAbility implements PassiveAbility {
 	@Override
 	public void progress() {
 		if (!this.bPlayer.canUsePassive(this) || !this.bPlayer.canBendPassive(this) || CoreAbility.hasAbility(this.player, WaterSpout.class) || CoreAbility.hasAbility(this.player, EarthArmor.class)) {
+			this.remove();
+			return;
+		}
+		
+		if (CoreAbility.hasAbility(this.player, WaterArms.class) && !this.allowWaterArms) {
 			this.remove();
 			return;
 		}


### PR DESCRIPTION
## Additions
* Added a configurable AirSweep hit radius called "Radius" with a default of 1
* Added a configurable option to enable/disable WaterArms bound messages that are independent of the BendingPreview option, called "DisplayBoundMsg" under the WaterArms config, with a default of false
* Added a configurable option to allow/prohibit FastSwim while WaterArms is in use, called "AllowWaterArms" under the FastSwim config, with a default of false