### PR TITLE
Fix typo in MultiAbilityManager

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -134,7 +134,7 @@ public class MultiAbilityManager {
 			return false;
 		}
 
-		return playerAbilities.containsKey(player) && playerBoundAbility.get(player).equals(multiAbility));
+		return playerAbilities.containsKey(player) && playerBoundAbility.get(player).equals(multiAbility);
 	}
 
 	/**


### PR DESCRIPTION
## Fixes
* Fixes a compiler error caused by an extra parenthesis in MultiAbilityManager