### PR TITLE
Add bendable earth TempBlocks

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1302,7 +1302,7 @@ public class GeneralMethods {
 
 			if (trans.contains(block.getType())) {
 				continue;
-			} else if (ignoreTempBlocks && (TempBlock.isTempBlock(block) && !WaterAbility.isBendableWaterTempBlock(block))) {
+			} else if (ignoreTempBlocks && (TempBlock.isTempBlock(block) && !WaterAbility.isBendableWaterTempBlock(block) && !EarthAbility.isBendableEarthTempBlock(block))) {
 				continue;
 			} else {
 				location.subtract(vec);

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -90,6 +90,14 @@ public abstract class EarthAbility extends ElementalAbility {
 			ParticleEffect.BLOCK_CRACK.display(collision.getLocationFirst(), 10, 1, 1, 1, 0.1, Material.DIRT.createBlockData());
 		}
 	}
+	
+	public static boolean isBendableEarthTempBlock(final Block block) {
+		return isBendableEarthTempBlock(TempBlock.get(block));
+	}
+	
+	public static boolean isBendableEarthTempBlock(final TempBlock tempBlock) {
+		return DensityShift.getSandBlocks().contains(tempBlock);
+	}
 
 	public static boolean isEarthbendable(final Material material, final boolean metal, final boolean sand, final boolean lava) {
 		return isEarth(material) || (metal && isMetal(material)) || (sand && isSand(material)) || (lava && isLava(material));
@@ -128,7 +136,7 @@ public abstract class EarthAbility extends ElementalAbility {
 	}
 
 	public boolean moveEarth(Block block, final Vector direction, final int chainlength, final boolean throwplayer) {
-		if (!TempBlock.isTempBlock(block) && this.isEarthbendable(block) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
+		if ((!TempBlock.isTempBlock(block) || isBendableEarthTempBlock(block)) && this.isEarthbendable(block) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
 			boolean up = false;
 			boolean down = false;
 			final Vector norm = direction.clone().normalize();

--- a/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
@@ -84,6 +84,10 @@ public class EarthArmor extends EarthAbility {
 			if (!this.moveBlocks()) {
 				return;
 			}
+			if ((TempBlock.isTempBlock(oldHeadBlock) && !isBendableEarthTempBlock(oldHeadBlock))
+					|| (TempBlock.isTempBlock(oldLegsBlock) && !isBendableEarthTempBlock(oldLegsBlock))) {
+				return;
+			}
 			if (isEarthRevertOn()) {
 				addTempAirBlock(oldHeadBlock);
 				addTempAirBlock(oldLegsBlock);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
@@ -156,7 +156,7 @@ public class EarthBlast extends EarthAbility {
 		final Block block = BlockSource.getEarthSourceBlock(this.player, this.range, ClickType.SHIFT_DOWN);
 		if (block == null || !this.isEarthbendable(block)) {
 			return false;
-		} else if (TempBlock.isTempBlock(block)) {
+		} else if (TempBlock.isTempBlock(block) && !EarthAbility.isBendableEarthTempBlock(block)) {
 			return false;
 		}
 

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -201,6 +201,9 @@ public class EarthSmash extends EarthAbility {
 					if (this.origin == null) {
 						this.remove();
 						return;
+					} else if (TempBlock.isTempBlock(this.origin) && !isBendableEarthTempBlock(this.origin)) {
+						this.remove();
+						return;
 					}
 					this.bPlayer.addCooldown(this);
 					this.location = this.origin.getLocation();

--- a/src/com/projectkorra/projectkorra/earthbending/RaiseEarth.java
+++ b/src/com/projectkorra/projectkorra/earthbending/RaiseEarth.java
@@ -102,7 +102,7 @@ public class RaiseEarth extends EarthAbility {
 
 	private boolean canInstantiate() {
 		for (final Block block : this.affectedBlocks.keySet()) {
-			if (!this.isEarthbendable(block) || TempBlock.isTempBlock(block)) {
+			if (!this.isEarthbendable(block) || (TempBlock.isTempBlock(block) && !EarthAbility.isBendableEarthTempBlock(block))) {
 				return false;
 			}
 		}

--- a/src/com/projectkorra/projectkorra/util/BlockSource.java
+++ b/src/com/projectkorra/projectkorra/util/BlockSource.java
@@ -161,7 +161,7 @@ public class BlockSource {
 	public static Block getSourceBlock(final Player player, final double range, final BlockSourceType sourceType, final ClickType clickType) {
 		final BlockSourceInformation info = getValidBlockSourceInformation(player, range, sourceType, clickType);
 		if (info != null) {
-			if (TempBlock.isTempBlock(info.getBlock()) && !WaterAbility.isBendableWaterTempBlock(info.getBlock())) {
+			if (TempBlock.isTempBlock(info.getBlock()) && !WaterAbility.isBendableWaterTempBlock(info.getBlock()) && !EarthAbility.isBendableEarthTempBlock(info.getBlock())) {
 				return null;
 			}
 			return info.getBlock();


### PR DESCRIPTION
## Additions
* DensityShift sand blocks are now "bendable earth TempBlocks," similar to water's PhaseChange and Torrent ice
  * This is to allow those who want sand blocks to be earthbendable and not just sandbendable to use the full range of earth abilities with DensityShift sand
  * The main culprits were EarthBlast and RaiseEarth, which both prevented sourcing from TempBlocks, so now there's an exception for bendable TempBlocks
  * A lot of people have been asking for this feature, so I thought I would try to add it to the plugin by the next release
  * If you ever need bendable earth TempBlocks in the future, you will be able to use this and just add the blocks in question to the new boolean in EarthAbility