### PR TITLE
Fixed pointless waste of execution time

### DIFF
--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -511,7 +511,7 @@ public class BendingPlayer {
 			return null;
 		}
 
-		return getBendingPlayer(player.getName());
+		return getBendingPlayer((OfflinePlayer)player);
 	}
 
 	/**


### PR DESCRIPTION
# What this does
- Changes `BendingPlayer.getBendingPlayer(Player player)` to redirect to `BendingPlayer.getBendingPlayer(OfflinePlayer player)` instead of `BendingPlayer.getBendingPlayer(String playerName)`

# Reason for change
- Redirecting to `BendingPlayer.getBendingPlayer(String playerName)` (current behaviour) makes lots of pointless calls to bukkit to fetch the player object again when one was already originally provided. This fixes that and optimizes it so there are no longer any pointless calls to Bukkit.