### PR TITLE
Fix players falling through lifting EarthSmash

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1290,7 +1290,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthSmash.Damage", 5);
 			config.addDefault("Abilities.Earth.EarthSmash.Knockback", 3.5);
 			config.addDefault("Abilities.Earth.EarthSmash.Knockup", 0.15);
-			config.addDefault("Abilities.Earth.EarthSmash.LiftKnockup", 1.1);
+			config.addDefault("Abilities.Earth.EarthSmash.Lift.Knockup", 1.1);
+			config.addDefault("Abilities.Earth.EarthSmash.Lift.Range", 3.5);
 			config.addDefault("Abilities.Earth.EarthSmash.Flight.Enabled", true);
 			config.addDefault("Abilities.Earth.EarthSmash.Flight.Speed", 0.72);
 			config.addDefault("Abilities.Earth.EarthSmash.Flight.Duration", 3000);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1290,6 +1290,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthSmash.Damage", 5);
 			config.addDefault("Abilities.Earth.EarthSmash.Knockback", 3.5);
 			config.addDefault("Abilities.Earth.EarthSmash.Knockup", 0.15);
+			config.addDefault("Abilities.Earth.EarthSmash.LiftKnockup", 1.1);
 			config.addDefault("Abilities.Earth.EarthSmash.Flight.Enabled", true);
 			config.addDefault("Abilities.Earth.EarthSmash.Flight.Speed", 0.72);
 			config.addDefault("Abilities.Earth.EarthSmash.Flight.Duration", 3000);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -64,7 +64,8 @@ public class EarthSmash extends EarthAbility {
 	private double knockback;
 	@Attribute(Attribute.KNOCKUP)
 	private double knockup;
-	private double lift_knockup;
+	private double liftKnockup;
+	private double liftRange;
 	@Attribute(Attribute.SPEED)
 	private double flightSpeed;
 	private double grabbedDistance;
@@ -158,7 +159,8 @@ public class EarthSmash extends EarthAbility {
 		this.damage = getConfig().getDouble("Abilities.Earth.EarthSmash.Damage");
 		this.knockback = getConfig().getDouble("Abilities.Earth.EarthSmash.Knockback");
 		this.knockup = getConfig().getDouble("Abilities.Earth.EarthSmash.Knockup");
-		this.lift_knockup = getConfig().getDouble("Abilities.Earth.EarthSmash.LiftKnockup");
+		this.liftKnockup = getConfig().getDouble("Abilities.Earth.EarthSmash.Lift.Knockup");
+		this.liftRange = getConfig().getDouble("Abilities.Earth.EarthSmash.Lift.Range");
 		this.flightSpeed = getConfig().getDouble("Abilities.Earth.EarthSmash.Flight.Speed");
 		this.chargeTime = getConfig().getLong("Abilities.Earth.EarthSmash.ChargeTime");
 		this.cooldown = getConfig().getLong("Abilities.Earth.EarthSmash.Cooldown");
@@ -401,10 +403,10 @@ public class EarthSmash extends EarthAbility {
 				this.location.add(0, -1, 0);
 
 				// Move any entities that are above the rock.
-				final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, 3.5);
+				final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, this.liftRange);
 				for (final Entity entity : entities) {
 					final org.bukkit.util.Vector velocity = entity.getVelocity();
-					entity.setVelocity(velocity.add(new Vector(0, this.lift_knockup, 0)));
+					entity.setVelocity(velocity.add(new Vector(0, this.liftKnockup, 0)));
 				}
 			}
 

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -64,6 +64,7 @@ public class EarthSmash extends EarthAbility {
 	private double knockback;
 	@Attribute(Attribute.KNOCKUP)
 	private double knockup;
+	private double lift_knockup;
 	@Attribute(Attribute.SPEED)
 	private double flightSpeed;
 	private double grabbedDistance;
@@ -157,6 +158,7 @@ public class EarthSmash extends EarthAbility {
 		this.damage = getConfig().getDouble("Abilities.Earth.EarthSmash.Damage");
 		this.knockback = getConfig().getDouble("Abilities.Earth.EarthSmash.Knockback");
 		this.knockup = getConfig().getDouble("Abilities.Earth.EarthSmash.Knockup");
+		this.lift_knockup = getConfig().getDouble("Abilities.Earth.EarthSmash.LiftKnockup");
 		this.flightSpeed = getConfig().getDouble("Abilities.Earth.EarthSmash.Flight.Speed");
 		this.chargeTime = getConfig().getLong("Abilities.Earth.EarthSmash.ChargeTime");
 		this.cooldown = getConfig().getLong("Abilities.Earth.EarthSmash.Cooldown");
@@ -402,7 +404,7 @@ public class EarthSmash extends EarthAbility {
 				final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, 3.5);
 				for (final Entity entity : entities) {
 					final org.bukkit.util.Vector velocity = entity.getVelocity();
-					entity.setVelocity(velocity.add(new Vector(0, 1.1, 0)));
+					entity.setVelocity(velocity.add(new Vector(0, this.lift_knockup, 0)));
 				}
 			}
 

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -398,13 +398,14 @@ public class EarthSmash extends EarthAbility {
 				 */
 				this.location.add(0, -1, 0);
 
+				// Move any entities that are above the rock.
+				final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, 3.5);
+				for (final Entity entity : entities) {
+					final org.bukkit.util.Vector velocity = entity.getVelocity();
+					entity.setVelocity(velocity.add(new Vector(0, 1.1, 0)));
+				}
 			}
-			// Move any entities that are above the rock.
-			final List<Entity> entities = GeneralMethods.getEntitiesAroundPoint(this.location, 2.5);
-			for (final Entity entity : entities) {
-				final org.bukkit.util.Vector velocity = entity.getVelocity();
-				entity.setVelocity(velocity.add(new Vector(0, 0.36, 0)));
-			}
+
 			this.location.getWorld().playEffect(this.location, Effect.GHAST_SHOOT, 0, 7);
 			this.draw();
 		} else {


### PR DESCRIPTION
## Additions
 * Adds new `"Abilities.Earth.EarthSmash.Lift.Knockup"` configuration option to control the velocity applied to players standing where an EarthSmash is created.
 * Adds new `"Abilities.Earth.EarthSmash.Lift.Range"` configuration option to control the range in which entities need to be standing in relation to where an EarthSmash is created to get the Knockup applied.

## Fixes
* Fixes players sometimes "falling through" their EarthSmash if they try to create it underneath themselves. Fixes #1120
  * Reduces the overall push so it feels more natural.
  * Expands the push radius so it can affect entities within one block of the location.