### PR TITLE
Fix ability bug with gamerule doDaylightCycle

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -747,8 +747,12 @@ public abstract class CoreAbility implements Ability {
 		return this.startTick;
 	}
 
-	public long getCurrentTick() {
+	public static long getCurrentTick() {
 		return currentTick;
+	}
+
+	public long getRunningTicks() {
+		return currentTick - this.startTick;
 	}
 
 	public boolean isStarted() {

--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -90,6 +90,7 @@ public abstract class CoreAbility implements Ability {
 	private static final Map<Class<? extends CoreAbility>, Map<String, Field>> ATTRIBUTE_FIELDS = new HashMap<>();
 
 	private static int idCounter;
+	private static long currentTick;
 
 	protected Player player;
 	protected BendingPlayer bPlayer;
@@ -102,7 +103,7 @@ public abstract class CoreAbility implements Ability {
 	private boolean hidden;
 	private int id;
 	private long startTime;
-	private long currentTick;
+	private long startTick;
 	private boolean attributesModified;
 
 	static {
@@ -180,6 +181,7 @@ public abstract class CoreAbility implements Ability {
 
 		this.started = true;
 		this.startTime = System.currentTimeMillis();
+		this.startTick = getCurrentTick();
 		final Class<? extends CoreAbility> clazz = this.getClass();
 		final UUID uuid = this.player.getUniqueId();
 
@@ -273,7 +275,6 @@ public abstract class CoreAbility implements Ability {
 						abil.progress();
 					}
 
-					abil.currentTick++;
 					Bukkit.getServer().getPluginManager().callEvent(new AbilityProgressEvent(abil));
 				} catch (final Exception e) {
 					e.printStackTrace();
@@ -291,6 +292,7 @@ public abstract class CoreAbility implements Ability {
 				}
 			}
 		}
+		currentTick++;
 	}
 
 	/**
@@ -742,11 +744,11 @@ public abstract class CoreAbility implements Ability {
 	}
 
 	public long getStartTick() {
-		return 0;
+		return this.startTick;
 	}
 
 	public long getCurrentTick() {
-		return this.currentTick;
+		return currentTick;
 	}
 
 	public boolean isStarted() {

--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -102,7 +102,7 @@ public abstract class CoreAbility implements Ability {
 	private boolean hidden;
 	private int id;
 	private long startTime;
-	private long startTick;
+	private long currentTick;
 	private boolean attributesModified;
 
 	static {
@@ -149,7 +149,6 @@ public abstract class CoreAbility implements Ability {
 		this.startTime = System.currentTimeMillis();
 		this.started = false;
 		this.id = CoreAbility.idCounter;
-		this.startTick = this.getCurrentTick();
 
 		if (idCounter == Integer.MAX_VALUE) {
 			idCounter = Integer.MIN_VALUE;
@@ -274,6 +273,7 @@ public abstract class CoreAbility implements Ability {
 						abil.progress();
 					}
 
+					abil.currentTick++;
 					Bukkit.getServer().getPluginManager().callEvent(new AbilityProgressEvent(abil));
 				} catch (final Exception e) {
 					e.printStackTrace();
@@ -742,11 +742,11 @@ public abstract class CoreAbility implements Ability {
 	}
 
 	public long getStartTick() {
-		return this.startTick;
+		return 0;
 	}
 
 	public long getCurrentTick() {
-		return this.player.getWorld().getFullTime();
+		return this.currentTick;
 	}
 
 	public boolean isStarted() {


### PR DESCRIPTION
Small bugfix for abilities' running ticks.
Method signatures (getStartTick and getCurrentTick) have remained the same to maintain compatibility (even though CoreAbility::getStartTick is unnecessary).
##  Fixes
* Fixes #1084 