### PR TITLE
Fix IceWave activation and mobility problems

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -372,7 +372,7 @@ public class WaterSpoutWave extends WaterAbility {
 		final BukkitRunnable br = new BukkitRunnable() {
 			@Override
 			public void run() {
-				WaterSpoutWave.this.createBlock(block, mat);
+				WaterSpoutWave.this.createBlock(block, block.getLocation().distance(player.getLocation()) >= 1.6 ? mat : Material.WATER);
 			}
 		};
 		br.runTaskLater(ProjectKorra.plugin, delay);

--- a/src/com/projectkorra/projectkorra/waterbending/combo/IceWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/combo/IceWave.java
@@ -27,6 +27,10 @@ public class IceWave extends IceAbility implements ComboAbility {
 	public IceWave(final Player player) {
 		super(player);
 
+		if (!hasAbility(player, WaterSpoutWave.class)) {
+			return;
+		}
+
 		if (!this.bPlayer.canBendIgnoreBindsCooldowns(this)) {
 			return;
 		}


### PR DESCRIPTION
## Fixes
* Fixed IceWave activating when PhaseChange wasn't clicked
    * The problem was due to an earlier WaterWave shift up and PhaseChange left click instantiating IceWave even when WaterSpoutWave wasn't active. Adding a check in IceWave's constructor to account for this solves the problem.
* Fixed IceWave users getting stuck on the ice midair
    * The ice was being placed faster than the player could move, and when it gets towards the end of the combo (and therefore slower), the ice is being placed right on/beneath the player, so they get stuck. Adding water instead of ice when the player is close enough solves this problem. I chose 1.6 because after testing 2, 1, and 1.5 I found 1.6 to be smooth. It can easily be changed.