### PR TITLE
Cooldown bug fixes, earth tunnel revert time

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1243,6 +1243,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthGrab.DamageThreshold", 4);
 
 			config.addDefault("Abilities.Earth.EarthTunnel.Enabled", true);
+			config.addDefault("Properties.Earth.EarthTunnel.RevertCheckTime", 30000);
 			config.addDefault("Abilities.Earth.EarthTunnel.Cooldown", 0);
 			config.addDefault("Abilities.Earth.EarthTunnel.MaxRadius", 1);
 			config.addDefault("Abilities.Earth.EarthTunnel.Range", 10);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1243,7 +1243,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthGrab.DamageThreshold", 4);
 
 			config.addDefault("Abilities.Earth.EarthTunnel.Enabled", true);
-			config.addDefault("Abilities.Earth.EarthTunnel.RevertCheckTime", 30000);
+			config.addDefault("Abilities.Earth.EarthTunnel.RevertCheckTime", 300000);
 			config.addDefault("Abilities.Earth.EarthTunnel.Cooldown", 0);
 			config.addDefault("Abilities.Earth.EarthTunnel.MaxRadius", 1);
 			config.addDefault("Abilities.Earth.EarthTunnel.Range", 10);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1243,7 +1243,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthGrab.DamageThreshold", 4);
 
 			config.addDefault("Abilities.Earth.EarthTunnel.Enabled", true);
-			config.addDefault("Properties.Earth.EarthTunnel.RevertCheckTime", 30000);
+			config.addDefault("Abilities.Earth.EarthTunnel.RevertCheckTime", 30000);
 			config.addDefault("Abilities.Earth.EarthTunnel.Cooldown", 0);
 			config.addDefault("Abilities.Earth.EarthTunnel.MaxRadius", 1);
 			config.addDefault("Abilities.Earth.EarthTunnel.Range", 10);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
@@ -52,7 +52,7 @@ public class EarthTunnel extends EarthAbility {
 		this.revert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.Revert");
 		this.dropLootIfNotRevert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.DropLootIfNotRevert");
 		this.ignoreOres = getConfig().getBoolean("Abilities.Earth.EarthTunnel.IgnoreOres");
-		this.revertTime = getConfig().getLong("Properties.Earth.RevertCheckTime");
+		this.revertTime = getConfig().getLong("Properties.Earth.EarthTunnel.RevertCheckTime");
 
 		this.time = System.currentTimeMillis();
 

--- a/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthTunnel.java
@@ -52,7 +52,7 @@ public class EarthTunnel extends EarthAbility {
 		this.revert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.Revert");
 		this.dropLootIfNotRevert = getConfig().getBoolean("Abilities.Earth.EarthTunnel.DropLootIfNotRevert");
 		this.ignoreOres = getConfig().getBoolean("Abilities.Earth.EarthTunnel.IgnoreOres");
-		this.revertTime = getConfig().getLong("Properties.Earth.EarthTunnel.RevertCheckTime");
+		this.revertTime = getConfig().getLong("Abilities.Earth.EarthTunnel.RevertCheckTime");
 
 		this.time = System.currentTimeMillis();
 

--- a/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
@@ -124,6 +124,7 @@ public class FireManipulation extends FireAbility {
 			}
 		} else if (!this.firing && this.charging) {
 			if (!this.player.isSneaking()) {
+				this.bPlayer.addCooldown(this, this.streamCooldown);
 				this.remove();
 				return;
 			}

--- a/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
+++ b/src/com/projectkorra/projectkorra/waterbending/blood/Bloodbending.java
@@ -165,6 +165,7 @@ public class Bloodbending extends BloodAbility {
 		final PotionEffect effect = new PotionEffect(PotionEffectType.SLOW, 60, 1);
 
 		if (!this.player.isSneaking()) {
+			bPlayer.addCooldown(this);
 			this.remove();
 			return;
 		} else if (this.duration > 0 && System.currentTimeMillis() - this.time > this.duration) {


### PR DESCRIPTION
## Additions
- Adds separate revert time for EarthTunnel. In general, on servers, you want a small revert time for arena's, but you can't do that because people get trapped in EarthTunnel in survival because it resets so quickly.

## Fixes
- Fixes cooldown on Bloodbending not activating. The previous implementation would allow a user to constantly spam shift to Bloodbend without going on cooldown.
- Fixes FireManipulation stream cooldown not being applied.