### PR TITLE
Add config option for Lightning on FireJet

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1456,6 +1456,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.Lightning.SelfHitWater", true);
 			config.addDefault("Abilities.Fire.Lightning.SelfHitClose", false);
 			config.addDefault("Abilities.Fire.Lightning.ArcOnIce", false);
+			config.addDefault("Abilities.Fire.Lightning.AllowOnFireJet", true);
 
 			config.addDefault("Abilities.Fire.WallOfFire.Enabled", true);
 			config.addDefault("Abilities.Fire.WallOfFire.Range", 3);

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -35,6 +35,7 @@ public class Lightning extends LightningAbility {
 	private boolean hitIce;
 	private boolean selfHitWater;
 	private boolean selfHitClose;
+	private boolean allowOnFireJet;
 	@Attribute("ArcOnIce")
 	private boolean arcOnIce;
 	private int waterArcs;
@@ -110,6 +111,7 @@ public class Lightning extends LightningAbility {
 		this.waterArcs = getConfig().getInt("Abilities.Fire.Lightning.WaterArcs");
 		this.chargeTime = getConfig().getLong("Abilities.Fire.Lightning.ChargeTime");
 		this.cooldown = getConfig().getLong("Abilities.Fire.Lightning.Cooldown");
+		this.allowOnFireJet = getConfig().getBoolean("Abilities.Fire.Lightning.AllowOnFireJet");
 
 		this.range = this.getDayFactor(this.range);
 		this.subArcChance = this.getDayFactor(this.subArcChance);
@@ -182,7 +184,7 @@ public class Lightning extends LightningAbility {
 		} else if (!this.bPlayer.canBendIgnoreCooldowns(this)) {
 			this.remove();
 			return;
-		} else if (CoreAbility.hasAbility(player, FireJet.class)){
+		} else if (CoreAbility.hasAbility(player, FireJet.class) && !allowOnFireJet){
 			this.removeWithTasks();
 			return;
 		}


### PR DESCRIPTION
## Additions
* Added a configurable boolean for Lightning called "AllowOnFireJet" with a default of true, which allows the use of Lightning while on FireJet
* Implements #1082 