### PR TITLE
Fix AttributeModifier throwing IllegalArgumentException

### DIFF
--- a/src/com/projectkorra/projectkorra/attribute/AttributeModifier.java
+++ b/src/com/projectkorra/projectkorra/attribute/AttributeModifier.java
@@ -3,46 +3,46 @@ package com.projectkorra.projectkorra.attribute;
 public enum AttributeModifier {
 
 	ADDITION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() + modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() + modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() + modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() + modifier.intValue();
 		}
 		return 0;
 	}), SUBTRACTION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() - modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() - modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() - modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() - modifier.intValue();
 		}
 		return 0;
 	}), MULTIPLICATION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() * modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() * modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() * modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() * modifier.intValue();
 		}
 		return 0;
 	}), DIVISION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() / modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() / modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() / modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() / modifier.intValue();
 		}
 		return 0;


### PR DESCRIPTION
## Fixes
* Adding attribute modifiers to abilities sometimes results in an IllegalArgumentException due to flawed logic in this class.
* Tested back in February I think, and it has worked well for me ever since.
