### PR TITLE
Add config option to TremorSense click without being in darkness

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1342,6 +1342,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.Tremorsense.MaxDepth", 10);
 			config.addDefault("Abilities.Earth.Tremorsense.Radius", 5);
 			config.addDefault("Abilities.Earth.Tremorsense.LightThreshold", 7);
+			config.addDefault("Abilities.Earth.Tremorsense.ClickRequiresDarkness", false);
 			config.addDefault("Abilities.Earth.Tremorsense.Cooldown", 1000);
 			config.addDefault("Abilities.Earth.Tremorsense.StickyRange", 3);
 

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -22,6 +22,7 @@ public class Tremorsense extends EarthAbility {
 	private int maxDepth;
 	@Attribute(Attribute.RADIUS)
 	private int radius;
+	private boolean requireDarkness;
 	@Attribute(Attribute.COOLDOWN)
 	private long cooldown;
 	private Block block;
@@ -38,8 +39,13 @@ public class Tremorsense extends EarthAbility {
 		this.setFields();
 		final byte lightLevel = player.getLocation().getBlock().getLightLevel();
 
+		if (!this.requireDarkness && clicked) {
+			this.bPlayer.addCooldown(this);
+			this.activate();
+		}
+
 		if (lightLevel < this.lightThreshold && this.isEarthbendable(player.getLocation().getBlock().getRelative(BlockFace.DOWN))) {
-			if (clicked) {
+			if (this.requireDarkness && clicked) {
 				this.bPlayer.addCooldown(this);
 				this.activate();
 			}
@@ -51,6 +57,7 @@ public class Tremorsense extends EarthAbility {
 		this.maxDepth = getConfig().getInt("Abilities.Earth.Tremorsense.MaxDepth");
 		this.radius = getConfig().getInt("Abilities.Earth.Tremorsense.Radius");
 		this.lightThreshold = (byte) getConfig().getInt("Abilities.Earth.Tremorsense.LightThreshold");
+		this.requireDarkness = getConfig().getBoolean("Abilities.Earth.Tremorsense.ClickRequiresDarkness");
 		this.cooldown = getConfig().getLong("Abilities.Earth.Tremorsense.Cooldown");
 		this.stickyRange = getConfig().getInt("Abilities.Earth.Tremorsense.StickyRange");
 	}


### PR DESCRIPTION
## Additions
* Adds a new `"Abilities.Earth.Tremorsense.ClickRequiresDarkness"` configuration option to TremorSense allowing the click functionality to be used without needing to be in darkness.

## Misc Changes
* TremorSense click no longer requires darkness to activate anymore, this change can be reverted using the implemented configuration option.