### PR TITLE
Fix MultiAbilityManager#hasMultiAbilityBound

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -134,10 +134,7 @@ public class MultiAbilityManager {
 			return false;
 		}
 
-		if (playerAbilities.containsKey(player)) {
-			if (!playerBoundAbility.get(player).equals(multiAbility) && bPlayer.getBoundAbility() != null) {
-				return false;
-			}
+		if (playerAbilities.containsKey(player) && playerBoundAbility.get(player).equals(multiAbility)) {
 			return true;
 		}
 		return false;

--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -134,10 +134,7 @@ public class MultiAbilityManager {
 			return false;
 		}
 
-		if (playerAbilities.containsKey(player) && playerBoundAbility.get(player).equals(multiAbility)) {
-			return true;
-		}
-		return false;
+		return playerAbilities.containsKey(player) && playerBoundAbility.get(player).equals(multiAbility));
 	}
 
 	/**


### PR DESCRIPTION
This method causes problems because it doesn't actually determine whether it's the same ability.
If the player has WaterArms bound and we want to know if they have PlantArmor bound, this will return true:
- !playerBoundAbility.get(player).equals(multiAbility) is TRUE if they're not the same ability, which is working properly
- bPlayer.getBoundAbility() != null returns FALSE because multiabilities clear binds.
- The whole boolean on line 138 is then false, meaning the method doesn't return false if they're different multiabilities
- So it defaults to returning true. Therefore WaterArms is the same ability as PlantArmor, which is problematic for addons

The solution is to get rid of the second part of that boolean. Been using this on my server for a while, but figured I would PR because it's causing others issues.
