### PR TITLE
Fix FireBlast not checking for daytime

### DIFF
--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -113,8 +113,10 @@ public class FireBlast extends FireAbility {
 		double damageMod = 0;
 		double rangeMod = 0;
 
-		damageMod = this.getDayFactor(damage) - damage;
-		rangeMod = this.getDayFactor(range) - range;
+		if (isDay(player.getWorld())) {
+			damageMod = this.getDayFactor(damage) - damage;
+			rangeMod = this.getDayFactor(range) - range;
+		}
 
 		damageMod = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (BlueFireAbility.getDamageFactor() * damage - damage) + damageMod : damageMod;
 		rangeMod = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? (BlueFireAbility.getRangeFactor() * range - range) + rangeMod : rangeMod;


### PR DESCRIPTION
## Fixes
- Adds daytime check so that FireBlast applies day factor when it's day and no other time
- The getDayFactor() method just multiplies the value by the day factor without checking if it's actually day. This could be problematic, as this would mean FireBlast is just always stronger than it would normally be.