### PR TITLE
Add AbilityVelocityAffectEntityEvent

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -2513,7 +2513,9 @@ public class GeneralMethods {
 		if (event.isCancelled()) 
 			return;
 		
-		Vector velocity = event.getNewVector();
+		Vector velocity = event.getVelocity();
+		if(velocity == null || Double.isNaN(velocity.length()))
+		    return;
 		
 		if (entity instanceof TNTPrimed) {
 			if (ConfigManager.defaultConfig.get().getBoolean("Properties.BendingAffectFallingSand.TNT")) {

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -2507,7 +2507,6 @@ public class GeneralMethods {
 	}
 	
 	public static void setVelocity(Ability ability, Entity entity, Vector vector) {
-		
 		final AbilityVelocityAffectEntityEvent event = new AbilityVelocityAffectEntityEvent(ability, entity, vector);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 		if (event.isCancelled()) 
@@ -2547,6 +2546,5 @@ public class GeneralMethods {
 		}
 
 		event.getAffected().setVelocity(velocity);
-		
 	}
 }

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -112,6 +112,7 @@ import com.projectkorra.projectkorra.airbending.AirSwipe;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.earthbending.EarthBlast;
 import com.projectkorra.projectkorra.earthbending.passive.EarthPassive;
+import com.projectkorra.projectkorra.event.AbilityVelocityAffectEntityEvent;
 import com.projectkorra.projectkorra.event.BendingPlayerCreationEvent;
 import com.projectkorra.projectkorra.event.BendingReloadEvent;
 import com.projectkorra.projectkorra.event.PlayerBindChangeEvent;
@@ -2531,5 +2532,24 @@ public class GeneralMethods {
 			default:
 				return false;
 		}
+	}
+
+	public static void setEntityVelocity(Ability ability, Entity entity, Vector vector) {
+		setEntityVelocity(ability, entity, vector, false);
+	}
+	
+	public static void setEntityVelocity(Ability ability, Entity entity, Vector vector, boolean useGeneral) {
+		
+		final AbilityVelocityAffectEntityEvent event = new AbilityVelocityAffectEntityEvent(ability, entity, vector);
+		Bukkit.getServer().getPluginManager().callEvent(event);
+		if (event.isCancelled()) 
+			return;
+		
+		if(!useGeneral)
+			event.getAffected().setVelocity(event.getNewVector());
+		else
+			GeneralMethods.setVelocity(event.getAffected(), event.getNewVector());
+		
+		
 	}
 }

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -2315,39 +2315,6 @@ public class GeneralMethods {
 		DBConnection.sql.modifyQuery("UPDATE pk_players SET permaremoved = '" + (permaRemoved ? "true" : "false") + "' WHERE uuid = '" + uuid + "'");
 	}
 
-	public static void setVelocity(final Entity entity, final Vector velocity) {
-		if (entity instanceof TNTPrimed) {
-			if (ConfigManager.defaultConfig.get().getBoolean("Properties.BendingAffectFallingSand.TNT")) {
-				velocity.multiply(ConfigManager.defaultConfig.get().getDouble("Properties.BendingAffectFallingSand.TNTStrengthMultiplier"));
-			}
-		} else if (entity instanceof FallingBlock) {
-			if (ConfigManager.defaultConfig.get().getBoolean("Properties.BendingAffectFallingSand.Normal")) {
-				velocity.multiply(ConfigManager.defaultConfig.get().getDouble("Properties.BendingAffectFallingSand.NormalStrengthMultiplier"));
-			}
-		}
-
-		// Attempt to stop velocity from going over the packet cap.
-		if (velocity.getX() > 4) {
-			velocity.setX(4);
-		} else if (velocity.getX() < -4) {
-			velocity.setX(-4);
-		}
-
-		if (velocity.getY() > 4) {
-			velocity.setY(4);
-		} else if (velocity.getY() < -4) {
-			velocity.setY(-4);
-		}
-
-		if (velocity.getZ() > 4) {
-			velocity.setZ(4);
-		} else if (velocity.getZ() < -4) {
-			velocity.setZ(-4);
-		}
-
-		entity.setVelocity(velocity);
-	}
-
 	public static FallingBlock spawnFallingBlock(final Location loc, final Material type) {
 		return spawnFallingBlock(loc, type, type.createBlockData());
 	}
@@ -2534,22 +2501,50 @@ public class GeneralMethods {
 		}
 	}
 
-	public static void setEntityVelocity(Ability ability, Entity entity, Vector vector) {
-		setEntityVelocity(ability, entity, vector, false);
+	@Deprecated
+	public static void setVelocity(Entity entity, Vector vector) {
+		setVelocity(null,entity,vector);
 	}
 	
-	public static void setEntityVelocity(Ability ability, Entity entity, Vector vector, boolean useGeneral) {
+	public static void setVelocity(Ability ability, Entity entity, Vector vector) {
 		
 		final AbilityVelocityAffectEntityEvent event = new AbilityVelocityAffectEntityEvent(ability, entity, vector);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 		if (event.isCancelled()) 
 			return;
 		
-		if(!useGeneral)
-			event.getAffected().setVelocity(event.getNewVector());
-		else
-			GeneralMethods.setVelocity(event.getAffected(), event.getNewVector());
+		Vector velocity = event.getNewVector();
 		
+		if (entity instanceof TNTPrimed) {
+			if (ConfigManager.defaultConfig.get().getBoolean("Properties.BendingAffectFallingSand.TNT")) {
+				velocity.multiply(ConfigManager.defaultConfig.get().getDouble("Properties.BendingAffectFallingSand.TNTStrengthMultiplier"));
+			}
+		} else if (entity instanceof FallingBlock) {
+			if (ConfigManager.defaultConfig.get().getBoolean("Properties.BendingAffectFallingSand.Normal")) {
+				velocity.multiply(ConfigManager.defaultConfig.get().getDouble("Properties.BendingAffectFallingSand.NormalStrengthMultiplier"));
+			}
+		}
+
+		// Attempt to stop velocity from going over the packet cap.
+		if (velocity.getX() > 4) {
+			velocity.setX(4);
+		} else if (velocity.getX() < -4) {
+			velocity.setX(-4);
+		}
+
+		if (velocity.getY() > 4) {
+			velocity.setY(4);
+		} else if (velocity.getY() < -4) {
+			velocity.setY(-4);
+		}
+
+		if (velocity.getZ() > 4) {
+			velocity.setZ(4);
+		} else if (velocity.getZ() < -4) {
+			velocity.setZ(-4);
+		}
+
+		event.getAffected().setVelocity(velocity);
 		
 	}
 }

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -170,14 +170,14 @@ public abstract class EarthAbility extends ElementalAbility {
 							final LivingEntity lentity = (LivingEntity) entity;
 							if (lentity.getEyeLocation().getBlockX() == affectedblock.getX() && lentity.getEyeLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									GeneralMethods.setVelocity((Ability)this,entity, norm.clone().multiply(.75));
+									GeneralMethods.setVelocity(this,entity, norm.clone().multiply(.75));
 									
 								}
 							}
 						} else {
 							if (entity.getLocation().getBlockX() == affectedblock.getX() && entity.getLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									GeneralMethods.setVelocity((Ability)this,entity, norm.clone().multiply(.75));
+									GeneralMethods.setVelocity(this,entity, norm.clone().multiply(.75));
 								}
 							}
 						}

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -170,13 +170,14 @@ public abstract class EarthAbility extends ElementalAbility {
 							final LivingEntity lentity = (LivingEntity) entity;
 							if (lentity.getEyeLocation().getBlockX() == affectedblock.getX() && lentity.getEyeLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									entity.setVelocity(norm.clone().multiply(.75));
+									GeneralMethods.setEntityVelocity((Ability)this,entity, norm.clone().multiply(.75));
+									
 								}
 							}
 						} else {
 							if (entity.getLocation().getBlockX() == affectedblock.getX() && entity.getLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									entity.setVelocity(norm.clone().multiply(.75));
+									GeneralMethods.setEntityVelocity((Ability)this,entity, norm.clone().multiply(.75));
 								}
 							}
 						}

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -170,14 +170,14 @@ public abstract class EarthAbility extends ElementalAbility {
 							final LivingEntity lentity = (LivingEntity) entity;
 							if (lentity.getEyeLocation().getBlockX() == affectedblock.getX() && lentity.getEyeLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									GeneralMethods.setVelocity(this,entity, norm.clone().multiply(.75));
+									GeneralMethods.setVelocity(this, entity, norm.clone().multiply(.75));
 									
 								}
 							}
 						} else {
 							if (entity.getLocation().getBlockX() == affectedblock.getX() && entity.getLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									GeneralMethods.setVelocity(this,entity, norm.clone().multiply(.75));
+									GeneralMethods.setVelocity(this, entity, norm.clone().multiply(.75));
 								}
 							}
 						}

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -170,14 +170,14 @@ public abstract class EarthAbility extends ElementalAbility {
 							final LivingEntity lentity = (LivingEntity) entity;
 							if (lentity.getEyeLocation().getBlockX() == affectedblock.getX() && lentity.getEyeLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									GeneralMethods.setEntityVelocity((Ability)this,entity, norm.clone().multiply(.75));
+									GeneralMethods.setVelocity((Ability)this,entity, norm.clone().multiply(.75));
 									
 								}
 							}
 						} else {
 							if (entity.getLocation().getBlockX() == affectedblock.getX() && entity.getLocation().getBlockZ() == affectedblock.getZ()) {
 								if (!(entity instanceof FallingBlock)) {
-									GeneralMethods.setEntityVelocity((Ability)this,entity, norm.clone().multiply(.75));
+									GeneralMethods.setVelocity((Ability)this,entity, norm.clone().multiply(.75));
 								}
 							}
 						}

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -280,7 +280,7 @@ public class AirBlast extends AirAbility {
 		if (Math.abs(entity.getVelocity().dot(push)) > knockback && entity.getVelocity().angle(push) > Math.PI / 3) {
 			push.normalize().add(entity.getVelocity()).multiply(knockback);
 		}
-		GeneralMethods.setVelocity(this,entity, push);
+		GeneralMethods.setVelocity(this, entity, push);
 		
 		if (this.source != null) {
 			new HorizontalVelocityTracker(entity, this.player, 200l, this.source);

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -281,7 +281,7 @@ public class AirBlast extends AirAbility {
 		if (Math.abs(entity.getVelocity().dot(push)) > knockback && entity.getVelocity().angle(push) > Math.PI / 3) {
 			push.normalize().add(entity.getVelocity()).multiply(knockback);
 		}
-		GeneralMethods.setVelocity((Ability)this,entity, push);
+		GeneralMethods.setVelocity(this,entity, push);
 		
 		if (this.source != null) {
 			new HorizontalVelocityTracker(entity, this.player, 200l, this.source);

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -26,7 +26,6 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -281,7 +281,7 @@ public class AirBlast extends AirAbility {
 		if (Math.abs(entity.getVelocity().dot(push)) > knockback && entity.getVelocity().angle(push) > Math.PI / 3) {
 			push.normalize().add(entity.getVelocity()).multiply(knockback);
 		}
-		GeneralMethods.setEntityVelocity((Ability)this,entity, push,true);
+		GeneralMethods.setVelocity((Ability)this,entity, push);
 		
 		if (this.source != null) {
 			new HorizontalVelocityTracker(entity, this.player, 200l, this.source);

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -26,6 +26,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -280,8 +281,7 @@ public class AirBlast extends AirAbility {
 		if (Math.abs(entity.getVelocity().dot(push)) > knockback && entity.getVelocity().angle(push) > Math.PI / 3) {
 			push.normalize().add(entity.getVelocity()).multiply(knockback);
 		}
-		
-		GeneralMethods.setVelocity(entity, push);
+		GeneralMethods.setEntityVelocity((Ability)this,entity, push,true);
 		
 		if (this.source != null) {
 			new HorizontalVelocityTracker(entity, this.player, 200l, this.source);

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -201,9 +201,9 @@ public class AirScooter extends AirAbility {
 		this.player.setSprinting(false);
 		this.player.removePotionEffect(PotionEffectType.SPEED);
 		if (this.useslime) {
-			GeneralMethods.setVelocity(this,this.slime, velocity);
+			GeneralMethods.setVelocity(this, this.slime, velocity);
 		} else {
-			GeneralMethods.setVelocity(this,this.player, velocity);
+			GeneralMethods.setVelocity(this, this.player, velocity);
 		}
 
 		if (this.random.nextInt(4) == 0) {

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -15,6 +15,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -201,9 +202,9 @@ public class AirScooter extends AirAbility {
 		this.player.setSprinting(false);
 		this.player.removePotionEffect(PotionEffectType.SPEED);
 		if (this.useslime) {
-			this.slime.setVelocity(velocity);
+			GeneralMethods.setEntityVelocity((Ability)this,this.slime, velocity);
 		} else {
-			this.player.setVelocity(velocity);
+			GeneralMethods.setEntityVelocity((Ability)this,this.player, velocity);
 		}
 
 		if (this.random.nextInt(4) == 0) {

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -15,7 +15,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -202,9 +202,9 @@ public class AirScooter extends AirAbility {
 		this.player.setSprinting(false);
 		this.player.removePotionEffect(PotionEffectType.SPEED);
 		if (this.useslime) {
-			GeneralMethods.setVelocity((Ability)this,this.slime, velocity);
+			GeneralMethods.setVelocity(this,this.slime, velocity);
 		} else {
-			GeneralMethods.setVelocity((Ability)this,this.player, velocity);
+			GeneralMethods.setVelocity(this,this.player, velocity);
 		}
 
 		if (this.random.nextInt(4) == 0) {

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -202,9 +202,9 @@ public class AirScooter extends AirAbility {
 		this.player.setSprinting(false);
 		this.player.removePotionEffect(PotionEffectType.SPEED);
 		if (this.useslime) {
-			GeneralMethods.setEntityVelocity((Ability)this,this.slime, velocity);
+			GeneralMethods.setVelocity((Ability)this,this.slime, velocity);
 		} else {
-			GeneralMethods.setEntityVelocity((Ability)this,this.player, velocity);
+			GeneralMethods.setVelocity((Ability)this,this.player, velocity);
 		}
 
 		if (this.random.nextInt(4) == 0) {

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -163,7 +163,7 @@ public class AirShield extends AirAbility {
 				}
 
 				velocity.multiply(0.5);
-				GeneralMethods.setVelocity((Ability)this,entity, velocity);
+				GeneralMethods.setVelocity(this,entity, velocity);
 				entity.setFallDistance(0);
 			}
 		}

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -162,7 +163,7 @@ public class AirShield extends AirAbility {
 				}
 
 				velocity.multiply(0.5);
-				GeneralMethods.setVelocity(entity, velocity);
+				GeneralMethods.setEntityVelocity((Ability)this,entity, velocity,true);
 				entity.setFallDistance(0);
 			}
 		}

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -163,7 +162,7 @@ public class AirShield extends AirAbility {
 				}
 
 				velocity.multiply(0.5);
-				GeneralMethods.setVelocity(this,entity, velocity);
+				GeneralMethods.setVelocity(this, entity, velocity);
 				entity.setFallDistance(0);
 			}
 		}

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -163,7 +163,7 @@ public class AirShield extends AirAbility {
 				}
 
 				velocity.multiply(0.5);
-				GeneralMethods.setEntityVelocity((Ability)this,entity, velocity,true);
+				GeneralMethods.setVelocity((Ability)this,entity, velocity);
 				entity.setFallDistance(0);
 			}
 		}

--- a/src/com/projectkorra/projectkorra/airbending/AirSuction.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSuction.java
@@ -232,7 +232,7 @@ public class AirSuction extends AirAbility {
 				if (Math.abs(entity.getVelocity().dot(push)) > knockback) {
 					push.normalize().add(entity.getVelocity()).multiply(knockback);
 				}
-				GeneralMethods.setVelocity((Ability)this,entity, push.normalize().multiply(knockback));
+				GeneralMethods.setVelocity(this,entity, push.normalize().multiply(knockback));
 				
 				new HorizontalVelocityTracker(entity, this.player, 200l, this);
 				entity.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/airbending/AirSuction.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSuction.java
@@ -232,7 +232,7 @@ public class AirSuction extends AirAbility {
 				if (Math.abs(entity.getVelocity().dot(push)) > knockback) {
 					push.normalize().add(entity.getVelocity()).multiply(knockback);
 				}
-				GeneralMethods.setEntityVelocity((Ability)this,entity, push.normalize().multiply(knockback),true);
+				GeneralMethods.setVelocity((Ability)this,entity, push.normalize().multiply(knockback));
 				
 				new HorizontalVelocityTracker(entity, this.player, 200l, this);
 				entity.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/airbending/AirSuction.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSuction.java
@@ -18,7 +18,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -232,7 +231,7 @@ public class AirSuction extends AirAbility {
 				if (Math.abs(entity.getVelocity().dot(push)) > knockback) {
 					push.normalize().add(entity.getVelocity()).multiply(knockback);
 				}
-				GeneralMethods.setVelocity(this,entity, push.normalize().multiply(knockback));
+				GeneralMethods.setVelocity(this, entity, push.normalize().multiply(knockback));
 				
 				new HorizontalVelocityTracker(entity, this.player, 200l, this);
 				entity.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/airbending/AirSuction.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSuction.java
@@ -18,6 +18,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -231,8 +232,8 @@ public class AirSuction extends AirAbility {
 				if (Math.abs(entity.getVelocity().dot(push)) > knockback) {
 					push.normalize().add(entity.getVelocity()).multiply(knockback);
 				}
-
-				GeneralMethods.setVelocity(entity, push.normalize().multiply(knockback));
+				GeneralMethods.setEntityVelocity((Ability)this,entity, push.normalize().multiply(knockback),true);
+				
 				new HorizontalVelocityTracker(entity, this.player, 200l, this);
 				entity.setFallDistance(0);
 

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -244,7 +244,7 @@ public class AirSwipe extends AirAbility {
 						}
 						if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
 							
-							GeneralMethods.setVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor));
+							GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 
 						}
 						if (!AirSwipe.this.affectedEntities.contains(entity)) {
@@ -256,7 +256,7 @@ public class AirSwipe extends AirAbility {
 						breakBreathbendingHold(entity);
 					} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
 
-						GeneralMethods.setVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor));
+						GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 
 					}
 				}

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -243,8 +243,7 @@ public class AirSwipe extends AirAbility {
 							}
 						}
 						if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
-							GeneralMethods.setVelocity(this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
-
+							GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 						}
 						if (!AirSwipe.this.affectedEntities.contains(entity)) {
 							if (AirSwipe.this.damage != 0) {
@@ -254,7 +253,7 @@ public class AirSwipe extends AirAbility {
 						}
 						breakBreathbendingHold(entity);
 					} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
-						GeneralMethods.setVelocity(this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
+						GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 					}
 				}
 			}.runTaskLater(ProjectKorra.plugin, i / MAX_AFFECTABLE_ENTITIES);

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -244,7 +244,7 @@ public class AirSwipe extends AirAbility {
 						}
 						if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
 							
-							GeneralMethods.setEntityVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor),true);
+							GeneralMethods.setVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor));
 
 						}
 						if (!AirSwipe.this.affectedEntities.contains(entity)) {
@@ -256,7 +256,7 @@ public class AirSwipe extends AirAbility {
 						breakBreathbendingHold(entity);
 					} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
 
-						GeneralMethods.setEntityVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor),true);
+						GeneralMethods.setVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor));
 
 					}
 				}

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -243,7 +243,6 @@ public class AirSwipe extends AirAbility {
 							}
 						}
 						if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
-							
 							GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 
 						}
@@ -255,9 +254,7 @@ public class AirSwipe extends AirAbility {
 						}
 						breakBreathbendingHold(entity);
 					} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
-
 						GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
-
 					}
 				}
 			}.runTaskLater(ProjectKorra.plugin, i / MAX_AFFECTABLE_ENTITIES);

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -243,7 +243,7 @@ public class AirSwipe extends AirAbility {
 							}
 						}
 						if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
-							GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
+							GeneralMethods.setVelocity(this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 
 						}
 						if (!AirSwipe.this.affectedEntities.contains(entity)) {
@@ -254,7 +254,7 @@ public class AirSwipe extends AirAbility {
 						}
 						breakBreathbendingHold(entity);
 					} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
-						GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
+						GeneralMethods.setVelocity(this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 					}
 				}
 			}.runTaskLater(ProjectKorra.plugin, i / MAX_AFFECTABLE_ENTITIES);

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -243,8 +243,8 @@ public class AirSwipe extends AirAbility {
 							}
 						}
 						if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
-
-							GeneralMethods.setVelocity(entity, fDirection.multiply(AirSwipe.this.pushFactor));
+							
+							GeneralMethods.setEntityVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor),true);
 
 						}
 						if (!AirSwipe.this.affectedEntities.contains(entity)) {
@@ -256,7 +256,7 @@ public class AirSwipe extends AirAbility {
 						breakBreathbendingHold(entity);
 					} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
 
-						GeneralMethods.setVelocity(entity, fDirection.multiply(AirSwipe.this.pushFactor));
+						GeneralMethods.setEntityVelocity(AirSwipe.this,entity, fDirection.multiply(AirSwipe.this.pushFactor),true);
 
 					}
 				}

--- a/src/com/projectkorra/projectkorra/airbending/Tornado.java
+++ b/src/com/projectkorra/projectkorra/airbending/Tornado.java
@@ -169,7 +169,7 @@ public class Tornado extends AirAbility {
 						velocity.setZ(vz);
 						velocity.setY(vy);
 						velocity.multiply(timefactor);
-						GeneralMethods.setVelocity(this,entity, velocity);
+						GeneralMethods.setVelocity(this, entity, velocity);
 						entity.setFallDistance(0);
 
 						breakBreathbendingHold(entity);

--- a/src/com/projectkorra/projectkorra/airbending/Tornado.java
+++ b/src/com/projectkorra/projectkorra/airbending/Tornado.java
@@ -169,7 +169,7 @@ public class Tornado extends AirAbility {
 						velocity.setZ(vz);
 						velocity.setY(vy);
 						velocity.multiply(timefactor);
-						GeneralMethods.setVelocity(entity, velocity);
+						GeneralMethods.setEntityVelocity(this,entity, velocity,true);
 						entity.setFallDistance(0);
 
 						breakBreathbendingHold(entity);

--- a/src/com/projectkorra/projectkorra/airbending/Tornado.java
+++ b/src/com/projectkorra/projectkorra/airbending/Tornado.java
@@ -169,7 +169,7 @@ public class Tornado extends AirAbility {
 						velocity.setZ(vz);
 						velocity.setY(vy);
 						velocity.multiply(timefactor);
-						GeneralMethods.setEntityVelocity(this,entity, velocity,true);
+						GeneralMethods.setVelocity(this,entity, velocity);
 						entity.setFallDistance(0);
 
 						breakBreathbendingHold(entity);

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
@@ -10,7 +10,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
@@ -166,7 +165,7 @@ public class AirStream extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector force = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc);
-			GeneralMethods.setVelocity(this,entity, force.clone().normalize().multiply(this.speed));
+			GeneralMethods.setVelocity(this, entity, force.clone().normalize().multiply(this.speed));
 			entity.setFallDistance(0F);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
@@ -10,6 +10,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
@@ -165,7 +166,7 @@ public class AirStream extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector force = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc);
-			entity.setVelocity(force.clone().normalize().multiply(this.speed));
+			GeneralMethods.setEntityVelocity((Ability)this,entity, force.clone().normalize().multiply(this.speed));
 			entity.setFallDistance(0F);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
@@ -166,7 +166,7 @@ public class AirStream extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector force = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc);
-			GeneralMethods.setVelocity((Ability)this,entity, force.clone().normalize().multiply(this.speed));
+			GeneralMethods.setVelocity(this,entity, force.clone().normalize().multiply(this.speed));
 			entity.setFallDistance(0F);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
@@ -166,7 +166,7 @@ public class AirStream extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector force = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc);
-			GeneralMethods.setEntityVelocity((Ability)this,entity, force.clone().normalize().multiply(this.speed));
+			GeneralMethods.setVelocity((Ability)this,entity, force.clone().normalize().multiply(this.speed));
 			entity.setFallDistance(0F);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -13,6 +13,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -198,7 +199,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 					if (!entity.equals(this.player) && !(entity instanceof Player && Commands.invincible.contains(((Player) entity).getName()))) {
 						if (this.knockback != 0) {
 							final Vector force = fstream.getLocation().getDirection();
-							GeneralMethods.setVelocity(entity, force.clone().multiply(this.knockback));
+							GeneralMethods.setEntityVelocity((Ability)this,entity, force.clone().multiply(this.knockback),true);
 							new HorizontalVelocityTracker(entity, this.player, 200l, this);
 							entity.setFallDistance(0);
 						}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -199,7 +199,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 					if (!entity.equals(this.player) && !(entity instanceof Player && Commands.invincible.contains(((Player) entity).getName()))) {
 						if (this.knockback != 0) {
 							final Vector force = fstream.getLocation().getDirection();
-							GeneralMethods.setEntityVelocity((Ability)this,entity, force.clone().multiply(this.knockback),true);
+							GeneralMethods.setVelocity((Ability)this,entity, force.clone().multiply(this.knockback));
 							new HorizontalVelocityTracker(entity, this.player, 200l, this);
 							entity.setFallDistance(0);
 						}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -199,7 +199,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 					if (!entity.equals(this.player) && !(entity instanceof Player && Commands.invincible.contains(((Player) entity).getName()))) {
 						if (this.knockback != 0) {
 							final Vector force = fstream.getLocation().getDirection();
-							GeneralMethods.setVelocity((Ability)this,entity, force.clone().multiply(this.knockback));
+							GeneralMethods.setVelocity(this,entity, force.clone().multiply(this.knockback));
 							new HorizontalVelocityTracker(entity, this.player, 200l, this);
 							entity.setFallDistance(0);
 						}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -13,7 +13,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -199,7 +198,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 					if (!entity.equals(this.player) && !(entity instanceof Player && Commands.invincible.contains(((Player) entity).getName()))) {
 						if (this.knockback != 0) {
 							final Vector force = fstream.getLocation().getDirection();
-							GeneralMethods.setVelocity(this,entity, force.clone().multiply(this.knockback));
+							GeneralMethods.setVelocity(this, entity, force.clone().multiply(this.knockback));
 							new HorizontalVelocityTracker(entity, this.player, 200l, this);
 							entity.setFallDistance(0);
 						}

--- a/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
@@ -147,7 +147,7 @@ public class Twister extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector forceDir = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc.clone().add(0, height, 0));
-			GeneralMethods.setEntityVelocity((Ability)this,entity, forceDir.clone().normalize().multiply(0.3));
+			GeneralMethods.setVelocity((Ability)this,entity, forceDir.clone().normalize().multiply(0.3));
 			
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
@@ -9,7 +9,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
@@ -147,7 +146,7 @@ public class Twister extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector forceDir = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc.clone().add(0, height, 0));
-			GeneralMethods.setVelocity(this,entity, forceDir.clone().normalize().multiply(0.3));
+			GeneralMethods.setVelocity(this, entity, forceDir.clone().normalize().multiply(0.3));
 			
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
@@ -146,7 +147,8 @@ public class Twister extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector forceDir = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc.clone().add(0, height, 0));
-			entity.setVelocity(forceDir.clone().normalize().multiply(0.3));
+			GeneralMethods.setEntityVelocity((Ability)this,entity, forceDir.clone().normalize().multiply(0.3));
+			
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
@@ -147,7 +147,7 @@ public class Twister extends AirAbility implements ComboAbility {
 				continue;
 			}
 			final Vector forceDir = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc.clone().add(0, height, 0));
-			GeneralMethods.setVelocity((Ability)this,entity, forceDir.clone().normalize().multiply(0.3));
+			GeneralMethods.setVelocity(this,entity, forceDir.clone().normalize().multiply(0.3));
 			
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
@@ -147,7 +147,6 @@ public class Twister extends AirAbility implements ComboAbility {
 			}
 			final Vector forceDir = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc.clone().add(0, height, 0));
 			GeneralMethods.setVelocity(this, entity, forceDir.clone().normalize().multiply(0.3));
-			
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -235,7 +235,6 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 
 			this.particles();
 			GeneralMethods.setVelocity(this, this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
-			
 		} else if (this.mode == FlightMode.GLIDE) {
 			this.player.setAllowFlight(false);
 			this.player.setFlying(false);

--- a/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -19,7 +19,6 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.FlightAbility;
 import com.projectkorra.projectkorra.ability.MultiAbility;
@@ -228,14 +227,14 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 						if (!GeneralMethods.isRegionProtectedFromBuild(this.player, e.getLocation())) {
 							final LivingEntity le = (LivingEntity) e;
 							DamageHandler.damageEntity(le, this.speed / 2, this);
-							GeneralMethods.setVelocity(this,le, this.player.getVelocity().clone().multiply(2 / 3));
+							GeneralMethods.setVelocity(this, le, this.player.getVelocity().clone().multiply(2 / 3));
 						}
 					}
 				}
 			}
 
 			this.particles();
-			GeneralMethods.setVelocity(this,this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
+			GeneralMethods.setVelocity(this, this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
 			
 		} else if (this.mode == FlightMode.GLIDE) {
 			this.player.setAllowFlight(false);

--- a/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -228,14 +228,14 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 						if (!GeneralMethods.isRegionProtectedFromBuild(this.player, e.getLocation())) {
 							final LivingEntity le = (LivingEntity) e;
 							DamageHandler.damageEntity(le, this.speed / 2, this);
-							GeneralMethods.setEntityVelocity((Ability)this,le, this.player.getVelocity().clone().multiply(2 / 3));
+							GeneralMethods.setVelocity((Ability)this,le, this.player.getVelocity().clone().multiply(2 / 3));
 						}
 					}
 				}
 			}
 
 			this.particles();
-			GeneralMethods.setEntityVelocity((Ability)this,this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
+			GeneralMethods.setVelocity((Ability)this,this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
 			
 		} else if (this.mode == FlightMode.GLIDE) {
 			this.player.setAllowFlight(false);

--- a/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -228,14 +228,14 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 						if (!GeneralMethods.isRegionProtectedFromBuild(this.player, e.getLocation())) {
 							final LivingEntity le = (LivingEntity) e;
 							DamageHandler.damageEntity(le, this.speed / 2, this);
-							GeneralMethods.setVelocity((Ability)this,le, this.player.getVelocity().clone().multiply(2 / 3));
+							GeneralMethods.setVelocity(this,le, this.player.getVelocity().clone().multiply(2 / 3));
 						}
 					}
 				}
 			}
 
 			this.particles();
-			GeneralMethods.setVelocity((Ability)this,this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
+			GeneralMethods.setVelocity(this,this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
 			
 		} else if (this.mode == FlightMode.GLIDE) {
 			this.player.setAllowFlight(false);

--- a/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -19,6 +19,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.FlightAbility;
 import com.projectkorra.projectkorra.ability.MultiAbility;
@@ -227,14 +228,15 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 						if (!GeneralMethods.isRegionProtectedFromBuild(this.player, e.getLocation())) {
 							final LivingEntity le = (LivingEntity) e;
 							DamageHandler.damageEntity(le, this.speed / 2, this);
-							le.setVelocity(this.player.getVelocity().clone().multiply(2 / 3));
+							GeneralMethods.setEntityVelocity((Ability)this,le, this.player.getVelocity().clone().multiply(2 / 3));
 						}
 					}
 				}
 			}
 
 			this.particles();
-			this.player.setVelocity(this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
+			GeneralMethods.setEntityVelocity((Ability)this,this.player, this.player.getEyeLocation().getDirection().clone().multiply(this.multiplier));
+			
 		} else if (this.mode == FlightMode.GLIDE) {
 			this.player.setAllowFlight(false);
 			this.player.setFlying(false);

--- a/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
@@ -7,7 +7,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ChiAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.waterbending.multiabilities.WaterArmsWhip;
@@ -36,7 +35,7 @@ public class HighJump extends ChiAbility {
 		}
 		final Vector vec = p.getVelocity();
 		vec.setY(this.height);
-		GeneralMethods.setVelocity(this,p, vec);
+		GeneralMethods.setVelocity(this, p, vec);
 		this.bPlayer.addCooldown(this);
 		return;
 	}

--- a/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
@@ -36,7 +36,7 @@ public class HighJump extends ChiAbility {
 		}
 		final Vector vec = p.getVelocity();
 		vec.setY(this.height);
-		GeneralMethods.setEntityVelocity((Ability)this,p, vec);
+		GeneralMethods.setVelocity((Ability)this,p, vec);
 		this.bPlayer.addCooldown(this);
 		return;
 	}

--- a/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
@@ -36,7 +36,7 @@ public class HighJump extends ChiAbility {
 		}
 		final Vector vec = p.getVelocity();
 		vec.setY(this.height);
-		GeneralMethods.setVelocity((Ability)this,p, vec);
+		GeneralMethods.setVelocity(this,p, vec);
 		this.bPlayer.addCooldown(this);
 		return;
 	}

--- a/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/HighJump.java
@@ -7,6 +7,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ChiAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.waterbending.multiabilities.WaterArmsWhip;
@@ -35,7 +36,7 @@ public class HighJump extends ChiAbility {
 		}
 		final Vector vec = p.getVelocity();
 		vec.setY(this.height);
-		p.setVelocity(vec);
+		GeneralMethods.setEntityVelocity((Ability)this,p, vec);
 		this.bPlayer.addCooldown(this);
 		return;
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/Catapult.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Catapult.java
@@ -74,7 +74,7 @@ public class Catapult extends EarthAbility {
 				if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) || ((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 					continue;
 				}
-				GeneralMethods.setEntityVelocity((Ability)this,	entity, apply);
+				GeneralMethods.setVelocity((Ability)this,	entity, apply);
 			}
 		}
 		this.moveEarth(this.origin.clone().subtract(direction), direction, 3, false);
@@ -136,7 +136,7 @@ public class Catapult extends EarthAbility {
 		final Location tar = this.origin.clone().add(direction.clone().normalize().multiply(this.stage + 0.5));
 		this.target = tar;
 		final Vector apply = this.target.clone().toVector().subtract(this.origin.clone().toVector());
-		GeneralMethods.setEntityVelocity((Ability)this, this.player, apply);
+		GeneralMethods.setVelocity((Ability)this, this.player, apply);
 		this.moveEarth(apply, direction);
 		this.remove();
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/Catapult.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Catapult.java
@@ -13,6 +13,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.util.ParticleEffect;
@@ -73,7 +74,7 @@ public class Catapult extends EarthAbility {
 				if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) || ((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 					continue;
 				}
-				entity.setVelocity(apply);
+				GeneralMethods.setEntityVelocity((Ability)this,	entity, apply);
 			}
 		}
 		this.moveEarth(this.origin.clone().subtract(direction), direction, 3, false);
@@ -135,7 +136,7 @@ public class Catapult extends EarthAbility {
 		final Location tar = this.origin.clone().add(direction.clone().normalize().multiply(this.stage + 0.5));
 		this.target = tar;
 		final Vector apply = this.target.clone().toVector().subtract(this.origin.clone().toVector());
-		this.player.setVelocity(apply);
+		GeneralMethods.setEntityVelocity((Ability)this, this.player, apply);
 		this.moveEarth(apply, direction);
 		this.remove();
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/Catapult.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Catapult.java
@@ -13,7 +13,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.util.ParticleEffect;

--- a/src/com/projectkorra/projectkorra/earthbending/Catapult.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Catapult.java
@@ -74,7 +74,7 @@ public class Catapult extends EarthAbility {
 				if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) || ((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 					continue;
 				}
-				GeneralMethods.setVelocity((Ability)this,	entity, apply);
+				GeneralMethods.setVelocity(this, entity, apply);
 			}
 		}
 		this.moveEarth(this.origin.clone().subtract(direction), direction, 3, false);
@@ -136,7 +136,7 @@ public class Catapult extends EarthAbility {
 		final Location tar = this.origin.clone().add(direction.clone().normalize().multiply(this.stage + 0.5));
 		this.target = tar;
 		final Vector apply = this.target.clone().toVector().subtract(this.origin.clone().toVector());
-		GeneralMethods.setVelocity((Ability)this, this.player, apply);
+		GeneralMethods.setVelocity(this, this.player, apply);
 		this.moveEarth(apply, direction);
 		this.remove();
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
@@ -277,7 +277,7 @@ public class EarthBlast extends EarthAbility {
 
 						final Location location = this.player.getEyeLocation();
 						final Vector vector = location.getDirection();
-						GeneralMethods.setVelocity((Ability)this,	entity, vector.normalize().multiply(this.pushFactor));
+						GeneralMethods.setVelocity(this, entity, vector.normalize().multiply(this.pushFactor));
 						double damage = this.damage;
 
 						if (isMetal(this.sourceBlock) && this.bPlayer.canMetalbend()) {

--- a/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
@@ -277,7 +277,7 @@ public class EarthBlast extends EarthAbility {
 
 						final Location location = this.player.getEyeLocation();
 						final Vector vector = location.getDirection();
-						GeneralMethods.setEntityVelocity((Ability)this,	entity, vector.normalize().multiply(this.pushFactor));
+						GeneralMethods.setVelocity((Ability)this,	entity, vector.normalize().multiply(this.pushFactor));
 						double damage = this.damage;
 
 						if (isMetal(this.sourceBlock) && this.bPlayer.canMetalbend()) {

--- a/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
@@ -13,6 +13,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -276,7 +277,7 @@ public class EarthBlast extends EarthAbility {
 
 						final Location location = this.player.getEyeLocation();
 						final Vector vector = location.getDirection();
-						entity.setVelocity(vector.normalize().multiply(this.pushFactor));
+						GeneralMethods.setEntityVelocity((Ability)this,	entity, vector.normalize().multiply(this.pushFactor));
 						double damage = this.damage;
 
 						if (isMetal(this.sourceBlock) && this.bPlayer.canMetalbend()) {

--- a/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
@@ -13,7 +13,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;

--- a/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
@@ -27,6 +27,7 @@ import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
@@ -320,7 +321,7 @@ public class EarthGrab extends EarthAbility {
 				continue;
 			}
 			final Block b = entity.getLocation().getBlock().getRelative(BlockFace.DOWN);
-			entity.setVelocity(GeneralMethods.getDirection(entity.getLocation(), this.player.getLocation()).normalize().multiply(this.dragSpeed));
+			GeneralMethods.setEntityVelocity((Ability)this,	entity, GeneralMethods.getDirection(entity.getLocation(), this.player.getLocation()).normalize().multiply(this.dragSpeed));
 			ParticleEffect.BLOCK_CRACK.display(entity.getLocation(), 2, 0, 0, 0, b.getBlockData());
 			playEarthbendingSound(entity.getLocation());
 		}

--- a/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
@@ -321,7 +321,7 @@ public class EarthGrab extends EarthAbility {
 				continue;
 			}
 			final Block b = entity.getLocation().getBlock().getRelative(BlockFace.DOWN);
-			GeneralMethods.setEntityVelocity((Ability)this,	entity, GeneralMethods.getDirection(entity.getLocation(), this.player.getLocation()).normalize().multiply(this.dragSpeed));
+			GeneralMethods.setVelocity((Ability)this,	entity, GeneralMethods.getDirection(entity.getLocation(), this.player.getLocation()).normalize().multiply(this.dragSpeed));
 			ParticleEffect.BLOCK_CRACK.display(entity.getLocation(), 2, 0, 0, 0, b.getBlockData());
 			playEarthbendingSound(entity.getLocation());
 		}

--- a/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
@@ -27,7 +27,6 @@ import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;

--- a/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthGrab.java
@@ -321,7 +321,7 @@ public class EarthGrab extends EarthAbility {
 				continue;
 			}
 			final Block b = entity.getLocation().getBlock().getRelative(BlockFace.DOWN);
-			GeneralMethods.setVelocity((Ability)this,	entity, GeneralMethods.getDirection(entity.getLocation(), this.player.getLocation()).normalize().multiply(this.dragSpeed));
+			GeneralMethods.setVelocity(this, entity, GeneralMethods.getDirection(entity.getLocation(), this.player.getLocation()).normalize().multiply(this.dragSpeed));
 			ParticleEffect.BLOCK_CRACK.display(entity.getLocation(), 2, 0, 0, 0, b.getBlockData());
 			playEarthbendingSound(entity.getLocation());
 		}

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -16,7 +16,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -294,7 +294,7 @@ public class EarthSmash extends EarthAbility {
 					if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) || ((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 						continue;
 					}
-					GeneralMethods.setVelocity((Ability)this,	entity, direction.clone().multiply(this.flightSpeed));
+					GeneralMethods.setVelocity(this, entity, direction.clone().multiply(this.flightSpeed));
 				}
 
 				// These values tend to work well when dealing with a person aiming upward or downward.
@@ -399,7 +399,7 @@ public class EarthSmash extends EarthAbility {
 			final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, 2.5);
 			for (final Entity entity : entities) {
 				final org.bukkit.util.Vector velocity = entity.getVelocity();
-				GeneralMethods.setVelocity((Ability)this, entity, velocity.add(new Vector(0, 0.36, 0)));
+				GeneralMethods.setVelocity(this, entity, velocity.add(new Vector(0, 0.36, 0)));
 			}
 			this.location.getWorld().playEffect(this.location, Effect.GHAST_SHOOT, 0, 7);
 			this.draw();
@@ -574,7 +574,7 @@ public class EarthSmash extends EarthAbility {
 				final double damage = this.currentBlocks.size() / 13.0 * this.damage;
 				DamageHandler.damageEntity(entity, damage, this);
 				final Vector travelVec = GeneralMethods.getDirection(this.location, entity.getLocation());
-				GeneralMethods.setVelocity((Ability)this,	entity, travelVec.setY(this.knockup).normalize().multiply(this.knockback));
+				GeneralMethods.setVelocity(this, entity, travelVec.setY(this.knockup).normalize().multiply(this.knockback));
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -294,7 +294,7 @@ public class EarthSmash extends EarthAbility {
 					if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) || ((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 						continue;
 					}
-					GeneralMethods.setEntityVelocity((Ability)this,	entity, direction.clone().multiply(this.flightSpeed));
+					GeneralMethods.setVelocity((Ability)this,	entity, direction.clone().multiply(this.flightSpeed));
 				}
 
 				// These values tend to work well when dealing with a person aiming upward or downward.
@@ -399,7 +399,7 @@ public class EarthSmash extends EarthAbility {
 			final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, 2.5);
 			for (final Entity entity : entities) {
 				final org.bukkit.util.Vector velocity = entity.getVelocity();
-				GeneralMethods.setEntityVelocity((Ability)this, entity, velocity.add(new Vector(0, 0.36, 0)));
+				GeneralMethods.setVelocity((Ability)this, entity, velocity.add(new Vector(0, 0.36, 0)));
 			}
 			this.location.getWorld().playEffect(this.location, Effect.GHAST_SHOOT, 0, 7);
 			this.draw();
@@ -574,7 +574,7 @@ public class EarthSmash extends EarthAbility {
 				final double damage = this.currentBlocks.size() / 13.0 * this.damage;
 				DamageHandler.damageEntity(entity, damage, this);
 				final Vector travelVec = GeneralMethods.getDirection(this.location, entity.getLocation());
-				GeneralMethods.setEntityVelocity((Ability)this,	entity, travelVec.setY(this.knockup).normalize().multiply(this.knockback));
+				GeneralMethods.setVelocity((Ability)this,	entity, travelVec.setY(this.knockup).normalize().multiply(this.knockback));
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -16,6 +16,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -293,7 +294,7 @@ public class EarthSmash extends EarthAbility {
 					if (GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) || ((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 						continue;
 					}
-					entity.setVelocity(direction.clone().multiply(this.flightSpeed));
+					GeneralMethods.setEntityVelocity((Ability)this,	entity, direction.clone().multiply(this.flightSpeed));
 				}
 
 				// These values tend to work well when dealing with a person aiming upward or downward.
@@ -398,7 +399,7 @@ public class EarthSmash extends EarthAbility {
 			final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, 2.5);
 			for (final Entity entity : entities) {
 				final org.bukkit.util.Vector velocity = entity.getVelocity();
-				entity.setVelocity(velocity.add(new Vector(0, 0.36, 0)));
+				GeneralMethods.setEntityVelocity((Ability)this, entity, velocity.add(new Vector(0, 0.36, 0)));
 			}
 			this.location.getWorld().playEffect(this.location, Effect.GHAST_SHOOT, 0, 7);
 			this.draw();
@@ -573,7 +574,7 @@ public class EarthSmash extends EarthAbility {
 				final double damage = this.currentBlocks.size() / 13.0 * this.damage;
 				DamageHandler.damageEntity(entity, damage, this);
 				final Vector travelVec = GeneralMethods.getDirection(this.location, entity.getLocation());
-				entity.setVelocity(travelVec.setY(this.knockup).normalize().multiply(this.knockback));
+				GeneralMethods.setEntityVelocity((Ability)this,	entity, travelVec.setY(this.knockup).normalize().multiply(this.knockback));
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/earthbending/Ripple.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Ripple.java
@@ -286,7 +286,7 @@ public class Ripple extends EarthAbility {
 		final Vector vector = this.direction.clone();
 		vector.setY(.5);
 		final double knock = this.bPlayer.isAvatarState() ? AvatarState.getValue(this.knockback) : this.knockback;
-		GeneralMethods.setEntityVelocity((Ability)this, entity, vector.clone().normalize().multiply(knock));
+		GeneralMethods.setVelocity((Ability)this, entity, vector.clone().normalize().multiply(knock));
 		AirAbility.breakBreathbendingHold(entity);
 	}
 

--- a/src/com/projectkorra/projectkorra/earthbending/Ripple.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Ripple.java
@@ -14,7 +14,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;

--- a/src/com/projectkorra/projectkorra/earthbending/Ripple.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Ripple.java
@@ -286,7 +286,7 @@ public class Ripple extends EarthAbility {
 		final Vector vector = this.direction.clone();
 		vector.setY(.5);
 		final double knock = this.bPlayer.isAvatarState() ? AvatarState.getValue(this.knockback) : this.knockback;
-		GeneralMethods.setVelocity((Ability)this, entity, vector.clone().normalize().multiply(knock));
+		GeneralMethods.setVelocity(this, entity, vector.clone().normalize().multiply(knock));
 		AirAbility.breakBreathbendingHold(entity);
 	}
 

--- a/src/com/projectkorra/projectkorra/earthbending/Ripple.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Ripple.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -285,7 +286,7 @@ public class Ripple extends EarthAbility {
 		final Vector vector = this.direction.clone();
 		vector.setY(.5);
 		final double knock = this.bPlayer.isAvatarState() ? AvatarState.getValue(this.knockback) : this.knockback;
-		entity.setVelocity(vector.clone().normalize().multiply(knock));
+		GeneralMethods.setEntityVelocity((Ability)this, entity, vector.clone().normalize().multiply(knock));
 		AirAbility.breakBreathbendingHold(entity);
 	}
 

--- a/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
+++ b/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
@@ -100,8 +101,7 @@ public class EarthPillars extends EarthAbility implements ComboAbility {
 					if (lent instanceof Player && !((Player) lent).isOnline()) {
 						continue;
 					}
-
-					lent.setVelocity(new Vector(0, this.knockup, 0));
+					GeneralMethods.setEntityVelocity((Ability)this,lent, new Vector(0, this.knockup, 0));
 				}
 				if (this.damaging) {
 					DamageHandler.damageEntity(lent, this.damage, this);

--- a/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
+++ b/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ComboAbility;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
@@ -101,7 +100,7 @@ public class EarthPillars extends EarthAbility implements ComboAbility {
 					if (lent instanceof Player && !((Player) lent).isOnline()) {
 						continue;
 					}
-					GeneralMethods.setVelocity(this,lent, new Vector(0, this.knockup, 0));
+					GeneralMethods.setVelocity(this, lent, new Vector(0, this.knockup, 0));
 				}
 				if (this.damaging) {
 					DamageHandler.damageEntity(lent, this.damage, this);

--- a/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
+++ b/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
@@ -101,7 +101,7 @@ public class EarthPillars extends EarthAbility implements ComboAbility {
 					if (lent instanceof Player && !((Player) lent).isOnline()) {
 						continue;
 					}
-					GeneralMethods.setEntityVelocity((Ability)this,lent, new Vector(0, this.knockup, 0));
+					GeneralMethods.setVelocity((Ability)this,lent, new Vector(0, this.knockup, 0));
 				}
 				if (this.damaging) {
 					DamageHandler.damageEntity(lent, this.damage, this);

--- a/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
+++ b/src/com/projectkorra/projectkorra/earthbending/combo/EarthPillars.java
@@ -101,7 +101,7 @@ public class EarthPillars extends EarthAbility implements ComboAbility {
 					if (lent instanceof Player && !((Player) lent).isOnline()) {
 						continue;
 					}
-					GeneralMethods.setVelocity((Ability)this,lent, new Vector(0, this.knockup, 0));
+					GeneralMethods.setVelocity(this,lent, new Vector(0, this.knockup, 0));
 				}
 				if (this.damaging) {
 					DamageHandler.damageEntity(lent, this.damage, this);

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
@@ -19,6 +19,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.LavaAbility;
 import com.projectkorra.projectkorra.util.BlockSource;
@@ -236,7 +237,7 @@ public class LavaSurge extends LavaAbility {
 				x = (this.random.nextBoolean()) ? -x : x;
 				z = (this.random.nextBoolean()) ? -z : z;
 
-				fbs.setVelocity(this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
+				GeneralMethods.setEntityVelocity((Ability)this,fbs, this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
 				fbs.setDropItem(false);
 
 				for (final Block b : this.fracture) {
@@ -244,7 +245,7 @@ public class LavaSurge extends LavaAbility {
 						final FallingBlock fb = GeneralMethods.spawnFallingBlock(b.getLocation().add(new Vector(0, 1, 0)), Material.MAGMA_BLOCK, Material.MAGMA_BLOCK.createBlockData());
 						ALL_FALLING_BLOCKS.add(fb);
 						this.fallingBlocks.add(fb);
-						fb.setVelocity(this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
+						GeneralMethods.setEntityVelocity((Ability)this,fb, this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
 						fb.setDropItem(false);
 					}
 				}
@@ -258,7 +259,7 @@ public class LavaSurge extends LavaAbility {
 						if (e.getEntityId() != this.player.getEntityId()) {
 							DamageHandler.damageEntity(e, this.impactDamage, this);
 							e.setFireTicks(100);
-							GeneralMethods.setVelocity(e, this.direction.clone());
+							GeneralMethods.setEntityVelocity(this,e, this.direction.clone(),true);
 						}
 					}
 				}

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
@@ -237,7 +237,7 @@ public class LavaSurge extends LavaAbility {
 				x = (this.random.nextBoolean()) ? -x : x;
 				z = (this.random.nextBoolean()) ? -z : z;
 
-				GeneralMethods.setVelocity((Ability)this,fbs, this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
+				GeneralMethods.setVelocity(this,fbs, this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
 				fbs.setDropItem(false);
 
 				for (final Block b : this.fracture) {
@@ -245,7 +245,7 @@ public class LavaSurge extends LavaAbility {
 						final FallingBlock fb = GeneralMethods.spawnFallingBlock(b.getLocation().add(new Vector(0, 1, 0)), Material.MAGMA_BLOCK, Material.MAGMA_BLOCK.createBlockData());
 						ALL_FALLING_BLOCKS.add(fb);
 						this.fallingBlocks.add(fb);
-						GeneralMethods.setVelocity((Ability)this,fb, this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
+						GeneralMethods.setVelocity(this,fb, this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
 						fb.setDropItem(false);
 					}
 				}

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
@@ -237,7 +237,7 @@ public class LavaSurge extends LavaAbility {
 				x = (this.random.nextBoolean()) ? -x : x;
 				z = (this.random.nextBoolean()) ? -z : z;
 
-				GeneralMethods.setEntityVelocity((Ability)this,fbs, this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
+				GeneralMethods.setVelocity((Ability)this,fbs, this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
 				fbs.setDropItem(false);
 
 				for (final Block b : this.fracture) {
@@ -245,7 +245,7 @@ public class LavaSurge extends LavaAbility {
 						final FallingBlock fb = GeneralMethods.spawnFallingBlock(b.getLocation().add(new Vector(0, 1, 0)), Material.MAGMA_BLOCK, Material.MAGMA_BLOCK.createBlockData());
 						ALL_FALLING_BLOCKS.add(fb);
 						this.fallingBlocks.add(fb);
-						GeneralMethods.setEntityVelocity((Ability)this,fb, this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
+						GeneralMethods.setVelocity((Ability)this,fb, this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
 						fb.setDropItem(false);
 					}
 				}
@@ -259,7 +259,7 @@ public class LavaSurge extends LavaAbility {
 						if (e.getEntityId() != this.player.getEntityId()) {
 							DamageHandler.damageEntity(e, this.impactDamage, this);
 							e.setFireTicks(100);
-							GeneralMethods.setEntityVelocity(this,e, this.direction.clone(),true);
+							GeneralMethods.setVelocity(this,e, this.direction.clone());
 						}
 					}
 				}

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurge.java
@@ -19,7 +19,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.LavaAbility;
 import com.projectkorra.projectkorra.util.BlockSource;
@@ -237,7 +236,7 @@ public class LavaSurge extends LavaAbility {
 				x = (this.random.nextBoolean()) ? -x : x;
 				z = (this.random.nextBoolean()) ? -z : z;
 
-				GeneralMethods.setVelocity(this,fbs, this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
+				GeneralMethods.setVelocity(this, fbs, this.direction.clone().add(new Vector(x, 0.2, z)).multiply(1.2));
 				fbs.setDropItem(false);
 
 				for (final Block b : this.fracture) {
@@ -245,7 +244,7 @@ public class LavaSurge extends LavaAbility {
 						final FallingBlock fb = GeneralMethods.spawnFallingBlock(b.getLocation().add(new Vector(0, 1, 0)), Material.MAGMA_BLOCK, Material.MAGMA_BLOCK.createBlockData());
 						ALL_FALLING_BLOCKS.add(fb);
 						this.fallingBlocks.add(fb);
-						GeneralMethods.setVelocity(this,fb, this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
+						GeneralMethods.setVelocity(this, fb, this.direction.clone().add(new Vector(this.random.nextDouble() / 10, 0.1, this.random.nextDouble() / 10)).multiply(1.2));
 						fb.setDropItem(false);
 					}
 				}
@@ -259,7 +258,7 @@ public class LavaSurge extends LavaAbility {
 						if (e.getEntityId() != this.player.getEntityId()) {
 							DamageHandler.damageEntity(e, this.impactDamage, this);
 							e.setFireTicks(100);
-							GeneralMethods.setVelocity(this,e, this.direction.clone());
+							GeneralMethods.setVelocity(this, e, this.direction.clone());
 						}
 					}
 				}

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.LavaAbility;
 import com.projectkorra.projectkorra.avatar.AvatarState;
@@ -207,7 +208,7 @@ public class LavaSurgeWave extends LavaAbility {
 				if (knockback) {
 					final Vector dir = direction.clone();
 					dir.setY(dir.getY() * this.verticalPush);
-					entity.setVelocity(entity.getVelocity().clone().add(dir.clone().multiply(this.horizontalPush)));
+					GeneralMethods.setEntityVelocity((Ability)this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.horizontalPush)));
 					entity.setFallDistance(0);
 
 					if (entity.getFireTicks() > 0) {

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
@@ -208,7 +208,7 @@ public class LavaSurgeWave extends LavaAbility {
 				if (knockback) {
 					final Vector dir = direction.clone();
 					dir.setY(dir.getY() * this.verticalPush);
-					GeneralMethods.setEntityVelocity((Ability)this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.horizontalPush)));
+					GeneralMethods.setVelocity((Ability)this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.horizontalPush)));
 					entity.setFallDistance(0);
 
 					if (entity.getFireTicks() > 0) {

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
@@ -208,7 +208,7 @@ public class LavaSurgeWave extends LavaAbility {
 				if (knockback) {
 					final Vector dir = direction.clone();
 					dir.setY(dir.getY() * this.verticalPush);
-					GeneralMethods.setVelocity((Ability)this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.horizontalPush)));
+					GeneralMethods.setVelocity(this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.horizontalPush)));
 					entity.setFallDistance(0);
 
 					if (entity.getFireTicks() > 0) {

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaSurgeWave.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.LavaAbility;
 import com.projectkorra.projectkorra.avatar.AvatarState;

--- a/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -157,7 +157,7 @@ public class MetalClips extends MetalAbility {
 			vector = GeneralMethods.getDirection(this.player.getLocation(), GeneralMethods.getTargetedLocation(this.player, this.range));
 		}
 
-		GeneralMethods.setEntityVelocity((Ability)this, item, vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
+		GeneralMethods.setVelocity((Ability)this, item, vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
 		this.trackedIngots.add(item);
 		this.player.getInventory().removeItem(is);
 	}
@@ -229,7 +229,7 @@ public class MetalClips extends MetalAbility {
 		dz = target.getZ() - location.getZ();
 		final Vector vector = new Vector(dx, dy, dz);
 		vector.normalize();
-		GeneralMethods.setEntityVelocity((Ability)this,	this.targetEntity, vector.multiply(this.metalClipsCount / 2D));
+		GeneralMethods.setVelocity((Ability)this,	this.targetEntity, vector.multiply(this.metalClipsCount / 2D));
 		this.remove();
 	}
 
@@ -343,7 +343,7 @@ public class MetalClips extends MetalAbility {
 					final Item iron = (Item) entity;
 
 					if (Arrays.asList(METAL_ITEMS).contains(iron.getItemStack().getType())) {
-						GeneralMethods.setEntityVelocity((Ability)this,	iron, vector.normalize().multiply(this.magnetSpeed).add(new Vector(0, 0.2, 0)));
+						GeneralMethods.setVelocity((Ability)this,	iron, vector.normalize().multiply(this.magnetSpeed).add(new Vector(0, 0.2, 0)));
 					}
 				}
 			}
@@ -368,7 +368,7 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(this.targetEntity.getLocation(), this.player.getLocation());
 
 				if (distance > 0.5) {
-					GeneralMethods.setEntityVelocity((Ability)this,	this.targetEntity, vector.normalize().multiply(0.2));
+					GeneralMethods.setVelocity((Ability)this,	this.targetEntity, vector.normalize().multiply(0.2));
 				}
 			}
 
@@ -385,7 +385,7 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(this.targetEntity.getLocation(), GeneralMethods.getTargetedLocation(this.player, 10));
 
 				if (distance > 1.2) {
-					GeneralMethods.setEntityVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(0.2));
+					GeneralMethods.setVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(0.2));
 				}
 			}
 
@@ -402,9 +402,9 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(oldLocation, GeneralMethods.getTargetedLocation(this.player, 10));
 
 				if (distance > 1.2) {
-					GeneralMethods.setEntityVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(.5));
+					GeneralMethods.setVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(.5));
 				} else {
-					GeneralMethods.setEntityVelocity((Ability)this, this.targetEntity, new Vector(0, 0, 0));
+					GeneralMethods.setVelocity((Ability)this, this.targetEntity, new Vector(0, 0, 0));
 				}
 
 				this.targetEntity.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -20,7 +20,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.MetalAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -229,7 +228,7 @@ public class MetalClips extends MetalAbility {
 		dz = target.getZ() - location.getZ();
 		final Vector vector = new Vector(dx, dy, dz);
 		vector.normalize();
-		GeneralMethods.setVelocity(this,	this.targetEntity, vector.multiply(this.metalClipsCount / 2D));
+		GeneralMethods.setVelocity(this, this.targetEntity, vector.multiply(this.metalClipsCount / 2D));
 		this.remove();
 	}
 

--- a/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -20,6 +20,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.MetalAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -156,7 +157,7 @@ public class MetalClips extends MetalAbility {
 			vector = GeneralMethods.getDirection(this.player.getLocation(), GeneralMethods.getTargetedLocation(this.player, this.range));
 		}
 
-		item.setVelocity(vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
+		GeneralMethods.setEntityVelocity((Ability)this, item, vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
 		this.trackedIngots.add(item);
 		this.player.getInventory().removeItem(is);
 	}
@@ -228,7 +229,7 @@ public class MetalClips extends MetalAbility {
 		dz = target.getZ() - location.getZ();
 		final Vector vector = new Vector(dx, dy, dz);
 		vector.normalize();
-		this.targetEntity.setVelocity(vector.multiply(this.metalClipsCount / 2D));
+		GeneralMethods.setEntityVelocity((Ability)this,	this.targetEntity, vector.multiply(this.metalClipsCount / 2D));
 		this.remove();
 	}
 
@@ -342,7 +343,7 @@ public class MetalClips extends MetalAbility {
 					final Item iron = (Item) entity;
 
 					if (Arrays.asList(METAL_ITEMS).contains(iron.getItemStack().getType())) {
-						iron.setVelocity(vector.normalize().multiply(this.magnetSpeed).add(new Vector(0, 0.2, 0)));
+						GeneralMethods.setEntityVelocity((Ability)this,	iron, vector.normalize().multiply(this.magnetSpeed).add(new Vector(0, 0.2, 0)));
 					}
 				}
 			}
@@ -367,7 +368,7 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(this.targetEntity.getLocation(), this.player.getLocation());
 
 				if (distance > 0.5) {
-					this.targetEntity.setVelocity(vector.normalize().multiply(0.2));
+					GeneralMethods.setEntityVelocity((Ability)this,	this.targetEntity, vector.normalize().multiply(0.2));
 				}
 			}
 
@@ -384,7 +385,7 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(this.targetEntity.getLocation(), GeneralMethods.getTargetedLocation(this.player, 10));
 
 				if (distance > 1.2) {
-					this.targetEntity.setVelocity(vector.normalize().multiply(0.2));
+					GeneralMethods.setEntityVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(0.2));
 				}
 			}
 
@@ -401,9 +402,9 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(oldLocation, GeneralMethods.getTargetedLocation(this.player, 10));
 
 				if (distance > 1.2) {
-					this.targetEntity.setVelocity(vector.normalize().multiply(.5));
+					GeneralMethods.setEntityVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(.5));
 				} else {
-					this.targetEntity.setVelocity(new Vector(0, 0, 0));
+					GeneralMethods.setEntityVelocity((Ability)this, this.targetEntity, new Vector(0, 0, 0));
 				}
 
 				this.targetEntity.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -157,7 +157,7 @@ public class MetalClips extends MetalAbility {
 			vector = GeneralMethods.getDirection(this.player.getLocation(), GeneralMethods.getTargetedLocation(this.player, this.range));
 		}
 
-		GeneralMethods.setVelocity((Ability)this, item, vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
+		GeneralMethods.setVelocity(this, item, vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
 		this.trackedIngots.add(item);
 		this.player.getInventory().removeItem(is);
 	}
@@ -229,7 +229,7 @@ public class MetalClips extends MetalAbility {
 		dz = target.getZ() - location.getZ();
 		final Vector vector = new Vector(dx, dy, dz);
 		vector.normalize();
-		GeneralMethods.setVelocity((Ability)this,	this.targetEntity, vector.multiply(this.metalClipsCount / 2D));
+		GeneralMethods.setVelocity(this,	this.targetEntity, vector.multiply(this.metalClipsCount / 2D));
 		this.remove();
 	}
 
@@ -343,7 +343,7 @@ public class MetalClips extends MetalAbility {
 					final Item iron = (Item) entity;
 
 					if (Arrays.asList(METAL_ITEMS).contains(iron.getItemStack().getType())) {
-						GeneralMethods.setVelocity((Ability)this,	iron, vector.normalize().multiply(this.magnetSpeed).add(new Vector(0, 0.2, 0)));
+						GeneralMethods.setVelocity(this, iron, vector.normalize().multiply(this.magnetSpeed).add(new Vector(0, 0.2, 0)));
 					}
 				}
 			}
@@ -368,7 +368,7 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(this.targetEntity.getLocation(), this.player.getLocation());
 
 				if (distance > 0.5) {
-					GeneralMethods.setVelocity((Ability)this,	this.targetEntity, vector.normalize().multiply(0.2));
+					GeneralMethods.setVelocity(this, this.targetEntity, vector.normalize().multiply(0.2));
 				}
 			}
 
@@ -385,7 +385,7 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(this.targetEntity.getLocation(), GeneralMethods.getTargetedLocation(this.player, 10));
 
 				if (distance > 1.2) {
-					GeneralMethods.setVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(0.2));
+					GeneralMethods.setVelocity(this, this.targetEntity, vector.normalize().multiply(0.2));
 				}
 			}
 
@@ -402,9 +402,9 @@ public class MetalClips extends MetalAbility {
 				final Vector vector = GeneralMethods.getDirection(oldLocation, GeneralMethods.getTargetedLocation(this.player, 10));
 
 				if (distance > 1.2) {
-					GeneralMethods.setVelocity((Ability)this, this.targetEntity, vector.normalize().multiply(.5));
+					GeneralMethods.setVelocity(this, this.targetEntity, vector.normalize().multiply(.5));
 				} else {
-					GeneralMethods.setVelocity((Ability)this, this.targetEntity, new Vector(0, 0, 0));
+					GeneralMethods.setVelocity(this, this.targetEntity, new Vector(0, 0, 0));
 				}
 
 				this.targetEntity.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/event/AbilityVelocityAffectEntityEvent.java
+++ b/src/com/projectkorra/projectkorra/event/AbilityVelocityAffectEntityEvent.java
@@ -9,10 +9,11 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.ability.Ability;
 
 /**
- * Cancellable event called when an ability would push or alter the velocity of an entity.
+ * Cancellable event called when an ability would push or alter the velocity of
+ * an entity.
  * 
- * the entity can be changed, vector can be modified, 
- * and the ability that caused the change can be accessed.
+ * the entity can be changed, vector can be modified, and the ability that
+ * caused the change can be accessed.
  *
  * @author dNiym
  *
@@ -20,55 +21,55 @@ import com.projectkorra.projectkorra.ability.Ability;
 
 public class AbilityVelocityAffectEntityEvent extends Event implements Cancellable {
 
-	Entity affected;
-	Vector newVector;
-	Ability ability;
-	boolean cancelled = false;
-	
-	private static final HandlerList handlers = new HandlerList();
-	
-	public AbilityVelocityAffectEntityEvent(Ability ability, Entity entity, Vector vector) {
-		this.affected = entity;
-		this.ability = ability;
-		this.newVector = vector;
-	}
+    Entity affected;
+    Vector newVector;
+    Ability ability;
+    boolean cancelled = false;
 
-	@Override
-	public boolean isCancelled() {
-		return cancelled;
-	}
+    private static final HandlerList handlers = new HandlerList();
 
-	@Override
-	public void setCancelled(boolean cancel) {
-		this.cancelled = cancel;
-	}
+    public AbilityVelocityAffectEntityEvent(Ability ability, Entity entity, Vector vector) {
+        this.affected = entity;
+        this.ability = ability;
+        this.newVector = vector;
+    }
 
-	@Override
-	public HandlerList getHandlers() {
-		return handlers;
-	}
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
 
-	public Entity getAffected() {
-		return affected;
-	}
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
 
-	public void setAffected(Entity affected) {
-		this.affected = affected;
-	}
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
 
-	public Vector getNewVector() {
-		return newVector;
-	}
+    public Entity getAffected() {
+        return affected;
+    }
 
-	public void setNewVector(Vector newVector) {
-		this.newVector = newVector;
-	}
+    public void setAffected(Entity affected) {
+        this.affected = affected;
+    }
 
-	public Ability getAbility() {
-		return ability;
-	}
+    public Vector getNewVector() {
+        return newVector;
+    }
 
-	public static HandlerList getHandlerList() {
-		return handlers;
-	}
+    public void setNewVector(Vector newVector) {
+        this.newVector = newVector;
+    }
+
+    public Ability getAbility() {
+        return ability;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/com/projectkorra/projectkorra/event/AbilityVelocityAffectEntityEvent.java
+++ b/src/com/projectkorra/projectkorra/event/AbilityVelocityAffectEntityEvent.java
@@ -1,0 +1,74 @@
+package com.projectkorra.projectkorra.event;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.util.Vector;
+
+import com.projectkorra.projectkorra.ability.Ability;
+
+/**
+ * Cancellable event called when an ability would push or alter the velocity of an entity.
+ * 
+ * the entity can be changed, vector can be modified, 
+ * and the ability that caused the change can be accessed.
+ *
+ * @author dNiym
+ *
+ */
+
+public class AbilityVelocityAffectEntityEvent extends Event implements Cancellable {
+
+	Entity affected;
+	Vector newVector;
+	Ability ability;
+	boolean cancelled = false;
+	
+	private static final HandlerList handlers = new HandlerList();
+	
+	public AbilityVelocityAffectEntityEvent(Ability ability, Entity entity, Vector vector) {
+		this.affected = entity;
+		this.ability = ability;
+		this.newVector = vector;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean cancel) {
+		this.cancelled = cancel;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public Entity getAffected() {
+		return affected;
+	}
+
+	public void setAffected(Entity affected) {
+		this.affected = affected;
+	}
+
+	public Vector getNewVector() {
+		return newVector;
+	}
+
+	public void setNewVector(Vector newVector) {
+		this.newVector = newVector;
+	}
+
+	public Ability getAbility() {
+		return ability;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/com/projectkorra/projectkorra/event/AbilityVelocityAffectEntityEvent.java
+++ b/src/com/projectkorra/projectkorra/event/AbilityVelocityAffectEntityEvent.java
@@ -22,7 +22,7 @@ import com.projectkorra.projectkorra.ability.Ability;
 public class AbilityVelocityAffectEntityEvent extends Event implements Cancellable {
 
     Entity affected;
-    Vector newVector;
+    Vector velocity;
     Ability ability;
     boolean cancelled = false;
 
@@ -31,7 +31,7 @@ public class AbilityVelocityAffectEntityEvent extends Event implements Cancellab
     public AbilityVelocityAffectEntityEvent(Ability ability, Entity entity, Vector vector) {
         this.affected = entity;
         this.ability = ability;
-        this.newVector = vector;
+        this.velocity = vector;
     }
 
     @Override
@@ -57,12 +57,12 @@ public class AbilityVelocityAffectEntityEvent extends Event implements Cancellab
         this.affected = affected;
     }
 
-    public Vector getNewVector() {
-        return newVector;
+    public Vector getVelocity() {
+        return velocity;
     }
 
-    public void setNewVector(Vector newVector) {
-        this.newVector = newVector;
+    public void setVelocity(Vector velocity) {
+        this.velocity = velocity;
     }
 
     public Ability getAbility() {

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -199,9 +199,9 @@ public class FireBlast extends FireAbility {
 	private void affect(final Entity entity) {
 		if (entity.getUniqueId() != this.player.getUniqueId() && !GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) && !((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 			if (this.bPlayer.isAvatarState()) {
-				GeneralMethods.setVelocity(entity, this.direction.clone().multiply(AvatarState.getValue(this.knockback)));
+				GeneralMethods.setEntityVelocity(this, entity, this.direction.clone().multiply(AvatarState.getValue(this.knockback)), true);
 			} else {
-				GeneralMethods.setVelocity(entity, this.direction.clone().multiply(this.knockback));
+				GeneralMethods.setEntityVelocity(this, entity, this.direction.clone().multiply(this.knockback), true);
 			}
 			if (entity instanceof LivingEntity) {
 				entity.setFireTicks((int) (this.fireTicks * 20));

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -199,9 +199,9 @@ public class FireBlast extends FireAbility {
 	private void affect(final Entity entity) {
 		if (entity.getUniqueId() != this.player.getUniqueId() && !GeneralMethods.isRegionProtectedFromBuild(this, entity.getLocation()) && !((entity instanceof Player) && Commands.invincible.contains(((Player) entity).getName()))) {
 			if (this.bPlayer.isAvatarState()) {
-				GeneralMethods.setEntityVelocity(this, entity, this.direction.clone().multiply(AvatarState.getValue(this.knockback)), true);
+				GeneralMethods.setVelocity(this, entity, this.direction.clone().multiply(AvatarState.getValue(this.knockback)));
 			} else {
-				GeneralMethods.setEntityVelocity(this, entity, this.direction.clone().multiply(this.knockback), true);
+				GeneralMethods.setVelocity(this, entity, this.direction.clone().multiply(this.knockback));
 			}
 			if (entity instanceof LivingEntity) {
 				entity.setFireTicks((int) (this.fireTicks * 20));

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -10,6 +10,8 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.airbending.AirSpout;
@@ -57,7 +59,7 @@ public class FireJet extends FireAbility {
 		final Block block = player.getLocation().getBlock();
 
 		if (isIgnitable(block) || ElementalAbility.isAir(block.getType()) || block.getType() == Material.STONE_SLAB || block.getType() == Material.ACACIA_SLAB || block.getType() == Material.BIRCH_SLAB || block.getType() == Material.DARK_OAK_SLAB || block.getType() == Material.JUNGLE_SLAB || block.getType() == Material.OAK_SLAB || block.getType() == Material.SPRUCE_SLAB || isIlluminationTorch(block) || this.bPlayer.isAvatarState()) {
-			player.setVelocity(player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
+			GeneralMethods.setEntityVelocity((Ability)this,	player, player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
 			if (!canFireGrief()) {
 				if (ElementalAbility.isAir(block.getType())) {
 					createTempFire(block.getLocation());
@@ -102,7 +104,7 @@ public class FireJet extends FireAbility {
 			}
 
 			final Vector velocity = this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed * timefactor);
-			this.player.setVelocity(velocity);
+			GeneralMethods.setEntityVelocity((Ability)this, this.player, velocity);
 			this.player.setFallDistance(0);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -59,7 +59,7 @@ public class FireJet extends FireAbility {
 		final Block block = player.getLocation().getBlock();
 
 		if (isIgnitable(block) || ElementalAbility.isAir(block.getType()) || block.getType() == Material.STONE_SLAB || block.getType() == Material.ACACIA_SLAB || block.getType() == Material.BIRCH_SLAB || block.getType() == Material.DARK_OAK_SLAB || block.getType() == Material.JUNGLE_SLAB || block.getType() == Material.OAK_SLAB || block.getType() == Material.SPRUCE_SLAB || isIlluminationTorch(block) || this.bPlayer.isAvatarState()) {
-			GeneralMethods.setVelocity((Ability)this,	player, player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
+			GeneralMethods.setVelocity(this, player, player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
 			if (!canFireGrief()) {
 				if (ElementalAbility.isAir(block.getType())) {
 					createTempFire(block.getLocation());
@@ -104,7 +104,7 @@ public class FireJet extends FireAbility {
 			}
 
 			final Vector velocity = this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed * timefactor);
-			GeneralMethods.setVelocity((Ability)this, this.player, velocity);
+			GeneralMethods.setVelocity(this, this.player, velocity);
 			this.player.setFallDistance(0);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -59,7 +59,7 @@ public class FireJet extends FireAbility {
 		final Block block = player.getLocation().getBlock();
 
 		if (isIgnitable(block) || ElementalAbility.isAir(block.getType()) || block.getType() == Material.STONE_SLAB || block.getType() == Material.ACACIA_SLAB || block.getType() == Material.BIRCH_SLAB || block.getType() == Material.DARK_OAK_SLAB || block.getType() == Material.JUNGLE_SLAB || block.getType() == Material.OAK_SLAB || block.getType() == Material.SPRUCE_SLAB || isIlluminationTorch(block) || this.bPlayer.isAvatarState()) {
-			GeneralMethods.setEntityVelocity((Ability)this,	player, player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
+			GeneralMethods.setVelocity((Ability)this,	player, player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed));
 			if (!canFireGrief()) {
 				if (ElementalAbility.isAir(block.getType())) {
 					createTempFire(block.getLocation());
@@ -104,7 +104,7 @@ public class FireJet extends FireAbility {
 			}
 
 			final Vector velocity = this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.speed * timefactor);
-			GeneralMethods.setEntityVelocity((Ability)this, this.player, velocity);
+			GeneralMethods.setVelocity((Ability)this, this.player, velocity);
 			this.player.setFallDistance(0);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -11,7 +11,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.airbending.AirSpout;

--- a/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -121,7 +121,7 @@ public class WallOfFire extends FireAbility {
 	}
 
 	private void affect(final Entity entity) {
-		GeneralMethods.setEntityVelocity(this, entity, new Vector(0, 0, 0), true);
+		GeneralMethods.setVelocity(this, entity, new Vector(0, 0, 0));
 		if (entity instanceof LivingEntity) {
 			final Block block = ((LivingEntity) entity).getEyeLocation().getBlock();
 			if (TempBlock.isTempBlock(block) && isIce(block)) {

--- a/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -121,7 +121,7 @@ public class WallOfFire extends FireAbility {
 	}
 
 	private void affect(final Entity entity) {
-		GeneralMethods.setVelocity(entity, new Vector(0, 0, 0));
+		GeneralMethods.setEntityVelocity(this, entity, new Vector(0, 0, 0), true);
 		if (entity instanceof LivingEntity) {
 			final Block block = ((LivingEntity) entity).getEyeLocation().getBlock();
 			if (TempBlock.isTempBlock(block) && isIce(block)) {

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -137,7 +137,7 @@ public class FireComboStream extends BukkitRunnable {
 				fireSpin.getAffectedEntities().add(entity);
 				final double newKnockback = this.bPlayer.isAvatarState() ? this.knockback + 0.5 : this.knockback;
 				DamageHandler.damageEntity(entity, this.damage, coreAbility);
-				GeneralMethods.setEntityVelocity((Ability)this,	entity, direction.normalize().multiply(newKnockback));
+				GeneralMethods.setVelocity((Ability)this,	entity, direction.normalize().multiply(newKnockback));
 			}
 		} else if (coreAbility.getName().equalsIgnoreCase("JetBlaze")) {
 			final JetBlaze jetBlaze = CoreAbility.getAbility(this.player, JetBlaze.class);

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -17,7 +17,6 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.command.Commands;

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -17,6 +17,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.command.Commands;
@@ -136,7 +137,7 @@ public class FireComboStream extends BukkitRunnable {
 				fireSpin.getAffectedEntities().add(entity);
 				final double newKnockback = this.bPlayer.isAvatarState() ? this.knockback + 0.5 : this.knockback;
 				DamageHandler.damageEntity(entity, this.damage, coreAbility);
-				entity.setVelocity(direction.normalize().multiply(newKnockback));
+				GeneralMethods.setEntityVelocity((Ability)this,	entity, direction.normalize().multiply(newKnockback));
 			}
 		} else if (coreAbility.getName().equalsIgnoreCase("JetBlaze")) {
 			final JetBlaze jetBlaze = CoreAbility.getAbility(this.player, JetBlaze.class);

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -137,7 +137,7 @@ public class FireComboStream extends BukkitRunnable {
 				fireSpin.getAffectedEntities().add(entity);
 				final double newKnockback = this.bPlayer.isAvatarState() ? this.knockback + 0.5 : this.knockback;
 				DamageHandler.damageEntity(entity, this.damage, coreAbility);
-				GeneralMethods.setVelocity((Ability)this,	entity, direction.normalize().multiply(newKnockback));
+				GeneralMethods.setVelocity(coreAbility, entity, direction.normalize().multiply(newKnockback));
 			}
 		} else if (coreAbility.getName().equalsIgnoreCase("JetBlaze")) {
 			final JetBlaze jetBlaze = CoreAbility.getAbility(this.player, JetBlaze.class);

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -208,7 +208,7 @@ public class OctopusForm extends WaterAbility {
 			}
 
 			final double knock = this.bPlayer.isAvatarState() ? AvatarState.getValue(this.knockback) : this.knockback;
-			GeneralMethods.setVelocity((Ability)this,	entity, GeneralMethods.getDirection(this.player.getLocation(), location).normalize().multiply(knock));
+			GeneralMethods.setVelocity(this, entity, GeneralMethods.getDirection(this.player.getLocation(), location).normalize().multiply(knock));
 
 			if (entity instanceof LivingEntity) {
 				DamageHandler.damageEntity(entity, this.damage, this);

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -15,7 +15,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -208,7 +208,7 @@ public class OctopusForm extends WaterAbility {
 			}
 
 			final double knock = this.bPlayer.isAvatarState() ? AvatarState.getValue(this.knockback) : this.knockback;
-			GeneralMethods.setEntityVelocity((Ability)this,	entity, GeneralMethods.getDirection(this.player.getLocation(), location).normalize().multiply(knock));
+			GeneralMethods.setVelocity((Ability)this,	entity, GeneralMethods.getDirection(this.player.getLocation(), location).normalize().multiply(knock));
 
 			if (entity instanceof LivingEntity) {
 				DamageHandler.damageEntity(entity, this.damage, this);

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -15,6 +15,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
@@ -207,7 +208,7 @@ public class OctopusForm extends WaterAbility {
 			}
 
 			final double knock = this.bPlayer.isAvatarState() ? AvatarState.getValue(this.knockback) : this.knockback;
-			entity.setVelocity(GeneralMethods.getDirection(this.player.getLocation(), location).normalize().multiply(knock));
+			GeneralMethods.setEntityVelocity((Ability)this,	entity, GeneralMethods.getDirection(this.player.getLocation(), location).normalize().multiply(knock));
 
 			if (entity instanceof LivingEntity) {
 				DamageHandler.damageEntity(entity, this.damage, this);

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -377,7 +377,7 @@ public class SurgeWave extends WaterAbility {
 						}
 						final Vector dir = direction.clone();
 						dir.setY(dir.getY() * this.knockup);
-						GeneralMethods.setEntityVelocity(this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.getNightFactor(this.knockback))),true);
+						GeneralMethods.setVelocity(this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.getNightFactor(this.knockback))));
 
 						entity.setFallDistance(0);
 						if (entity.getFireTicks() > 0) {

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -377,7 +377,7 @@ public class SurgeWave extends WaterAbility {
 						}
 						final Vector dir = direction.clone();
 						dir.setY(dir.getY() * this.knockup);
-						GeneralMethods.setVelocity(entity, entity.getVelocity().clone().add(dir.clone().multiply(this.getNightFactor(this.knockback))));
+						GeneralMethods.setEntityVelocity(this, entity, entity.getVelocity().clone().add(dir.clone().multiply(this.getNightFactor(this.knockback))),true);
 
 						entity.setFallDistance(0);
 						if (entity.getFireTicks() > 0) {

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -19,6 +19,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -591,7 +592,7 @@ public class Torrent extends WaterAbility {
 			velocity.setZ(vec.getY());
 		}
 
-		GeneralMethods.setVelocity(entity, velocity);
+		GeneralMethods.setEntityVelocity(this,entity, velocity,true);
 		entity.setFallDistance(0);
 		if (entity instanceof LivingEntity) {
 			final double damageDealt = this.getNightFactor(this.deflectDamage);
@@ -611,7 +612,7 @@ public class Torrent extends WaterAbility {
 			direction.setY(this.knockup);
 		}
 		if (!this.freeze) {
-			entity.setVelocity(direction.multiply(this.knockback));
+			GeneralMethods.setEntityVelocity((Ability)this,	entity, direction.multiply(this.knockback));
 		}
 		if (entity instanceof LivingEntity && !this.hurtEntities.contains(entity)) {
 			double damageDealt = this.getNightFactor(this.damage);

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -591,7 +591,7 @@ public class Torrent extends WaterAbility {
 			velocity.setZ(vec.getY());
 		}
 
-		GeneralMethods.setVelocity(this,entity, velocity);
+		GeneralMethods.setVelocity(this, entity, velocity);
 		entity.setFallDistance(0);
 		if (entity instanceof LivingEntity) {
 			final double damageDealt = this.getNightFactor(this.deflectDamage);

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -612,7 +612,7 @@ public class Torrent extends WaterAbility {
 			direction.setY(this.knockup);
 		}
 		if (!this.freeze) {
-			GeneralMethods.setVelocity((Ability)this,	entity, direction.multiply(this.knockback));
+			GeneralMethods.setVelocity(this, entity, direction.multiply(this.knockback));
 		}
 		if (entity instanceof LivingEntity && !this.hurtEntities.contains(entity)) {
 			double damageDealt = this.getNightFactor(this.damage);

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -592,7 +592,7 @@ public class Torrent extends WaterAbility {
 			velocity.setZ(vec.getY());
 		}
 
-		GeneralMethods.setEntityVelocity(this,entity, velocity,true);
+		GeneralMethods.setVelocity(this,entity, velocity);
 		entity.setFallDistance(0);
 		if (entity instanceof LivingEntity) {
 			final double damageDealt = this.getNightFactor(this.deflectDamage);
@@ -612,7 +612,7 @@ public class Torrent extends WaterAbility {
 			direction.setY(this.knockup);
 		}
 		if (!this.freeze) {
-			GeneralMethods.setEntityVelocity((Ability)this,	entity, direction.multiply(this.knockback));
+			GeneralMethods.setVelocity((Ability)this,	entity, direction.multiply(this.knockback));
 		}
 		if (entity instanceof LivingEntity && !this.hurtEntities.contains(entity)) {
 			double damageDealt = this.getNightFactor(this.damage);

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -19,7 +19,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;

--- a/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
@@ -14,7 +14,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;

--- a/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;
@@ -180,7 +181,7 @@ public class TorrentWave extends WaterAbility {
 		final Vector direction = GeneralMethods.getDirection(this.origin, entity.getLocation());
 		direction.setY(0);
 		direction.normalize();
-		entity.setVelocity(entity.getVelocity().clone().add(direction.multiply(this.knockback)));
+		GeneralMethods.setEntityVelocity((Ability)this, entity, entity.getVelocity().clone().add(direction.multiply(this.knockback)));
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
@@ -181,7 +181,7 @@ public class TorrentWave extends WaterAbility {
 		final Vector direction = GeneralMethods.getDirection(this.origin, entity.getLocation());
 		direction.setY(0);
 		direction.normalize();
-		GeneralMethods.setVelocity((Ability)this, entity, entity.getVelocity().clone().add(direction.multiply(this.knockback)));
+		GeneralMethods.setVelocity(this, entity, entity.getVelocity().clone().add(direction.multiply(this.knockback)));
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/TorrentWave.java
@@ -181,7 +181,7 @@ public class TorrentWave extends WaterAbility {
 		final Vector direction = GeneralMethods.getDirection(this.origin, entity.getLocation());
 		direction.setY(0);
 		direction.normalize();
-		GeneralMethods.setEntityVelocity((Ability)this, entity, entity.getVelocity().clone().add(direction.multiply(this.knockback)));
+		GeneralMethods.setVelocity((Ability)this, entity, entity.getVelocity().clone().add(direction.multiply(this.knockback)));
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -16,6 +16,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
@@ -283,7 +284,7 @@ public class WaterManipulation extends WaterAbility {
 							}
 							final Location location = this.player.getEyeLocation();
 							final Vector vector = location.getDirection();
-							entity.setVelocity(vector.normalize().multiply(this.knockback));
+							GeneralMethods.setEntityVelocity((Ability)this,	entity, vector.normalize().multiply(this.knockback));
 
 							if (this.bPlayer.isAvatarState()) {
 								this.damage = getConfig().getDouble("Abilities.Avatar.AvatarState.Water.WaterManipulation.Damage");

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -284,7 +284,7 @@ public class WaterManipulation extends WaterAbility {
 							}
 							final Location location = this.player.getEyeLocation();
 							final Vector vector = location.getDirection();
-							GeneralMethods.setVelocity((Ability)this,	entity, vector.normalize().multiply(this.knockback));
+							GeneralMethods.setVelocity(this, entity, vector.normalize().multiply(this.knockback));
 
 							if (this.bPlayer.isAvatarState()) {
 								this.damage = getConfig().getDouble("Abilities.Avatar.AvatarState.Water.WaterManipulation.Damage");

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -16,7 +16,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -284,7 +284,7 @@ public class WaterManipulation extends WaterAbility {
 							}
 							final Location location = this.player.getEyeLocation();
 							final Vector vector = location.getDirection();
-							GeneralMethods.setEntityVelocity((Ability)this,	entity, vector.normalize().multiply(this.knockback));
+							GeneralMethods.setVelocity((Ability)this,	entity, vector.normalize().multiply(this.knockback));
 
 							if (this.bPlayer.isAvatarState()) {
 								this.damage = getConfig().getDouble("Abilities.Avatar.AvatarState.Water.WaterManipulation.Damage");

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -20,6 +20,7 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
@@ -299,8 +300,7 @@ public class WaterSpoutWave extends WaterAbility {
 				if (this.bPlayer.isAvatarState()) {
 					currentSpeed = this.getNightFactor(this.speed);
 				}
-
-				this.player.setVelocity(this.player.getEyeLocation().getDirection().normalize().multiply(currentSpeed));
+				GeneralMethods.setEntityVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().normalize().multiply(currentSpeed));
 				for (final Block block : GeneralMethods.getBlocksAroundPoint(this.player.getLocation().add(0, -1, 0), this.waveRadius)) {
 					if (ElementalAbility.isAir(block.getType()) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 						if (this.iceWave) {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -300,7 +300,7 @@ public class WaterSpoutWave extends WaterAbility {
 				if (this.bPlayer.isAvatarState()) {
 					currentSpeed = this.getNightFactor(this.speed);
 				}
-				GeneralMethods.setVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().normalize().multiply(currentSpeed));
+				GeneralMethods.setVelocity(this, this.player, this.player.getEyeLocation().getDirection().normalize().multiply(currentSpeed));
 				for (final Block block : GeneralMethods.getBlocksAroundPoint(this.player.getLocation().add(0, -1, 0), this.waveRadius)) {
 					if (ElementalAbility.isAir(block.getType()) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 						if (this.iceWave) {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -300,7 +300,7 @@ public class WaterSpoutWave extends WaterAbility {
 				if (this.bPlayer.isAvatarState()) {
 					currentSpeed = this.getNightFactor(this.speed);
 				}
-				GeneralMethods.setEntityVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().normalize().multiply(currentSpeed));
+				GeneralMethods.setVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().normalize().multiply(currentSpeed));
 				for (final Block block : GeneralMethods.getBlocksAroundPoint(this.player.getLocation().add(0, -1, 0), this.waveRadius)) {
 					if (ElementalAbility.isAir(block.getType()) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 						if (this.iceWave) {

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -20,7 +20,6 @@ import org.bukkit.util.Vector;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;

--- a/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
@@ -154,7 +154,7 @@ public class Bloodbending extends BloodAbility {
 				vector = GeneralMethods.getDirection(location, GeneralMethods.getTargetedLocation(this.player, location.distance(target)));
 			}
 			vector.normalize();
-			GeneralMethods.setVelocity((Ability)this, entity, vector.multiply(this.knockback));
+			GeneralMethods.setVelocity(this, entity, vector.multiply(this.knockback));
 			new HorizontalVelocityTracker(entity, this.player, 200, this);
 		}
 		this.remove();
@@ -221,7 +221,7 @@ public class Bloodbending extends BloodAbility {
 					continue;
 				}
 				if (entity instanceof LivingEntity) {
-					GeneralMethods.setVelocity((Ability)this, entity, this.vector);
+					GeneralMethods.setVelocity(this, entity, this.vector);
 					new TempPotionEffect((LivingEntity) entity, effect);
 					entity.setFallDistance(0);
 					if (entity instanceof Creature) {
@@ -282,7 +282,7 @@ public class Bloodbending extends BloodAbility {
 				this.vector = new Vector(0, 0, 0);
 			}
 
-			GeneralMethods.setVelocity((Ability)this, this.target, this.vector);
+			GeneralMethods.setVelocity(this, this.target, this.vector);
 
 			new TempPotionEffect((LivingEntity) this.target, effect);
 			this.target.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
@@ -18,6 +18,7 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.BloodAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -153,7 +154,7 @@ public class Bloodbending extends BloodAbility {
 				vector = GeneralMethods.getDirection(location, GeneralMethods.getTargetedLocation(this.player, location.distance(target)));
 			}
 			vector.normalize();
-			entity.setVelocity(vector.multiply(this.knockback));
+			GeneralMethods.setEntityVelocity((Ability)this, entity, vector.multiply(this.knockback));
 			new HorizontalVelocityTracker(entity, this.player, 200, this);
 		}
 		this.remove();
@@ -220,7 +221,7 @@ public class Bloodbending extends BloodAbility {
 					continue;
 				}
 				if (entity instanceof LivingEntity) {
-					entity.setVelocity(this.vector);
+					GeneralMethods.setEntityVelocity((Ability)this, entity, this.vector);
 					new TempPotionEffect((LivingEntity) entity, effect);
 					entity.setFallDistance(0);
 					if (entity instanceof Creature) {
@@ -281,7 +282,7 @@ public class Bloodbending extends BloodAbility {
 				this.vector = new Vector(0, 0, 0);
 			}
 
-			this.target.setVelocity(this.vector);
+			GeneralMethods.setEntityVelocity((Ability)this, this.target, this.vector);
 
 			new TempPotionEffect((LivingEntity) this.target, effect);
 			this.target.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
@@ -18,7 +18,6 @@ import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.BloodAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;

--- a/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
@@ -154,7 +154,7 @@ public class Bloodbending extends BloodAbility {
 				vector = GeneralMethods.getDirection(location, GeneralMethods.getTargetedLocation(this.player, location.distance(target)));
 			}
 			vector.normalize();
-			GeneralMethods.setEntityVelocity((Ability)this, entity, vector.multiply(this.knockback));
+			GeneralMethods.setVelocity((Ability)this, entity, vector.multiply(this.knockback));
 			new HorizontalVelocityTracker(entity, this.player, 200, this);
 		}
 		this.remove();
@@ -221,7 +221,7 @@ public class Bloodbending extends BloodAbility {
 					continue;
 				}
 				if (entity instanceof LivingEntity) {
-					GeneralMethods.setEntityVelocity((Ability)this, entity, this.vector);
+					GeneralMethods.setVelocity((Ability)this, entity, this.vector);
 					new TempPotionEffect((LivingEntity) entity, effect);
 					entity.setFallDistance(0);
 					if (entity instanceof Creature) {
@@ -282,7 +282,7 @@ public class Bloodbending extends BloodAbility {
 				this.vector = new Vector(0, 0, 0);
 			}
 
-			GeneralMethods.setEntityVelocity((Ability)this, this.target, this.vector);
+			GeneralMethods.setVelocity((Ability)this, this.target, this.vector);
 
 			new TempPotionEffect((LivingEntity) this.target, effect);
 			this.target.setFallDistance(0);

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
@@ -17,7 +17,6 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.IceAbility;

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
@@ -247,7 +247,7 @@ public class IceSpikePillar extends IceAbility {
 	}
 
 	private void affect(final LivingEntity entity) {
-		GeneralMethods.setVelocity((Ability)this, entity, this.thrownForce);
+		GeneralMethods.setVelocity(this, entity, this.thrownForce);
 		DamageHandler.damageEntity(entity, this.damage, this);
 		this.damaged.add(entity);
 

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
@@ -247,7 +247,7 @@ public class IceSpikePillar extends IceAbility {
 	}
 
 	private void affect(final LivingEntity entity) {
-		GeneralMethods.setEntityVelocity((Ability)this, entity, this.thrownForce);
+		GeneralMethods.setVelocity((Ability)this, entity, this.thrownForce);
 		DamageHandler.damageEntity(entity, this.damage, this);
 		this.damaged.add(entity);
 

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikePillar.java
@@ -17,6 +17,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.IceAbility;
@@ -246,7 +247,7 @@ public class IceSpikePillar extends IceAbility {
 	}
 
 	private void affect(final LivingEntity entity) {
-		entity.setVelocity(this.thrownForce);
+		GeneralMethods.setEntityVelocity((Ability)this, entity, this.thrownForce);
 		DamageHandler.damageEntity(entity, this.damage, this);
 		this.damaged.add(entity);
 

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -115,7 +115,7 @@ public class WaterArmsWhip extends WaterAbility {
 				waw.grabbed = false;
 				if (waw.grabbedEntity != null) {
 					GRABBED_ENTITIES.remove(waw.grabbedEntity);
-					GeneralMethods.setEntityVelocity((Ability)this,	waw.grabbedEntity, waw.grabbedEntity.getVelocity().multiply(2.5));
+					GeneralMethods.setVelocity((Ability)this,	waw.grabbedEntity, waw.grabbedEntity.getVelocity().multiply(2.5));
 				}
 				return;
 			}
@@ -301,7 +301,7 @@ public class WaterArmsWhip extends WaterAbility {
 						continue;
 					}
 					final Vector vector = endOfArm.toVector().subtract(entity.getLocation().toVector());
-					GeneralMethods.setEntityVelocity((Ability)this, entity, vector.multiply(this.pullMultiplier));
+					GeneralMethods.setVelocity((Ability)this, entity, vector.multiply(this.pullMultiplier));
 				}
 				break;
 			case PUNCH:
@@ -311,7 +311,7 @@ public class WaterArmsWhip extends WaterAbility {
 					}
 
 					final Vector vector = entity.getLocation().toVector().subtract(endOfArm.toVector());
-					GeneralMethods.setEntityVelocity((Ability)this, entity, vector.multiply(0.15));
+					GeneralMethods.setVelocity((Ability)this, entity, vector.multiply(0.15));
 					if (entity instanceof LivingEntity) {
 						if (entity.getEntityId() != this.player.getEntityId()) {
 							this.hasDamaged = true;
@@ -374,9 +374,9 @@ public class WaterArmsWhip extends WaterAbility {
 			final Vector vector = new Vector(dx, dy, dz);
 
 			if (distance > 0.5) {
-				GeneralMethods.setEntityVelocity((Ability)this,	this.grabbedEntity, vector.normalize().multiply(.65));
+				GeneralMethods.setVelocity((Ability)this,	this.grabbedEntity, vector.normalize().multiply(.65));
 			} else {
-				GeneralMethods.setEntityVelocity((Ability)this,	this.grabbedEntity, new Vector(0, 0, 0));
+				GeneralMethods.setVelocity((Ability)this,	this.grabbedEntity, new Vector(0, 0, 0));
 			}
 
 			this.grabbedEntity.setFallDistance(0);
@@ -393,7 +393,7 @@ public class WaterArmsWhip extends WaterAbility {
 			}
 
 			final Vector vector = this.player.getLocation().toVector().subtract(location.toVector());
-			GeneralMethods.setEntityVelocity((Ability)this, this.player, vector.multiply(-0.25));
+			GeneralMethods.setVelocity((Ability)this, this.player, vector.multiply(-0.25));
 			this.player.setFallDistance(0);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.ability.util.MultiAbilityManager;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -114,7 +115,7 @@ public class WaterArmsWhip extends WaterAbility {
 				waw.grabbed = false;
 				if (waw.grabbedEntity != null) {
 					GRABBED_ENTITIES.remove(waw.grabbedEntity);
-					waw.grabbedEntity.setVelocity(waw.grabbedEntity.getVelocity().multiply(2.5));
+					GeneralMethods.setEntityVelocity((Ability)this,	waw.grabbedEntity, waw.grabbedEntity.getVelocity().multiply(2.5));
 				}
 				return;
 			}
@@ -300,7 +301,7 @@ public class WaterArmsWhip extends WaterAbility {
 						continue;
 					}
 					final Vector vector = endOfArm.toVector().subtract(entity.getLocation().toVector());
-					entity.setVelocity(vector.multiply(this.pullMultiplier));
+					GeneralMethods.setEntityVelocity((Ability)this, entity, vector.multiply(this.pullMultiplier));
 				}
 				break;
 			case PUNCH:
@@ -310,7 +311,7 @@ public class WaterArmsWhip extends WaterAbility {
 					}
 
 					final Vector vector = entity.getLocation().toVector().subtract(endOfArm.toVector());
-					entity.setVelocity(vector.multiply(0.15));
+					GeneralMethods.setEntityVelocity((Ability)this, entity, vector.multiply(0.15));
 					if (entity instanceof LivingEntity) {
 						if (entity.getEntityId() != this.player.getEntityId()) {
 							this.hasDamaged = true;
@@ -373,9 +374,9 @@ public class WaterArmsWhip extends WaterAbility {
 			final Vector vector = new Vector(dx, dy, dz);
 
 			if (distance > 0.5) {
-				this.grabbedEntity.setVelocity(vector.normalize().multiply(.65));
+				GeneralMethods.setEntityVelocity((Ability)this,	this.grabbedEntity, vector.normalize().multiply(.65));
 			} else {
-				this.grabbedEntity.setVelocity(new Vector(0, 0, 0));
+				GeneralMethods.setEntityVelocity((Ability)this,	this.grabbedEntity, new Vector(0, 0, 0));
 			}
 
 			this.grabbedEntity.setFallDistance(0);
@@ -392,7 +393,7 @@ public class WaterArmsWhip extends WaterAbility {
 			}
 
 			final Vector vector = this.player.getLocation().toVector().subtract(location.toVector());
-			this.player.setVelocity(vector.multiply(-0.25));
+			GeneralMethods.setEntityVelocity((Ability)this, this.player, vector.multiply(-0.25));
 			this.player.setFallDistance(0);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -13,7 +13,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.ability.util.MultiAbilityManager;
 import com.projectkorra.projectkorra.attribute.Attribute;

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -115,7 +115,7 @@ public class WaterArmsWhip extends WaterAbility {
 				waw.grabbed = false;
 				if (waw.grabbedEntity != null) {
 					GRABBED_ENTITIES.remove(waw.grabbedEntity);
-					GeneralMethods.setVelocity((Ability)this,	waw.grabbedEntity, waw.grabbedEntity.getVelocity().multiply(2.5));
+					GeneralMethods.setVelocity(this, waw.grabbedEntity, waw.grabbedEntity.getVelocity().multiply(2.5));
 				}
 				return;
 			}
@@ -301,7 +301,7 @@ public class WaterArmsWhip extends WaterAbility {
 						continue;
 					}
 					final Vector vector = endOfArm.toVector().subtract(entity.getLocation().toVector());
-					GeneralMethods.setVelocity((Ability)this, entity, vector.multiply(this.pullMultiplier));
+					GeneralMethods.setVelocity(this, entity, vector.multiply(this.pullMultiplier));
 				}
 				break;
 			case PUNCH:
@@ -311,7 +311,7 @@ public class WaterArmsWhip extends WaterAbility {
 					}
 
 					final Vector vector = entity.getLocation().toVector().subtract(endOfArm.toVector());
-					GeneralMethods.setVelocity((Ability)this, entity, vector.multiply(0.15));
+					GeneralMethods.setVelocity(this, entity, vector.multiply(0.15));
 					if (entity instanceof LivingEntity) {
 						if (entity.getEntityId() != this.player.getEntityId()) {
 							this.hasDamaged = true;
@@ -374,9 +374,9 @@ public class WaterArmsWhip extends WaterAbility {
 			final Vector vector = new Vector(dx, dy, dz);
 
 			if (distance > 0.5) {
-				GeneralMethods.setVelocity((Ability)this,	this.grabbedEntity, vector.normalize().multiply(.65));
+				GeneralMethods.setVelocity(this, this.grabbedEntity, vector.normalize().multiply(.65));
 			} else {
-				GeneralMethods.setVelocity((Ability)this,	this.grabbedEntity, new Vector(0, 0, 0));
+				GeneralMethods.setVelocity(this, this.grabbedEntity, new Vector(0, 0, 0));
 			}
 
 			this.grabbedEntity.setFallDistance(0);
@@ -393,7 +393,7 @@ public class WaterArmsWhip extends WaterAbility {
 			}
 
 			final Vector vector = this.player.getLocation().toVector().subtract(location.toVector());
-			GeneralMethods.setVelocity((Ability)this, this.player, vector.multiply(-0.25));
+			GeneralMethods.setVelocity(this, this.player, vector.multiply(-0.25));
 			this.player.setFallDistance(0);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
+++ b/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
@@ -59,7 +59,7 @@ public class FastSwim extends WaterAbility implements PassiveAbility {
 		if (this.bPlayer.getBoundAbility() == null || (this.bPlayer.getBoundAbility() != null && !this.bPlayer.getBoundAbility().isSneakAbility())) {
 			if (this.player.isSneaking()) {
 				if (isWater(this.player.getLocation().getBlock()) && !this.bPlayer.isOnCooldown(this)) {
-					GeneralMethods.setEntityVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.swimSpeed));
+					GeneralMethods.setVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.swimSpeed));
 				}
 			} else {
 				this.bPlayer.addCooldown(this);

--- a/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
+++ b/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
@@ -59,7 +59,7 @@ public class FastSwim extends WaterAbility implements PassiveAbility {
 		if (this.bPlayer.getBoundAbility() == null || (this.bPlayer.getBoundAbility() != null && !this.bPlayer.getBoundAbility().isSneakAbility())) {
 			if (this.player.isSneaking()) {
 				if (isWater(this.player.getLocation().getBlock()) && !this.bPlayer.isOnCooldown(this)) {
-					GeneralMethods.setVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.swimSpeed));
+					GeneralMethods.setVelocity(this, this.player, this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.swimSpeed));
 				}
 			} else {
 				this.bPlayer.addCooldown(this);

--- a/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
+++ b/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
@@ -4,7 +4,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.PassiveAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;

--- a/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
+++ b/src/com/projectkorra/projectkorra/waterbending/passive/FastSwim.java
@@ -3,6 +3,8 @@ package com.projectkorra.projectkorra.waterbending.passive;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.PassiveAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
@@ -57,7 +59,7 @@ public class FastSwim extends WaterAbility implements PassiveAbility {
 		if (this.bPlayer.getBoundAbility() == null || (this.bPlayer.getBoundAbility() != null && !this.bPlayer.getBoundAbility().isSneakAbility())) {
 			if (this.player.isSneaking()) {
 				if (isWater(this.player.getLocation().getBlock()) && !this.bPlayer.isOnCooldown(this)) {
-					this.player.setVelocity(this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.swimSpeed));
+					GeneralMethods.setEntityVelocity((Ability)this,	this.player, this.player.getEyeLocation().getDirection().clone().normalize().multiply(this.swimSpeed));
 				}
 			} else {
 				this.bPlayer.addCooldown(this);


### PR DESCRIPTION
Created a cancellable event that will fire whenever a bending move would
alter the velocity of an entity.

## Additions
* Adds 1.
    > The AbilityVelocityAffectEntityEvent
    > Adds a new method to GeneralMethods -> setEntityVelocity()
    > Updates existing setVelocity() calls to use the new method in general methods.
    > checks to see if anything in the event should be modified or if it should be cancelled.

## Fixes
* Fixes 2
    > The lack of a way to detect when a bending move pushed a player.

