### PR TITLE
Fix error resulting from NMS's EntityHuman being moved and renamed

### DIFF
--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -118,8 +118,6 @@ import com.projectkorra.projectkorra.util.BlockCacheElement;
 import com.projectkorra.projectkorra.util.ColoredParticle;
 import com.projectkorra.projectkorra.util.MovementHandler;
 import com.projectkorra.projectkorra.util.ParticleEffect;
-import com.projectkorra.projectkorra.util.ReflectionHandler;
-import com.projectkorra.projectkorra.util.ReflectionHandler.PackageType;
 import com.projectkorra.projectkorra.util.TempArmor;
 import com.projectkorra.projectkorra.util.TempArmorStand;
 import com.projectkorra.projectkorra.util.TempBlock;
@@ -148,20 +146,8 @@ public class GeneralMethods {
 	private static final ArrayList<Ability> INVINCIBLE = new ArrayList<>();
 	private static ProjectKorra plugin;
 
-	private static Method getAbsorption;
-	private static Method setAbsorption;
-	private static Method getHandle;
-
 	public GeneralMethods(final ProjectKorra plugin) {
 		GeneralMethods.plugin = plugin;
-
-		try {
-			getAbsorption = ReflectionHandler.getMethod("EntityHuman", PackageType.MINECRAFT_SERVER, "getAbsorptionHearts");
-			setAbsorption = ReflectionHandler.getMethod("EntityHuman", PackageType.MINECRAFT_SERVER, "setAbsorptionHearts", Float.class);
-			getHandle = ReflectionHandler.getMethod("CraftPlayer", PackageType.CRAFTBUKKIT_ENTITY, "getHandle");
-		} catch (final Exception e) {
-			e.printStackTrace();
-		}
 	}
 
 	/**
@@ -674,26 +660,25 @@ public class GeneralMethods {
 		ActionBar.sendActionBar(displayedMessage, player);
 	}
 
+	@Deprecated
+	/**
+	 * Gets the number of absorption hearts of a specified {@link Player}.
+	 * @param player the {@link Player} to get the absorption hearts of.
+	 * @deprecated Use {@link Player#getAbsorptionAmount()}.
+	 */
 	public static float getAbsorbationHealth(final Player player) {
-
-		try {
-			final Object entityplayer = getHandle.invoke(player);
-			final Object hearts = getAbsorption.invoke(entityplayer);
-			return (float) hearts;
-		} catch (final Exception e) {
-			e.printStackTrace();
-		}
-		return 0;
+		return (float) player.getAbsorptionAmount();
 	}
 
+	@Deprecated
+	/**
+	 * Sets the number of absorption hearts of a specified {@link Player}.
+	 * @param player the {@link Player} to set the absorption hearts of.
+	 * @param hearts a float representing the number of hearts to set.
+	 * @deprecated Use {@link Player#setAbsorptionAmount(double)}
+	 */
 	public static void setAbsorbationHealth(final Player player, final float hearts) {
-
-		try {
-			final Object entityplayer = getHandle.invoke(player);
-			setAbsorption.invoke(entityplayer, hearts);
-		} catch (final Exception e) {
-			e.printStackTrace();
-		}
+		player.setAbsorptionAmount(hearts);
 	}
 
 	public static int getArmorTier(Material mat) {

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -660,23 +660,23 @@ public class GeneralMethods {
 		ActionBar.sendActionBar(displayedMessage, player);
 	}
 
-	@Deprecated
 	/**
 	 * Gets the number of absorption hearts of a specified {@link Player}.
 	 * @param player the {@link Player} to get the absorption hearts of.
 	 * @deprecated Use {@link Player#getAbsorptionAmount()}.
 	 */
+	@Deprecated
 	public static float getAbsorbationHealth(final Player player) {
 		return (float) player.getAbsorptionAmount();
 	}
 
-	@Deprecated
 	/**
 	 * Sets the number of absorption hearts of a specified {@link Player}.
 	 * @param player the {@link Player} to set the absorption hearts of.
 	 * @param hearts a float representing the number of hearts to set.
 	 * @deprecated Use {@link Player#setAbsorptionAmount(double)}
 	 */
+	@Deprecated
 	public static void setAbsorbationHealth(final Player player, final float hearts) {
 		player.setAbsorptionAmount(hearts);
 	}

--- a/src/com/projectkorra/projectkorra/attribute/AttributeModifier.java
+++ b/src/com/projectkorra/projectkorra/attribute/AttributeModifier.java
@@ -3,46 +3,46 @@ package com.projectkorra.projectkorra.attribute;
 public enum AttributeModifier {
 
 	ADDITION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() + modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() + modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() + modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() + modifier.intValue();
 		}
 		return 0;
 	}), SUBTRACTION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() - modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() - modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() - modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() - modifier.intValue();
 		}
 		return 0;
 	}), MULTIPLICATION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() * modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() * modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() * modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() * modifier.intValue();
 		}
 		return 0;
 	}), DIVISION((oldValue, modifier) -> {
-		if (oldValue instanceof Double || modifier instanceof Double) {
+		if (oldValue instanceof Double) {
 			return oldValue.doubleValue() / modifier.doubleValue();
-		} else if (oldValue instanceof Float || modifier instanceof Float) {
+		} else if (oldValue instanceof Float) {
 			return oldValue.floatValue() / modifier.floatValue();
-		} else if (oldValue instanceof Long || modifier instanceof Long) {
+		} else if (oldValue instanceof Long) {
 			return oldValue.longValue() / modifier.longValue();
-		} else if (oldValue instanceof Integer || modifier instanceof Integer) {
+		} else if (oldValue instanceof Integer) {
 			return oldValue.intValue() / modifier.intValue();
 		}
 		return 0;

--- a/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
@@ -45,7 +45,7 @@ public class EarthArmor extends EarthAbility {
 	private Location legsBlockLocation;
 	private boolean active;
 	private PotionEffect oldAbsorbtion = null;
-	private float goldHearts;
+	private double goldHearts;
 	@Attribute("GoldHearts")
 	private int maxGoldHearts;
 	private TempArmor armor;
@@ -145,7 +145,7 @@ public class EarthArmor extends EarthAbility {
 		this.player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, Integer.MAX_VALUE, level, true, false));
 
 		this.goldHearts = this.maxGoldHearts * 2;
-		GeneralMethods.setAbsorbationHealth(this.player, this.goldHearts);
+		this.player.setAbsorptionAmount(this.goldHearts);
 	}
 
 	private boolean inPosition() {
@@ -249,7 +249,7 @@ public class EarthArmor extends EarthAbility {
 		if (this.formed) {
 			if (!this.player.hasPotionEffect(PotionEffectType.ABSORPTION)) {
 				this.player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, Integer.MAX_VALUE, 1, true, false));
-				GeneralMethods.setAbsorbationHealth(this.player, this.goldHearts);
+				this.player.setAbsorptionAmount(this.goldHearts);
 			}
 
 			if (!this.active) {
@@ -301,7 +301,7 @@ public class EarthArmor extends EarthAbility {
 		new BukkitRunnable() {
 			@Override
 			public void run() {
-				abil.goldHearts = GeneralMethods.getAbsorbationHealth(EarthArmor.this.player);
+				abil.goldHearts = EarthArmor.this.player.getAbsorptionAmount();
 				if (abil.formed && abil.goldHearts < 0.9F) {
 					abil.bPlayer.addCooldown(abil);
 
@@ -601,7 +601,7 @@ public class EarthArmor extends EarthAbility {
 		this.cooldown = cooldown;
 	}
 
-	public float getGoldHearts() {
+	public double getGoldHearts() {
 		return this.goldHearts;
 	}
 
@@ -609,7 +609,7 @@ public class EarthArmor extends EarthAbility {
 		return this.maxGoldHearts;
 	}
 
-	public void setGoldHearts(final float goldHearts) {
+	public void setGoldHearts(final double goldHearts) {
 		this.goldHearts = goldHearts;
 	}
 


### PR DESCRIPTION
Co-authored with @ChristopherWMM 

## Fixes
* ClassDefNotFoundError resulted from net.minecraft.server.1_17_R1.EntityHuman being moved and renamed during the 1.17 Minecraft update
* Instead of using the new name and location, we're using the methods in Bukkit's Damageable interface for the absorption hearts used in EarthArmor, which probably didn't exist when the original EarthArmor was written
* Removed unused static variables and imports
* Marked the GeneralMethods absorption methods as deprecated
* Changed EarthArmor method calls to the preferred Player#setAbsorptionAmount
* Changed EarthArmor's goldHearts field to a double since that is what the new method returns and it makes sense not to have to cast it

(Also, I'm sorry about the two extra commits in this PR; I'm not sure why they're there but they won't change anything. I can rebase if you'd like.)
