### PR TITLE
Fix PlantBending volume and pitch config options

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -616,8 +616,8 @@ public class ConfigManager {
 			config.addDefault("Properties.Water.IceSound.Volume", 1);
 			config.addDefault("Properties.Water.IceSound.Pitch", 1);
 			config.addDefault("Properties.Water.PlantSound.Sound", "BLOCK_GRASS_STEP");
-			config.addDefault("Properties.Water.IceSound.Volume", 1);
-			config.addDefault("Properties.Water.IceSound.Pitch", 1);
+			config.addDefault("Properties.Water.PlantSound.Volume", 1);
+			config.addDefault("Properties.Water.PlantSound.Pitch", 1);
 
 			config.addDefault("Properties.Earth.DynamicSourcing", true);
 			config.addDefault("Properties.Earth.RevertEarthbending", true);


### PR DESCRIPTION
## Fixes
* Fixes a typo in the volume and pitch config values for plantbending sounds.
  * `"Properties.Water.PlantSound.Volume"` should now work properly.
  * `"Properties.Water.PlantSound.Pitch"` should now work properly.