### PR TITLE
Modified some methods to ensure closing queries

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -166,7 +167,7 @@ public class GeneralMethods {
 
 	/**
 	 * Checks to see if an AbilityExists. Uses method
-	 * {@link #getAbility(String)} to check if it exists.
+	 * {@link CoreAbility#getAbility(String)} to check if it exists.
 	 *
 	 * @param string Ability Name
 	 * @return true if ability exists
@@ -335,219 +336,219 @@ public class GeneralMethods {
 	}
 
 	private static void createBendingPlayerAsynchronously(final UUID uuid, final String player) {
-		DBConnection.sql.readQuery("SELECT * FROM pk_players WHERE uuid = '" + uuid.toString() + "'",
-				(rs2) -> {
-					try {
-						if (!rs2.next()) { // Data doesn't exist, we want a completely new player.
-							DBConnection.sql.modifyQuery("INSERT INTO pk_players (uuid, player, slot1, slot2, slot3, slot4, slot5, slot6, slot7, slot8, slot9) VALUES ('" + uuid.toString() + "', '" + player + "', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null')");
-							new BukkitRunnable() {
-								@Override
-								public void run() {
-									new BendingPlayer(uuid, player, new ArrayList<Element>(), new ArrayList<SubElement>(), new HashMap<Integer, String>(), false);
-									ProjectKorra.log.info("Created new BendingPlayer for " + player);
-								}
-							}.runTask(ProjectKorra.plugin);
-						} else {
-							// The player has at least played before.
-							final String player2 = rs2.getString("player");
-							if (!player.equalsIgnoreCase(player2)) {
-								DBConnection.sql.modifyQuery("UPDATE pk_players SET player = '" + player + "' WHERE uuid = '" + uuid.toString() + "'");
-								// They have changed names.
-								ProjectKorra.log.info("Updating Player Name for " + player);
-							}
-							final String subelement = rs2.getString("subelement");
-							final String element = rs2.getString("element");
-							final String permaremoved = rs2.getString("permaremoved");
-							boolean p = false;
-							final ArrayList<Element> elements = new ArrayList<Element>();
-							if (element != null && !element.equals("NULL")) {
-								final boolean hasAddon = element.contains(";");
-								final String[] split = element.split(";");
-								if (split[0] != null) { // Player has an element.
-									if (split[0].contains("a")) {
-										elements.add(Element.AIR);
-									}
-									if (split[0].contains("w")) {
-										elements.add(Element.WATER);
-									}
-									if (split[0].contains("e")) {
-										elements.add(Element.EARTH);
-									}
-									if (split[0].contains("f")) {
-										elements.add(Element.FIRE);
-									}
-									if (split[0].contains("c")) {
-										elements.add(Element.CHI);
-									}
-									if (hasAddon) {
-										/*
-										 * Because plugins which depend on ProjectKorra
-										 * would be loaded after ProjectKorra, addon
-										 * elements would = null. To work around this, we
-										 * keep trying to load in the elements from the
-										 * database until it successfully loads everything
-										 * in, or it times out.
-										 */
-										final CopyOnWriteArrayList<String> addonClone = new CopyOnWriteArrayList<String>(Arrays.asList(split[split.length - 1].split(",")));
-										final long startTime = System.currentTimeMillis();
-										final long timeoutLength = 30000; // How long until it should time out attempting to load addons in.
-										new BukkitRunnable() {
-											@Override
-											public void run() {
-												if (addonClone.isEmpty()) {
-													ProjectKorra.log.info("Successfully loaded in all addon elements!");
-													this.cancel();
-												} else if (System.currentTimeMillis() - startTime > timeoutLength) {
-													ProjectKorra.log.severe("ProjectKorra has timed out after attempting to load in the following addon elements: " + addonClone.toString());
-													ProjectKorra.log.severe("These elements have taken too long to load in, resulting in users having lost these element.");
-													this.cancel();
-												} else {
-													ProjectKorra.log.info("Attempting to load in the following addon elements... " + addonClone.toString());
-													for (final String addon : addonClone) {
-														if (Element.getElement(addon) != null) {
-															elements.add(Element.getElement(addon));
-															addonClone.remove(addon);
-														}
-													}
-												}
-											}
-										}.runTaskTimer(ProjectKorra.plugin, 0, 20);
-									}
-								}
-							}
-							final ArrayList<SubElement> subelements = new ArrayList<SubElement>();
-							boolean shouldSave = false;
-							if (subelement != null && !subelement.equals("NULL")) {
-								final boolean hasAddon = subelement.contains(";");
-								final String[] split = subelement.split(";");
-								if (subelement.equals("-")) {
-									final Player playero = Bukkit.getPlayer(uuid);
-									for (final SubElement sub : Element.getAllSubElements()) {
-										if ((playero != null && playero.hasPermission("bending." + sub.getParentElement().getName().toLowerCase() + "." + sub.getName().toLowerCase() + sub.getType().getBending())) && elements.contains(sub.getParentElement())) {
-											subelements.add(sub);
-											shouldSave = true && playero != null;
-										}
-									}
-								} else if (split[0] != null) {
-									if (split[0].contains("m")) {
-										subelements.add(Element.METAL);
-									}
-									if (split[0].contains("v")) {
-										subelements.add(Element.LAVA);
-									}
-									if (split[0].contains("s")) {
-										subelements.add(Element.SAND);
-									}
-									if (split[0].contains("c")) {
-										subelements.add(Element.COMBUSTION);
-									}
-									if (split[0].contains("l")) {
-										subelements.add(Element.LIGHTNING);
-									}
-									if (split[0].contains("t")) {
-										subelements.add(Element.SPIRITUAL);
-									}
-									if (split[0].contains("f")) {
-										subelements.add(Element.FLIGHT);
-									}
-									if (split[0].contains("i")) {
-										subelements.add(Element.ICE);
-									}
-									if (split[0].contains("h")) {
-										subelements.add(Element.HEALING);
-									}
-									if (split[0].contains("b")) {
-										subelements.add(Element.BLOOD);
-									}
-									if (split[0].contains("p")) {
-										subelements.add(Element.PLANT);
-									}
-									if (split[0].contains("r")) {
-										subelements.add(Element.BLUE_FIRE);
-									}
-
-									if (hasAddon) {
-										final CopyOnWriteArrayList<String> addonClone = new CopyOnWriteArrayList<String>(Arrays.asList(split[split.length - 1].split(",")));
-										final long startTime = System.currentTimeMillis();
-										final long timeoutLength = 30000; // How long until it should time out attempting to load addons in.
-										new BukkitRunnable() {
-											@Override
-											public void run() {
-												if (addonClone.isEmpty()) {
-													ProjectKorra.log.info("Successfully loaded in all addon subelements!");
-													this.cancel();
-												} else if (System.currentTimeMillis() - startTime > timeoutLength) {
-													ProjectKorra.log.severe("ProjectKorra has timed out after attempting to load in the following addon subelements: " + addonClone.toString());
-													ProjectKorra.log.severe("These subelements have taken too long to load in, resulting in users having lost these subelement.");
-													this.cancel();
-												} else {
-													ProjectKorra.log.info("Attempting to load in the following addon subelements... " + addonClone.toString());
-													for (final String addon : addonClone) {
-														if (Element.getElement(addon) != null && Element.getElement(addon) instanceof SubElement) {
-															subelements.add((SubElement) Element.getElement(addon));
-															addonClone.remove(addon);
-														}
-													}
-												}
-											}
-										}.runTaskTimer(ProjectKorra.plugin, 0, 20);
-									}
-								}
-							}
-
-							final HashMap<Integer, String> abilities = new HashMap<Integer, String>();
-							final ConcurrentHashMap<Integer, String> abilitiesClone = new ConcurrentHashMap<Integer, String>(abilities);
-							for (int i = 1; i <= 9; i++) {
-								final String ability = rs2.getString("slot" + i);
-								abilitiesClone.put(i, ability);
-							}
+		final ResultSet rs2 = DBConnection.sql.readQuery("SELECT * FROM pk_players WHERE uuid = '" + uuid.toString() + "'");
+		try {
+			if (!rs2.next()) { // Data doesn't exist, we want a completely new player.
+				DBConnection.sql.modifyQuery("INSERT INTO pk_players (uuid, player, slot1, slot2, slot3, slot4, slot5, slot6, slot7, slot8, slot9) VALUES ('" + uuid.toString() + "', '" + player + "', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null')");
+				new BukkitRunnable() {
+					@Override
+					public void run() {
+						new BendingPlayer(uuid, player, new ArrayList<Element>(), new ArrayList<SubElement>(), new HashMap<Integer, String>(), false);
+						ProjectKorra.log.info("Created new BendingPlayer for " + player);
+					}
+				}.runTask(ProjectKorra.plugin);
+			} else {
+				// The player has at least played before.
+				final String player2 = rs2.getString("player");
+				if (!player.equalsIgnoreCase(player2)) {
+					DBConnection.sql.modifyQuery("UPDATE pk_players SET player = '" + player + "' WHERE uuid = '" + uuid.toString() + "'");
+					// They have changed names.
+					ProjectKorra.log.info("Updating Player Name for " + player);
+				}
+				final String subelement = rs2.getString("subelement");
+				final String element = rs2.getString("element");
+				final String permaremoved = rs2.getString("permaremoved");
+				boolean p = false;
+				final ArrayList<Element> elements = new ArrayList<Element>();
+				if (element != null && !element.equals("NULL")) {
+					final boolean hasAddon = element.contains(";");
+					final String[] split = element.split(";");
+					if (split[0] != null) { // Player has an element.
+						if (split[0].contains("a")) {
+							elements.add(Element.AIR);
+						}
+						if (split[0].contains("w")) {
+							elements.add(Element.WATER);
+						}
+						if (split[0].contains("e")) {
+							elements.add(Element.EARTH);
+						}
+						if (split[0].contains("f")) {
+							elements.add(Element.FIRE);
+						}
+						if (split[0].contains("c")) {
+							elements.add(Element.CHI);
+						}
+						if (hasAddon) {
+							/*
+							 * Because plugins which depend on ProjectKorra
+							 * would be loaded after ProjectKorra, addon
+							 * elements would = null. To work around this, we
+							 * keep trying to load in the elements from the
+							 * database until it successfully loads everything
+							 * in, or it times out.
+							 */
+							final CopyOnWriteArrayList<String> addonClone = new CopyOnWriteArrayList<String>(Arrays.asList(split[split.length - 1].split(",")));
 							final long startTime = System.currentTimeMillis();
 							final long timeoutLength = 30000; // How long until it should time out attempting to load addons in.
 							new BukkitRunnable() {
 								@Override
 								public void run() {
-									if (abilitiesClone.isEmpty()) {
-										// All abilities loaded.
+									if (addonClone.isEmpty()) {
+										ProjectKorra.log.info("Successfully loaded in all addon elements!");
 										this.cancel();
 									} else if (System.currentTimeMillis() - startTime > timeoutLength) {
-										ProjectKorra.log.severe("ProjectKorra has timed out after attempting to load in the following external abilities: " + abilitiesClone.values().toString());
-										ProjectKorra.log.severe("These abilities have taken too long to load in, resulting in users having lost them if bound.");
+										ProjectKorra.log.severe("ProjectKorra has timed out after attempting to load in the following addon elements: " + addonClone.toString());
+										ProjectKorra.log.severe("These elements have taken too long to load in, resulting in users having lost these element.");
 										this.cancel();
 									} else {
-										for (final int slot : abilitiesClone.keySet()) {
-											final String ability = abilitiesClone.get(slot);
-											if (ability.equalsIgnoreCase("null")) {
-												abilitiesClone.remove(slot);
-												continue;
-											} else if (CoreAbility.getAbility(ability) != null && CoreAbility.getAbility(ability).isEnabled()) {
-												abilities.put(slot, ability);
-												abilitiesClone.remove(slot);
-												continue;
+										ProjectKorra.log.info("Attempting to load in the following addon elements... " + addonClone.toString());
+										for (final String addon : addonClone) {
+											if (Element.getElement(addon) != null) {
+												elements.add(Element.getElement(addon));
+												addonClone.remove(addon);
 											}
 										}
 									}
 								}
 							}.runTaskTimer(ProjectKorra.plugin, 0, 20);
+						}
+					}
+				}
+				final ArrayList<SubElement> subelements = new ArrayList<SubElement>();
+				boolean shouldSave = false;
+				if (subelement != null && !subelement.equals("NULL")) {
+					final boolean hasAddon = subelement.contains(";");
+					final String[] split = subelement.split(";");
+					if (subelement.equals("-")) {
+						final Player playero = Bukkit.getPlayer(uuid);
+						for (final SubElement sub : Element.getAllSubElements()) {
+							if ((playero != null && playero.hasPermission("bending." + sub.getParentElement().getName().toLowerCase() + "." + sub.getName().toLowerCase() + sub.getType().getBending())) && elements.contains(sub.getParentElement())) {
+								subelements.add(sub);
+								shouldSave = true && playero != null;
+							}
+						}
+					} else if (split[0] != null) {
+						if (split[0].contains("m")) {
+							subelements.add(Element.METAL);
+						}
+						if (split[0].contains("v")) {
+							subelements.add(Element.LAVA);
+						}
+						if (split[0].contains("s")) {
+							subelements.add(Element.SAND);
+						}
+						if (split[0].contains("c")) {
+							subelements.add(Element.COMBUSTION);
+						}
+						if (split[0].contains("l")) {
+							subelements.add(Element.LIGHTNING);
+						}
+						if (split[0].contains("t")) {
+							subelements.add(Element.SPIRITUAL);
+						}
+						if (split[0].contains("f")) {
+							subelements.add(Element.FLIGHT);
+						}
+						if (split[0].contains("i")) {
+							subelements.add(Element.ICE);
+						}
+						if (split[0].contains("h")) {
+							subelements.add(Element.HEALING);
+						}
+						if (split[0].contains("b")) {
+							subelements.add(Element.BLOOD);
+						}
+						if (split[0].contains("p")) {
+							subelements.add(Element.PLANT);
+						}
+						if (split[0].contains("r")) {
+							subelements.add(Element.BLUE_FIRE);
+						}
 
-							p = (permaremoved != null && (permaremoved.equals("true")));
-
-							final boolean boolean_p = p;
-							final boolean shouldSave_ = shouldSave;
+						if (hasAddon) {
+							final CopyOnWriteArrayList<String> addonClone = new CopyOnWriteArrayList<String>(Arrays.asList(split[split.length - 1].split(",")));
+							final long startTime = System.currentTimeMillis();
+							final long timeoutLength = 30000; // How long until it should time out attempting to load addons in.
 							new BukkitRunnable() {
 								@Override
 								public void run() {
-									new BendingPlayer(uuid, player, elements, subelements, abilities, boolean_p);
-									if (shouldSave_) {
-										saveSubElements(BendingPlayer.getBendingPlayer(player));
+									if (addonClone.isEmpty()) {
+										ProjectKorra.log.info("Successfully loaded in all addon subelements!");
+										this.cancel();
+									} else if (System.currentTimeMillis() - startTime > timeoutLength) {
+										ProjectKorra.log.severe("ProjectKorra has timed out after attempting to load in the following addon subelements: " + addonClone.toString());
+										ProjectKorra.log.severe("These subelements have taken too long to load in, resulting in users having lost these subelement.");
+										this.cancel();
+									} else {
+										ProjectKorra.log.info("Attempting to load in the following addon subelements... " + addonClone.toString());
+										for (final String addon : addonClone) {
+											if (Element.getElement(addon) != null && Element.getElement(addon) instanceof SubElement) {
+												subelements.add((SubElement) Element.getElement(addon));
+												addonClone.remove(addon);
+											}
+										}
 									}
 								}
-							}.runTask(ProjectKorra.plugin);
+							}.runTaskTimer(ProjectKorra.plugin, 0, 20);
 						}
-					} catch (final SQLException ex) {
-						ex.printStackTrace();
 					}
-					return true;
-				});
+				}
+
+				final HashMap<Integer, String> abilities = new HashMap<Integer, String>();
+				final ConcurrentHashMap<Integer, String> abilitiesClone = new ConcurrentHashMap<Integer, String>(abilities);
+				for (int i = 1; i <= 9; i++) {
+					final String ability = rs2.getString("slot" + i);
+					abilitiesClone.put(i, ability);
+				}
+				final long startTime = System.currentTimeMillis();
+				final long timeoutLength = 30000; // How long until it should time out attempting to load addons in.
+				new BukkitRunnable() {
+					@Override
+					public void run() {
+						if (abilitiesClone.isEmpty()) {
+							// All abilities loaded.
+							this.cancel();
+						} else if (System.currentTimeMillis() - startTime > timeoutLength) {
+							ProjectKorra.log.severe("ProjectKorra has timed out after attempting to load in the following external abilities: " + abilitiesClone.values().toString());
+							ProjectKorra.log.severe("These abilities have taken too long to load in, resulting in users having lost them if bound.");
+							this.cancel();
+						} else {
+							for (final int slot : abilitiesClone.keySet()) {
+								final String ability = abilitiesClone.get(slot);
+								if (ability.equalsIgnoreCase("null")) {
+									abilitiesClone.remove(slot);
+									continue;
+								} else if (CoreAbility.getAbility(ability) != null && CoreAbility.getAbility(ability).isEnabled()) {
+									abilities.put(slot, ability);
+									abilitiesClone.remove(slot);
+									continue;
+								}
+							}
+						}
+					}
+				}.runTaskTimer(ProjectKorra.plugin, 0, 20);
+
+				p = (permaremoved != null && (permaremoved.equals("true")));
+
+				final boolean boolean_p = p;
+				final boolean shouldSave_ = shouldSave;
+				new BukkitRunnable() {
+					@Override
+					public void run() {
+						new BendingPlayer(uuid, player, elements, subelements, abilities, boolean_p);
+						if (shouldSave_) {
+							saveSubElements(BendingPlayer.getBendingPlayer(player));
+						}
+					}
+				}.runTask(ProjectKorra.plugin);
+			}
+			Statement stmt = rs2.getStatement();
+			rs2.close();
+			stmt.close();
+		} catch (final SQLException ex) {
+			ex.printStackTrace();
+		}
 	}
 
 	/**
@@ -562,7 +563,7 @@ public class GeneralMethods {
 		if (readFile.exists()) {
 			try (DataInputStream input = new DataInputStream(new FileInputStream(readFile)); BufferedReader reader = new BufferedReader(new InputStreamReader(input));
 
-					DataOutputStream output = new DataOutputStream(new FileOutputStream(writeFile)); BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output))) {
+				 DataOutputStream output = new DataOutputStream(new FileOutputStream(writeFile)); BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(output))) {
 
 				String line;
 				while ((line = reader.readLine()) != null) {
@@ -1766,7 +1767,7 @@ public class GeneralMethods {
 	}
 
 	public static boolean isWeapon(final Material mat) {
-	
+
 		switch(mat) {
 			case BOW:
 			case CROSSBOW:

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -151,13 +151,16 @@ public class BendingBoardManager {
 	 */
 	public static void loadDisabledPlayers() {
 		Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, () -> {
-			Set<UUID> disabled = new HashSet<>();
-			try {
-				final ResultSet rs = DBConnection.sql.readQuery("SELECT uuid FROM pk_board where enabled = 0");
-				while (rs.next()) disabled.add(UUID.fromString(rs.getString("uuid")));
-			} catch (SQLException e) {
-				e.printStackTrace();
-			}
+			final Set<UUID> disabled = new HashSet<>();
+			DBConnection.sql.readQuery("SELECT uuid FROM pk_board where enabled = 0",
+					(rs) -> {
+						try {
+							while (rs.next()) disabled.add(UUID.fromString(rs.getString("uuid")));
+						} catch (SQLException e) {
+							e.printStackTrace();
+						}
+						return null;
+					});
 			disabledPlayers.clear();
 			disabledPlayers.addAll(disabled);
 		});

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -151,16 +152,16 @@ public class BendingBoardManager {
 	 */
 	public static void loadDisabledPlayers() {
 		Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, () -> {
-			final Set<UUID> disabled = new HashSet<>();
-			DBConnection.sql.readQuery("SELECT uuid FROM pk_board where enabled = 0",
-					(rs) -> {
-						try {
-							while (rs.next()) disabled.add(UUID.fromString(rs.getString("uuid")));
-						} catch (SQLException e) {
-							e.printStackTrace();
-						}
-						return null;
-					});
+			Set<UUID> disabled = new HashSet<>();
+			try {
+				final ResultSet rs = DBConnection.sql.readQuery("SELECT uuid FROM pk_board where enabled = 0");
+				while (rs.next()) disabled.add(UUID.fromString(rs.getString("uuid")));
+				Statement stmt = rs.getStatement();
+				rs.close();
+				stmt.close();
+			} catch (SQLException e) {
+				e.printStackTrace();
+			}
 			disabledPlayers.clear();
 			disabledPlayers.addAll(disabled);
 		});

--- a/src/com/projectkorra/projectkorra/command/StatsCommand.java
+++ b/src/com/projectkorra/projectkorra/command/StatsCommand.java
@@ -184,22 +184,26 @@ public class StatsCommand extends PKCommand {
 
 	public List<UUID> pullUUIDs(final Statistic statistic, final Object object) {
 		final Set<UUID> uuids = new HashSet<>();
-		try (ResultSet rs = DBConnection.sql.readQuery("SELECT uuid FROM pk_stats")) {
-			while (rs.next()) {
-				final UUID uuid = UUID.fromString(rs.getString("uuid"));
-				if (object == null) {
-					if (StatisticsMethods.getStatisticTotal(uuid, statistic) > 0) {
-						uuids.add(uuid);
+		DBConnection.sql.readQuery("SELECT uuid FROM pk_stats",
+				(rs) -> {
+					try {
+						while (rs.next()) {
+							final UUID uuid = UUID.fromString(rs.getString("uuid"));
+							if (object == null) {
+								if (StatisticsMethods.getStatisticTotal(uuid, statistic) > 0) {
+									uuids.add(uuid);
+								}
+							} else {
+								if (StatisticsMethods.getStatistic(uuid, object, statistic) > 0) {
+									uuids.add(uuid);
+								}
+							}
+						}
+					} catch (final SQLException e) {
+						e.printStackTrace();
 					}
-				} else {
-					if (StatisticsMethods.getStatistic(uuid, object, statistic) > 0) {
-						uuids.add(uuid);
-					}
-				}
-			}
-		} catch (final SQLException e) {
-			e.printStackTrace();
-		}
+					return null;
+				});
 		for (final Player player : ProjectKorra.plugin.getServer().getOnlinePlayers()) {
 			final UUID uuid = player.getUniqueId();
 			if (object == null) {

--- a/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/src/com/projectkorra/projectkorra/storage/Database.java
@@ -5,6 +5,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.function.Function;
 import java.util.logging.Logger;
 
 import org.bukkit.scheduler.BukkitRunnable;
@@ -114,15 +115,17 @@ public abstract class Database {
 	 * @param query Query to run
 	 * @return Result set of ran query
 	 */
-	public ResultSet readQuery(final String query) {
+	public Object readQuery(final String query, Function<ResultSet, Object> func) {
 		try {
 			if (this.connection == null || this.connection.isClosed()) {
 				this.open();
 			}
 			final PreparedStatement stmt = this.connection.prepareStatement(query);
 			final ResultSet rs = stmt.executeQuery();
-
-			return rs;
+			Object res = func.apply(rs);
+			rs.close();
+			stmt.close();
+			return res;
 		} catch (final SQLException e) {
 			e.printStackTrace();
 			return null;
@@ -143,7 +146,9 @@ public abstract class Database {
 			final DatabaseMetaData dmd = this.connection.getMetaData();
 			final ResultSet rs = dmd.getTables(null, null, table, null);
 
-			return rs.next();
+			boolean result = rs.next();
+			rs.close();
+			return result;
 		} catch (final Exception e) {
 			e.printStackTrace();
 			return false;
@@ -164,7 +169,9 @@ public abstract class Database {
 			}
 			final DatabaseMetaData dmd = this.connection.getMetaData();
 			final ResultSet rs = dmd.getColumns(null, null, table, column);
-			return rs.next();
+			boolean result = rs.next();
+			rs.close();
+			return result;
 		} catch (final Exception e) {
 			e.printStackTrace();
 			return false;

--- a/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/src/com/projectkorra/projectkorra/storage/Database.java
@@ -115,17 +115,14 @@ public abstract class Database {
 	 * @param query Query to run
 	 * @return Result set of ran query
 	 */
-	public Object readQuery(final String query, Function<ResultSet, Object> func) {
+	public ResultSet readQuery(final String query) {
 		try {
 			if (this.connection == null || this.connection.isClosed()) {
 				this.open();
 			}
 			final PreparedStatement stmt = this.connection.prepareStatement(query);
 			final ResultSet rs = stmt.executeQuery();
-			Object res = func.apply(rs);
-			rs.close();
-			stmt.close();
-			return res;
+			return rs;
 		} catch (final SQLException e) {
 			e.printStackTrace();
 			return null;

--- a/src/com/projectkorra/projectkorra/storage/SQLite.java
+++ b/src/com/projectkorra/projectkorra/storage/SQLite.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Properties;
 import java.util.logging.Logger;
 
 public class SQLite extends Database {
@@ -28,10 +29,12 @@ public class SQLite extends Database {
 	@Override
 	public Connection open() {
 		try {
-			Class.forName("org.sqlite.JDBC");
+			if (this.connection == null || this.connection.isClosed()) {
+				Class.forName("org.sqlite.JDBC");
 
-			this.connection = DriverManager.getConnection("jdbc:sqlite:" + this.SQLfile.getAbsolutePath());
-			this.printInfo("Connection established!");
+				this.connection = DriverManager.getConnection("jdbc:sqlite:" + this.SQLfile.getAbsolutePath());
+				this.printInfo("Connection established!");
+			}
 
 			return this.connection;
 		} catch (final ClassNotFoundException e) {

--- a/src/com/projectkorra/projectkorra/storage/SQLite.java
+++ b/src/com/projectkorra/projectkorra/storage/SQLite.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Properties;
 import java.util.logging.Logger;
 
 public class SQLite extends Database {

--- a/src/com/projectkorra/projectkorra/util/DBCooldownManager.java
+++ b/src/com/projectkorra/projectkorra/util/DBCooldownManager.java
@@ -39,28 +39,36 @@ public class DBCooldownManager extends Manager {
 	}
 
 	public int getCooldownId(final String cooldown, final boolean async) {
-		try (ResultSet rs = DBConnection.sql.readQuery("SELECT id FROM pk_cooldown_ids WHERE cooldown_name = '" + cooldown + "'")) {
-			if (rs.next()) {
-				return rs.getInt("id");
-			} else {
-				DBConnection.sql.modifyQuery("INSERT INTO pk_cooldown_ids (cooldown_name) VALUES ('" + cooldown + "')", async);
-				return this.getCooldownId(cooldown, async);
-			}
-		} catch (final SQLException e) {
-			e.printStackTrace();
-		}
-		return -1;
+		int res = (int) DBConnection.sql.readQuery("SELECT id FROM pk_cooldown_ids WHERE cooldown_name = '" + cooldown + "'",
+				(rs) -> {
+					try {
+						if (rs.next()) {
+							return rs.getInt("id");
+						} else {
+							DBConnection.sql.modifyQuery("INSERT INTO pk_cooldown_ids (cooldown_name) VALUES ('" + cooldown + "')", async);
+							return this.getCooldownId(cooldown, async);
+						}
+					} catch (final SQLException e) {
+						e.printStackTrace();
+					}
+					return -1;
+				});
+		return res;
 	}
 
 	public String getCooldownName(final int id) {
-		try (ResultSet rs = DBConnection.sql.readQuery("SELECT cooldown_name FROM pk_cooldown_ids WHERE id = " + id)) {
-			if (rs.next()) {
-				return rs.getString("cooldown_name");
-			}
-		} catch (final SQLException e) {
-			e.printStackTrace();
-		}
-		return "";
+		String res = (String) DBConnection.sql.readQuery("SELECT cooldown_name FROM pk_cooldown_ids WHERE id = " + id,
+				(rs) -> {
+					try {
+						if (rs.next()) {
+							return rs.getString("cooldown_name");
+						}
+					} catch (final SQLException e) {
+						e.printStackTrace();
+					}
+					return "";
+				});
+		return res;
 	}
 
 }

--- a/src/com/projectkorra/projectkorra/util/DBCooldownManager.java
+++ b/src/com/projectkorra/projectkorra/util/DBCooldownManager.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.util;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import com.projectkorra.projectkorra.Manager;
 import com.projectkorra.projectkorra.ProjectKorra;
@@ -39,36 +40,48 @@ public class DBCooldownManager extends Manager {
 	}
 
 	public int getCooldownId(final String cooldown, final boolean async) {
-		int res = (int) DBConnection.sql.readQuery("SELECT id FROM pk_cooldown_ids WHERE cooldown_name = '" + cooldown + "'",
-				(rs) -> {
-					try {
-						if (rs.next()) {
-							return rs.getInt("id");
-						} else {
-							DBConnection.sql.modifyQuery("INSERT INTO pk_cooldown_ids (cooldown_name) VALUES ('" + cooldown + "')", async);
-							return this.getCooldownId(cooldown, async);
-						}
-					} catch (final SQLException e) {
-						e.printStackTrace();
-					}
-					return -1;
-				});
-		return res;
+		int id = -1;
+		Statement stmt = null;
+		try (ResultSet rs = DBConnection.sql.readQuery("SELECT id FROM pk_cooldown_ids WHERE cooldown_name = '" + cooldown + "'")) {
+			if (rs.next()) {
+				id = rs.getInt("id");
+			} else {
+				DBConnection.sql.modifyQuery("INSERT INTO pk_cooldown_ids (cooldown_name) VALUES ('" + cooldown + "')", async);
+				id = this.getCooldownId(cooldown, async);
+			}
+			stmt = rs.getStatement();
+		} catch (final SQLException e) {
+			e.printStackTrace();
+		}
+		if (stmt != null) {
+			try {
+				stmt.close();
+			} catch (final SQLException e) {
+				e.printStackTrace();
+			}
+		}
+		return id;
 	}
 
 	public String getCooldownName(final int id) {
-		String res = (String) DBConnection.sql.readQuery("SELECT cooldown_name FROM pk_cooldown_ids WHERE id = " + id,
-				(rs) -> {
-					try {
-						if (rs.next()) {
-							return rs.getString("cooldown_name");
-						}
-					} catch (final SQLException e) {
-						e.printStackTrace();
-					}
-					return "";
-				});
-		return res;
+		String name = "";
+		Statement stmt = null;
+		try (ResultSet rs = DBConnection.sql.readQuery("SELECT cooldown_name FROM pk_cooldown_ids WHERE id = " + id)) {
+			if (rs.next()) {
+				name = rs.getString("cooldown_name");
+			}
+			stmt = rs.getStatement();
+		} catch (final SQLException e) {
+			e.printStackTrace();
+		}
+		if (stmt != null) {
+			try {
+				stmt.close();
+			} catch (final SQLException e) {
+				e.printStackTrace();
+			}
+		}
+		return name;
 	}
 
 }

--- a/src/com/projectkorra/projectkorra/util/StatisticsManager.java
+++ b/src/com/projectkorra/projectkorra/util/StatisticsManager.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.util;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -85,49 +86,54 @@ public class StatisticsManager extends Manager implements Runnable {
 			}
 			for (final Statistic statistic : Statistic.values()) {
 				final String statName = statistic.getStatisticName(ability);
-				DBConnection.sql.readQuery("SELECT * FROM pk_statKeys WHERE statName = '" + statName + "'",
-						(rs) -> {
-							try {
-								if (!rs.next()) {
-									DBConnection.sql.modifyQuery("INSERT INTO pk_statKeys (statName) VALUES ('" + statName + "')", false);
-								}
-							} catch (final SQLException e) {
-								e.printStackTrace();
-							}
-							return null;
-						});
+				final ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_statKeys WHERE statName = '" + statName + "'");
+				try {
+					if (!rs.next()) {
+						DBConnection.sql.modifyQuery("INSERT INTO pk_statKeys (statName) VALUES ('" + statName + "')", false);
+					}
+					Statement stmt = rs.getStatement();
+					rs.close();
+					stmt.close();
+				} catch (final SQLException e) {
+					e.printStackTrace();
+				}
 			}
 		}
 		// Populate Keys Map with all loaded statName(s) in pk_statKeys.
-		DBConnection.sql.readQuery("SELECT * FROM pk_statKeys",
-				(rs) -> {
-					try {
-						while (rs.next()) {
-							this.KEYS_BY_NAME.put(rs.getString("statName"), rs.getInt("id"));
-							this.KEYS_BY_ID.put(rs.getInt("id"), rs.getString("statName"));
-						}
-					} catch (final SQLException e) {
-						e.printStackTrace();
-					}
-					return null;
-				});
+		final ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_statKeys");
+		try {
+			while (rs.next()) {
+				this.KEYS_BY_NAME.put(rs.getString("statName"), rs.getInt("id"));
+				this.KEYS_BY_ID.put(rs.getInt("id"), rs.getString("statName"));
+			}
+			Statement stmt = rs.getStatement();
+			rs.close();
+			stmt.close();
+		} catch (final SQLException e) {
+			e.printStackTrace();
+		}
 	}
 
 	public void load(final UUID uuid) {
 		this.STATISTICS.put(uuid, new HashMap<>());
 		this.DELTA.put(uuid, new HashMap<>());
-		DBConnection.sql.readQuery("SELECT * FROM pk_stats WHERE uuid = '" + uuid.toString() + "'",
-				(rs) -> {
-					try {
-						while (rs.next()) {
-							this.STATISTICS.get(uuid).put(rs.getInt("statId"), rs.getLong("statValue"));
-							this.DELTA.get(uuid).put(rs.getInt("statId"), 0L);
-						}
-					} catch (final SQLException e) {
-						e.printStackTrace();
-					}
-					return null;
-				});
+		Statement stmt = null;
+		try (ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_stats WHERE uuid = '" + uuid.toString() + "'")) {
+			while (rs.next()) {
+				this.STATISTICS.get(uuid).put(rs.getInt("statId"), rs.getLong("statValue"));
+				this.DELTA.get(uuid).put(rs.getInt("statId"), 0L);
+			}
+			stmt = rs.getStatement();
+		} catch (final SQLException e) {
+			e.printStackTrace();
+		}
+		if (stmt != null) {
+			try {
+				stmt.close();
+			} catch (final SQLException e) {
+				e.printStackTrace();
+			}
+		}
 	}
 
 	public void save(final UUID uuid, final boolean async) {
@@ -138,19 +144,24 @@ public class StatisticsManager extends Manager implements Runnable {
 		for (final Entry<Integer, Long> entry : stats.entrySet()) {
 			final int statId = entry.getKey();
 			final long statValue = entry.getValue();
-			DBConnection.sql.readQuery("SELECT * FROM pk_stats WHERE uuid = '" + uuid.toString() + "' AND statId = " + statId,
-					(rs) -> {
-						try {
-							if (!rs.next()) {
-								DBConnection.sql.modifyQuery("INSERT INTO pk_stats (statId, uuid, statValue) VALUES (" + statId + ", '" + uuid.toString() + "', " + statValue + ")", async);
-							} else {
-								DBConnection.sql.modifyQuery("UPDATE pk_stats SET statValue = statValue + " + statValue + " WHERE uuid = '" + uuid.toString() + "' AND statId = " + statId + ";", async);
-							}
-						} catch (final SQLException e) {
-							e.printStackTrace();
-						}
-						return null;
-					});
+			Statement stmt = null;
+			try (ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_stats WHERE uuid = '" + uuid.toString() + "' AND statId = " + statId)) {
+				if (!rs.next()) {
+					DBConnection.sql.modifyQuery("INSERT INTO pk_stats (statId, uuid, statValue) VALUES (" + statId + ", '" + uuid.toString() + "', " + statValue + ")", async);
+				} else {
+					DBConnection.sql.modifyQuery("UPDATE pk_stats SET statValue = statValue + " + statValue + " WHERE uuid = '" + uuid.toString() + "' AND statId = " + statId + ";", async);
+				}
+				stmt = rs.getStatement();
+			} catch (final SQLException e) {
+				e.printStackTrace();
+			}
+			if (stmt != null) {
+				try {
+					stmt.close();
+				} catch (final SQLException e) {
+					e.printStackTrace();
+				}
+			}
 		}
 	}
 
@@ -167,18 +178,24 @@ public class StatisticsManager extends Manager implements Runnable {
 	public long getStatisticCurrent(final UUID uuid, final int statId) {
 		// If the player is offline, pull value from database.
 		if (!this.STATISTICS.containsKey(uuid)) {
-			long res = (long) DBConnection.sql.readQuery("SELECT statValue FROM pk_stats WHERE uuid = '" + uuid.toString() + "' AND statId = " + statId + ";",
-					(rs) -> {
-						try {
-							if (rs.next()) {
-								return rs.getLong("statValue");
-							}
-						} catch (final SQLException e) {
-							e.printStackTrace();
-						}
-						return 0;
-					});
-			return res;
+			Statement stmt = null;
+			long count = 0;
+			try (ResultSet rs = DBConnection.sql.readQuery("SELECT statValue FROM pk_stats WHERE uuid = '" + uuid.toString() + "' AND statId = " + statId + ";")) {
+				if (rs.next()) {
+					count = rs.getLong("statValue");
+				}
+				stmt = rs.getStatement();
+			} catch (final SQLException e) {
+				e.printStackTrace();
+			}
+			if (stmt != null) {
+				try {
+					stmt.close();
+				} catch (final SQLException e) {
+					e.printStackTrace();
+				}
+			}
+			return count;
 		} else if (!this.STATISTICS.get(uuid).containsKey(statId)) {
 			return 0;
 		}
@@ -195,22 +212,27 @@ public class StatisticsManager extends Manager implements Runnable {
 	}
 
 	public Map<Integer, Long> getStatisticsMap(final UUID uuid) {
+		final Map<Integer, Long> map = new HashMap<>();
 		// If the player is offline, create a new temporary Map from the database.
 		if (!this.STATISTICS.containsKey(uuid)) {
-			final Map<Integer, Long> map = new HashMap<>();
-			DBConnection.sql.readQuery("SELECT * FROM pk_stats WHERE uuid = '" + uuid.toString() + "'",
-					(rs) -> {
-						try {
-							while (rs.next()) {
-								final int statId = rs.getInt("statId");
-								final long statValue = rs.getLong("statValue");
-								map.put(statId, statValue);
-							}
-						} catch (final SQLException e) {
-							e.printStackTrace();
-						}
-						return null;
-					});
+			Statement stmt = null;
+			try (ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_stats WHERE uuid = '" + uuid.toString() + "'")) {
+				while (rs.next()) {
+					final int statId = rs.getInt("statId");
+					final long statValue = rs.getLong("statValue");
+					map.put(statId, statValue);
+				}
+				stmt = rs.getStatement();
+			} catch (final SQLException e) {
+				e.printStackTrace();
+			}
+			if (stmt != null) {
+				try {
+					stmt.close();
+				} catch (final SQLException e) {
+					e.printStackTrace();
+				}
+			}
 			return map;
 		}
 		return this.STATISTICS.get(uuid);

--- a/src/com/projectkorra/projectkorra/util/StatisticsMethods.java
+++ b/src/com/projectkorra/projectkorra/util/StatisticsMethods.java
@@ -172,16 +172,20 @@ public class StatisticsMethods {
 		}
 		if (!Manager.getManager(StatisticsManager.class).getKeysByName().containsKey(statName)) {
 			DBConnection.sql.modifyQuery("INSERT INTO pk_statKeys (statName) VALUES ('" + statName + "')", false);
-			try (ResultSet rs = DBConnection.sql.readQuery("SELECT * FROM pk_statKeys WHERE statName = '" + statName + "'")) {
-				if (rs.next()) {
-					Manager.getManager(StatisticsManager.class).getKeysByName().put(rs.getString("statName"), rs.getInt("id"));
-					Manager.getManager(StatisticsManager.class).getKeysById().put(rs.getInt("id"), rs.getString("statName"));
-				}
-			} catch (final SQLException e) {
-				e.printStackTrace();
-			}
+			DBConnection.sql.readQuery("SELECT * FROM pk_statKeys WHERE statName = '" + statName + "'",
+					(rs) -> {
+						try {
+							if (rs.next()) {
+								Manager.getManager(StatisticsManager.class).getKeysByName().put(rs.getString("statName"), rs.getInt("id"));
+								Manager.getManager(StatisticsManager.class).getKeysById().put(rs.getInt("id"), rs.getString("statName"));
+							}
+						} catch (final SQLException e) {
+							e.printStackTrace();
+						}
+						return null;
+					});
 		}
-		return Manager.getManager(StatisticsManager.class).getKeysByName().containsKey(statName) ? Manager.getManager(StatisticsManager.class).getKeysByName().get(statName) : -1;
+		return Manager.getManager(StatisticsManager.class).getKeysByName().getOrDefault(statName, -1);
 	}
 
 	/**


### PR DESCRIPTION
Added .close() to all ResultSet and PreparedStatement used.
To enforce this, they are not returned by any database methods (these objects should only be used in Database classes).
readQuery method instead of returning the ResultSet, receives the function that will receive the ResultSet and ALWAYS return something (Object type). The Object returned by the said function will be the one returned by readQuery.

## Fixes
* Fixes "org.sqlite.SQLiteException: [SQLITE_BUSY] The database file is locked (database is locked)" error caused by some Database related objects not calling .close() after they are used.

## Removals
* Removed broken JavaDoc param references
