### PR TITLE
Fix passives not being shown by display command

### DIFF
--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -160,7 +160,7 @@ public class DisplayCommand extends PKCommand {
 							}
 
 							final CoreAbility coreAbil = CoreAbility.getAbility(passiveAbil);
-							if (coreAbil == null || coreAbil.isHiddenAbility()) {
+							if (coreAbil == null) {
 								continue;
 							}
 							passiveColor = coreAbil.getElement().getColor();
@@ -193,7 +193,7 @@ public class DisplayCommand extends PKCommand {
 					}
 
 					final CoreAbility coreAbil = CoreAbility.getAbility(passiveAbil);
-					if (coreAbil == null || coreAbil.isHiddenAbility()) {
+					if (coreAbil == null) {
 						continue;
 					}
 					passiveColor = coreAbil.getElement().getColor();


### PR DESCRIPTION
## Fixes
* Fixes passive abilities not being shown by the `/pk display <element>passives` command.
  * This issue was caused by unnecessarily filtering out hidden passives.