### PR TITLE
Improve BendingBoard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,4 @@ target/
 classes/
 out/
 projectkorra.iml
+.vscode/settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <!-- WorldGuard and WorldEdit Repo -->
     <repository>
       <id>sk89q-repo</id>
-      <url>http://maven.sk89q.com/repo/</url>
+      <url>https://maven.sk89q.com/repo/</url>
     </repository>
     <!-- GriefPrevention and Towny Repo -->
     <repository>
@@ -35,7 +35,7 @@
     <!-- Aikars Repo -->
     <repository>
       <id>aikar</id>
-      <url>http://repo.aikar.co/nexus/content/groups/aikar/</url>
+      <url>https://repo.aikar.co/nexus/content/groups/aikar/</url>
     </repository>
     <!-- Paper Repo -->
     <repository>
@@ -45,7 +45,7 @@
     <!-- Placeholder API Repo -->
     <repository>
       <id>placeholderapi</id>
-      <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+      <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
     </repository>
   </repositories>
   <dependencies>

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -187,13 +187,19 @@ public class GeneralMethods {
 			GeneralMethods.sendBrandingMessage(player, ChatColor.RED + "You can't edit your binds right now!");
 			return;
 		}
+		
+		PlayerBindChangeEvent event = new PlayerBindChangeEvent(player, ability, slot, ability != null, false);
+		ProjectKorra.plugin.getServer().getPluginManager().callEvent(event);
+		if (event.isCancelled()) {
+			return;
+		}
 
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player.getName());
-		final CoreAbility coreAbil = CoreAbility.getAbility(ability);
-
 		if (bPlayer == null) {
 			return;
 		}
+		
+		final CoreAbility coreAbil = CoreAbility.getAbility(ability);
 		bPlayer.getAbilities().put(slot, ability);
 
 		if (coreAbil != null) {
@@ -2141,20 +2147,14 @@ public class GeneralMethods {
 		if (bPlayer == null) {
 			return;
 		}
-		final String uuid = bPlayer.getUUIDString();
 
-		final PlayerBindChangeEvent event = new PlayerBindChangeEvent(Bukkit.getPlayer(UUID.fromString(uuid)), ability, slot, false);
-		Bukkit.getServer().getPluginManager().callEvent(event);
-		if (event.isCancelled()) {
-			return;
-		}
 		// Temp code to block modifications of binds, Should be replaced when bind event is added.
-		if (MultiAbilityManager.playerAbilities.containsKey(Bukkit.getPlayer(bPlayer.getUUID()))) {
+		if (MultiAbilityManager.playerAbilities.containsKey(bPlayer.getPlayer())) {
 			return;
 		}
 		final HashMap<Integer, String> abilities = bPlayer.getAbilities();
 
-		DBConnection.sql.modifyQuery("UPDATE pk_players SET slot" + slot + " = '" + (abilities.get(slot) == null ? null : abilities.get(slot)) + "' WHERE uuid = '" + uuid + "'");
+		DBConnection.sql.modifyQuery("UPDATE pk_players SET slot" + slot + " = '" + (abilities.get(slot) == null ? null : abilities.get(slot)) + "' WHERE uuid = '" + bPlayer.getUUIDString() + "'");
 	}
 
 	public static void saveElements(final BendingPlayer bPlayer) {

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1600,7 +1600,7 @@ public class PKListener implements Listener {
 
 		final int slot = event.getNewSlot() + 1;
 		GeneralMethods.displayMovePreview(player, slot);
-		BendingBoardManager.changeActiveSlot(player, event.getPreviousSlot(), event.getNewSlot());
+		BendingBoardManager.changeActiveSlot(player, event.getNewSlot());
 
 		if (ConfigManager.defaultConfig.get().getBoolean("Abilities.Water.WaterArms.DisplayBoundMsg")) {
 			final WaterArms waterArms = CoreAbility.getAbility(player, WaterArms.class);

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -144,7 +144,6 @@ import com.projectkorra.projectkorra.event.HorizontalVelocityChangeEvent;
 import com.projectkorra.projectkorra.event.PlayerBindChangeEvent;
 import com.projectkorra.projectkorra.event.PlayerChangeElementEvent;
 import com.projectkorra.projectkorra.event.PlayerChangeSubElementEvent;
-import com.projectkorra.projectkorra.event.PlayerCooldownChangeEvent;
 import com.projectkorra.projectkorra.event.PlayerJumpEvent;
 import com.projectkorra.projectkorra.event.PlayerStanceChangeEvent;
 import com.projectkorra.projectkorra.firebending.Blaze;
@@ -2007,7 +2006,18 @@ public class PKListener implements Listener {
 	public void onBindChange(final PlayerBindChangeEvent event) {
 		final Player player = event.getPlayer();
 		if (player == null) return;
-		BendingBoardManager.updateBoard(player, event.getAbility(), false, event.getSlot());
+		if (event.isMultiAbility()) {
+			new BukkitRunnable() {
+
+				@Override
+				public void run() {
+					BendingBoardManager.updateAllSlots(player);
+				}
+				
+			}.runTaskLater(ProjectKorra.plugin, 1);
+		} else {
+			BendingBoardManager.updateBoard(player, event.getAbility(), false, event.getSlot());
+		}
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1992,10 +1992,7 @@ public class PKListener implements Listener {
 		final Player player = event.getTarget();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 		if (bPlayer == null) return;
-
-		if (event.getResult() == PlayerChangeElementEvent.Result.CHOOSE || event.getResult() == PlayerChangeElementEvent.Result.REMOVE || event.getResult() == PlayerChangeElementEvent.Result.PERMAREMOVE) {
-			BendingBoardManager.updateAllSlots(player);
-		}
+		BendingBoardManager.updateAllSlots(player);
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)
@@ -2003,10 +2000,7 @@ public class PKListener implements Listener {
 		final Player player = event.getTarget();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 		if (bPlayer == null) return;
-
-		if (event.getResult() == PlayerChangeSubElementEvent.Result.CHOOSE || event.getResult() == PlayerChangeSubElementEvent.Result.REMOVE || event.getResult() == PlayerChangeSubElementEvent.Result.PERMAREMOVE) {
-			BendingBoardManager.updateAllSlots(player);
-		}
+		BendingBoardManager.updateAllSlots(player);
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR)

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -527,12 +527,6 @@ public class PKListener implements Listener {
 			FireDamageTimer.dealFlameDamage(entity);
 		}
 
-		if (entity instanceof LivingEntity && TempArmor.hasTempArmor((LivingEntity) entity)) {
-			if (event.isApplicable(DamageModifier.ARMOR)) {
-				event.setDamage(DamageModifier.ARMOR, 0);
-			}
-		}
-
 		if (entity instanceof Player) {
 			final Player player = (Player) entity;
 			final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
@@ -1241,7 +1235,7 @@ public class PKListener implements Listener {
 	@EventHandler
 	public void onPlayerChangeWorld(final PlayerChangedWorldEvent event) {
 		PassiveManager.registerPassives(event.getPlayer());
-		BendingBoardManager.forceToggleScoreboard(event.getPlayer());
+		BendingBoardManager.toggleBoard(event.getPlayer(), true);
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -1599,7 +1593,7 @@ public class PKListener implements Listener {
 
 		final int slot = event.getNewSlot() + 1;
 		GeneralMethods.displayMovePreview(player, slot);
-		BendingBoardManager.changeActiveSlot(player, event.getNewSlot());
+		BendingBoardManager.changeActiveSlot(player, slot);
 
 		if (ConfigManager.defaultConfig.get().getBoolean("Abilities.Water.WaterArms.DisplayBoundMsg")) {
 			final WaterArms waterArms = CoreAbility.getAbility(player, WaterArms.class);
@@ -2035,7 +2029,7 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onBendingPlayerCreation(final BendingPlayerCreationEvent event) {
 		final Player player = event.getBendingPlayer().getPlayer();
-		BendingBoardManager.canUseScoreboard(player);
+		BendingBoardManager.getBoard(player);
 	}
 
 	public static HashMap<Player, String> getBendingPlayerDeath() {

--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -41,7 +41,7 @@ public class MultiAbilityManager {
 	 * @param multiAbility MultiAbility being bound
 	 */
 	public static void bindMultiAbility(final Player player, final String multiAbility) {
-		final PlayerBindChangeEvent event = new PlayerBindChangeEvent(player, multiAbility, true);
+		final PlayerBindChangeEvent event = new PlayerBindChangeEvent(player, multiAbility, 0, true, true);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 		if (event.isCancelled()) {
 			return;
@@ -189,7 +189,7 @@ public class MultiAbilityManager {
 			int slot = playerSlot.getOrDefault(player, 0);
 			playerSlot.remove(player);
 			player.getInventory().setHeldItemSlot(slot);
-			ProjectKorra.plugin.getServer().getPluginManager().callEvent(new PlayerBindChangeEvent(player, playerBoundAbility.get(player), slot, false));
+			ProjectKorra.plugin.getServer().getPluginManager().callEvent(new PlayerBindChangeEvent(player, playerBoundAbility.get(player), slot, false, true));
 
 			int lastNonNull = -1;
 			for (int i = 1; i < 10; i++) {

--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.Element;
@@ -186,6 +185,11 @@ public class MultiAbilityManager {
 			if (bPlayer == null) {
 				return;
 			}
+			
+			int slot = playerSlot.getOrDefault(player, 0);
+			playerSlot.remove(player);
+			player.getInventory().setHeldItemSlot(slot);
+			ProjectKorra.plugin.getServer().getPluginManager().callEvent(new PlayerBindChangeEvent(player, playerBoundAbility.get(player), slot, false));
 
 			int lastNonNull = -1;
 			for (int i = 1; i < 10; i++) {
@@ -198,23 +202,10 @@ public class MultiAbilityManager {
 				GeneralMethods.saveAbility(bPlayer, lastNonNull, prevBinds.get(lastNonNull));
 			}
 
-			if (player.isOnline()) {
-				bPlayer.addCooldown("MAM_Setup", 1L); // Support for bending scoreboards.
-			}
+			bPlayer.addCooldown("MAM_Setup", 1L); // Support for bending scoreboards.
 			playerAbilities.remove(player);
 		}
-
-		if (playerSlot.containsKey(player)) {
-			if (player.isOnline()) {
-				player.getInventory().setHeldItemSlot(playerSlot.get(player));
-			}
-			playerSlot.remove(player);
-		} else {
-			if (player.isOnline()) {
-				player.getInventory().setHeldItemSlot(0);
-			}
-		}
-
+		
 		if (playerBoundAbility.containsKey(player)) {
 			playerBoundAbility.remove(player);
 		}

--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -41,6 +41,10 @@ public class MultiAbilityManager {
 	 * @param multiAbility MultiAbility being bound
 	 */
 	public static void bindMultiAbility(final Player player, final String multiAbility) {
+		if (!player.isOnline()) {
+			return;
+		}
+		
 		final PlayerBindChangeEvent event = new PlayerBindChangeEvent(player, multiAbility, 0, true, true);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 		if (event.isCancelled()) {
@@ -50,14 +54,12 @@ public class MultiAbilityManager {
 		if (playerAbilities.containsKey(player)) {
 			unbindMultiAbility(player);
 		}
+		
+		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+		
 		playerSlot.put(player, player.getInventory().getHeldItemSlot());
 		playerBoundAbility.put(player, multiAbility);
-		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-		final HashMap<Integer, String> currAbilities = new HashMap<Integer, String>();
-		for (final int i : bPlayer.getAbilities().keySet()) {
-			currAbilities.put(i, bPlayer.getAbilities().get(i));
-		}
-		playerAbilities.put(player, currAbilities);
+		playerAbilities.put(player, new HashMap<Integer, String>(bPlayer.getAbilities()));
 
 		final List<MultiAbilityInfoSub> modes = getMultiAbility(multiAbility).getAbilities();
 
@@ -69,11 +71,8 @@ public class MultiAbilityManager {
 				bPlayer.getAbilities().put(i + 1, modes.get(i).getAbilityColor() + modes.get(i).getName());
 			}
 		}
-
-		if (player.isOnline()) {
-			bPlayer.addCooldown("MAM_Setup", 1L); // Support for bending scoreboards.
-			player.getInventory().setHeldItemSlot(0);
-		}
+		
+		player.getInventory().setHeldItemSlot(0);
 	}
 
 	/**
@@ -179,36 +178,33 @@ public class MultiAbilityManager {
 	 * @param player
 	 */
 	public static void unbindMultiAbility(final Player player) {
-		if (playerAbilities.containsKey(player)) {
-			final HashMap<Integer, String> prevBinds = playerAbilities.get(player);
-			final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer == null) {
-				return;
-			}
-			
-			int slot = playerSlot.getOrDefault(player, 0);
-			playerSlot.remove(player);
-			player.getInventory().setHeldItemSlot(slot);
-			ProjectKorra.plugin.getServer().getPluginManager().callEvent(new PlayerBindChangeEvent(player, playerBoundAbility.get(player), slot, false, true));
-
-			int lastNonNull = -1;
-			for (int i = 1; i < 10; i++) {
-				if (prevBinds.get(i) != null) {
-					lastNonNull = i;
-				}
-				bPlayer.getAbilities().put(i, prevBinds.get(i));
-			}
-			if (lastNonNull > -1) {
-				GeneralMethods.saveAbility(bPlayer, lastNonNull, prevBinds.get(lastNonNull));
-			}
-
-			bPlayer.addCooldown("MAM_Setup", 1L); // Support for bending scoreboards.
-			playerAbilities.remove(player);
+		if (!player.isOnline()) {
+			return;
 		}
 		
-		if (playerBoundAbility.containsKey(player)) {
-			playerBoundAbility.remove(player);
+		playerAbilities.compute(player, MultiAbilityManager::resetBinds);
+		playerBoundAbility.remove(player);
+		playerSlot.remove(player);
+	}
+	
+	private static HashMap<Integer, String> resetBinds(Player player, HashMap<Integer, String> prevBinds) {
+		if (prevBinds == null) {
+			return null;
 		}
+		
+		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+		if (bPlayer == null) {
+			return null;
+		}
+		
+		player.getInventory().setHeldItemSlot(playerSlot.getOrDefault(player, 0));
+		ProjectKorra.plugin.getServer().getPluginManager().callEvent(new PlayerBindChangeEvent(player, playerBoundAbility.get(player), false, true));
+
+		for (int i = 1; i < 10; i++) {
+			bPlayer.getAbilities().put(i, prevBinds.get(i));
+		}
+		
+		return null;
 	}
 
 	/**

--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -23,7 +23,7 @@ import net.md_5.bungee.api.ChatColor;
 /**
  * Represents a player's scoreboard for bending purposes
  */
-public class BendingBoardInstance {
+public class BendingBoard {
 	
 	public static class BoardSlot {
 		
@@ -90,7 +90,7 @@ public class BendingBoardInstance {
 	private String prefix, emptySlot, miscSeparator;
 	private ChatColor selectedColor, altColor;
 
-	public BendingBoardInstance(final BendingPlayer bPlayer) {
+	public BendingBoard(final BendingPlayer bPlayer) {
 		bendingPlayer = bPlayer;
 		player = bPlayer.getPlayer();
 		selectedSlot = player.getInventory().getHeldItemSlot() + 1;

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -38,22 +38,26 @@ public class BendingBoardInstance {
 		public BoardSlot(Scoreboard board, Objective obj, int slot) {
 			this.board = board;
 			this.obj = obj;
-			this.slot = slot;
-			this.team = board.registerNewTeam("slot" + slot);
+			this.slot = slot + 1;
+			this.team = board.registerNewTeam("slot" + this.slot);
 			this.entry = ChatColor.values()[slot % 10] + "" + ChatColor.values()[slot % 16];
 			
 			team.addEntry(entry);
 		}
 		
-		public void update(String prefix, String name) {
-			team.setPrefix(prefix);
-			team.setSuffix(name);
+		private void set() {
 			obj.getScore(entry).setScore(-slot);
 		}
 		
+		public void update(String prefix, String name) {
+			team.setPrefix(prefix);
+			team.setSuffix(name);
+			set();
+		}
+		
 		public void setSlot(int slot) {
-			this.slot = slot;
-			obj.getScore(entry).setScore(-slot);
+			this.slot = slot + 1;
+			set();
 		}
 		
 		public void decreaseSlot() {
@@ -177,7 +181,7 @@ public class BendingBoardInstance {
 
 	public void updateAll() {
 		updateColors();
-		updateSelected(player.getInventory().getHeldItemSlot() + 1);
+		selectedSlot = player.getInventory().getHeldItemSlot() + 1;
 		for (int i = 1; i <= 9; i++) {
 			setSlot(i, bendingPlayer.getAbilities().get(i), false);
 		}
@@ -207,7 +211,7 @@ public class BendingBoardInstance {
 			
 			misc.remove(name);
 		} else {
-			BoardSlot slot = new BoardSlot(bendingBoard, bendingSlots, 11 + misc.size());
+			BoardSlot slot = new BoardSlot(bendingBoard, bendingSlots, 10 + misc.size());
 			slot.update(String.join("", Collections.nCopies(ChatColor.stripColor(prefix).length() + 1, " ")), color + "" + ChatColor.STRIKETHROUGH + name);
 			
 			if (miscTail != null) {

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
@@ -16,6 +15,8 @@ import org.bukkit.scoreboard.Team;
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
+
+import net.md_5.bungee.api.ChatColor;
 
 /**
  * Represents a player's scoreboard for bending purposes
@@ -31,6 +32,7 @@ public class BendingBoardInstance {
 		private String entry;
 		private Optional<BoardSlot> next = Optional.empty();
 		
+		@SuppressWarnings("deprecation")
 		public BoardSlot(Scoreboard board, Objective obj, int slot) {
 			this.board = board;
 			this.obj = obj;
@@ -79,7 +81,8 @@ public class BendingBoardInstance {
 	private final Objective bendingSlots;
 	private int selectedSlot;
 	
-	private String prefix, altPrefix, emptySlot, miscSeparator;
+	private String prefix, emptySlot, miscSeparator;
+	private ChatColor selectedColor, altColor;
 
 	public BendingBoardInstance(final BendingPlayer bPlayer) {
 		bendingPlayer = bPlayer;
@@ -97,8 +100,17 @@ public class BendingBoardInstance {
 			slots[i] = new BoardSlot(bendingBoard, bendingSlots, i);
 		}
 		
-		prefix = ChatColor.translateAlternateColorCodes('&', ConfigManager.languageConfig.get().getString("Board.SelectionPrefix"));
-		altPrefix = ChatColor.BLACK + ChatColor.stripColor(prefix);
+		prefix = ChatColor.stripColor(ConfigManager.languageConfig.get().getString("Board.SelectionPrefix"));
+		
+		try {
+			selectedColor = ChatColor.of(ConfigManager.languageConfig.get().getString("Board.SelectedColor"));
+			altColor = ChatColor.of(ConfigManager.languageConfig.get().getString("Board.NonSelectedColor"));
+		} catch (Exception e) {
+			Bukkit.getLogger().warning(ChatColor.RED + "Failed to parse a BendingBord color option, using defaults");
+			selectedColor = ChatColor.WHITE;
+			altColor = ChatColor.DARK_GRAY;
+		}
+		
 		emptySlot = ChatColor.translateAlternateColorCodes('&', ConfigManager.languageConfig.get().getString("Board.EmptySlot"));
 		miscSeparator = ChatColor.translateAlternateColorCodes('&', ConfigManager.languageConfig.get().getString("Board.MiscSeparator"));
 
@@ -133,7 +145,7 @@ public class BendingBoardInstance {
 			}
 		}
 		
-		slots[slot].update(slot == selectedSlot ? prefix : altPrefix, sb.toString());
+		slots[slot].update((slot == selectedSlot ? selectedColor : altColor) + prefix, sb.toString());
 	}
 
 	public void updateAll() {

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -139,23 +139,23 @@ public class BendingBoardInstance {
 		player.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
 	}
 
-	private void setSlot(int slot, String name, boolean cooldown) {
+	public void setSlot(int slot, String ability, boolean cooldown) {
 		if (slot < 1 || slot > 9 || !player.getScoreboard().equals(bendingBoard)) {
 			return;
 		}
 		
 		StringBuilder sb = new StringBuilder();
 		
-		if (name == null || name.isEmpty()) {
+		if (ability == null || ability.isEmpty()) {
 			sb.append(emptySlot.replaceAll("\\{slot_number\\}", "" + slot));
 		} else {
-			CoreAbility coreAbility = CoreAbility.getAbility(ChatColor.stripColor(name));
+			CoreAbility coreAbility = CoreAbility.getAbility(ChatColor.stripColor(ability));
 			if (coreAbility == null) { // MultiAbility
-				if (cooldown || bendingPlayer.isOnCooldown(name)) {
+				if (cooldown || bendingPlayer.isOnCooldown(ability)) {
 					sb.append(ChatColor.STRIKETHROUGH);
 				}
 				
-				sb.append(name);
+				sb.append(ability);
 			} else {
 				sb.append(coreAbility.getMovePreviewWithoutCooldownTimer(player, cooldown));
 			}
@@ -193,7 +193,7 @@ public class BendingBoardInstance {
 		setSlot(newSlot, bendingPlayer.getAbilities().get(newSlot), false);
 	}
 
-	public void setAbility(String name, boolean cooldown) {
+	public void setAbilityCooldown(String name, boolean cooldown) {
 		bendingPlayer.getAbilities().entrySet().stream().filter(entry -> name.equals(entry.getValue())).forEach(entry -> setSlot(entry.getKey(), name, cooldown));
 	}
 	

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -201,16 +201,21 @@ public class BendingBoardInstance {
 		bendingPlayer.getAbilities().entrySet().stream().filter(entry -> name.equals(entry.getValue())).forEach(entry -> setSlot(entry.getKey(), name, cooldown));
 	}
 	
-	public void updateMisc(String name, ChatColor color) {
-		if (misc.containsKey(name)) {
-			misc.get(name).clear();
-			
-			if (misc.get(name) == miscTail) {
-				miscTail = null;
+	public void updateMisc(String name, ChatColor color, boolean cooldown) {
+		if (!cooldown) {
+			misc.computeIfPresent(name, (key, slot) -> {
+				if (slot == miscTail) {
+					miscTail = null;
+				}
+				
+				slot.clear();
+				return null;
+			});
+				
+			if (misc.isEmpty()) {
+				bendingBoard.resetScores(miscSeparator);
 			}
-			
-			misc.remove(name);
-		} else {
+		} else if (!misc.containsKey(name)) {
 			BoardSlot slot = new BoardSlot(bendingBoard, bendingSlots, 10 + misc.size());
 			slot.update(String.join("", Collections.nCopies(ChatColor.stripColor(prefix).length() + 1, " ")), color + "" + ChatColor.STRIKETHROUGH + name);
 			
@@ -221,10 +226,6 @@ public class BendingBoardInstance {
 			miscTail = slot;
 			misc.put(name, slot);
 			bendingSlots.getScore(miscSeparator).setScore(-10);
-		}
-		
-		if (misc.isEmpty()) {
-			bendingBoard.resetScores(miscSeparator);
-		}
+		}	
 	}
 }

--- a/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardInstance.java
@@ -100,11 +100,11 @@ public class BendingBoardInstance {
 			slots[i] = new BoardSlot(bendingBoard, bendingSlots, i);
 		}
 		
-		prefix = ChatColor.stripColor(ConfigManager.languageConfig.get().getString("Board.SelectionPrefix"));
+		prefix = ChatColor.stripColor(ConfigManager.languageConfig.get().getString("Board.Prefix.Text"));
 		
 		try {
-			selectedColor = ChatColor.of(ConfigManager.languageConfig.get().getString("Board.SelectedColor"));
-			altColor = ChatColor.of(ConfigManager.languageConfig.get().getString("Board.NonSelectedColor"));
+			selectedColor = ChatColor.of(ConfigManager.languageConfig.get().getString("Board.Prefix.SelectedColor"));
+			altColor = ChatColor.of(ConfigManager.languageConfig.get().getString("Board.Prefix.NonSelectedColor"));
 		} catch (Exception e) {
 			Bukkit.getLogger().warning(ChatColor.RED + "Failed to parse a BendingBord color option, using defaults");
 			selectedColor = ChatColor.WHITE;

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -140,19 +140,16 @@ public final class BendingBoardManager {
 				return;
 			} else if (MultiAbilityManager.hasMultiAbilityBound(player)) {
 				scoreboardPlayers.get(player).updateAll();
-				return;
 			}
 			
 			CoreAbility coreAbility = CoreAbility.getAbility(abilityName);
 			if (coreAbility != null && coreAbility instanceof ComboAbility) {
 				scoreboardPlayers.get(player).updateMisc(abilityName, coreAbility.getElement().getColor().asBungee());
-				return;
 			} else if (coreAbility == null && trackedCooldowns.containsKey(abilityName)) {
 				scoreboardPlayers.get(player).updateMisc(abilityName, trackedCooldowns.get(abilityName));
-				return;
+			} else {
+				scoreboardPlayers.get(player).setAbility(abilityName, cooldown);
 			}
-			
-			scoreboardPlayers.get(player).setAbility(abilityName, cooldown);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -57,10 +57,19 @@ public final class BendingBoardManager {
 		disabledWorlds.clear();
 		disabledWorlds.addAll(ConfigManager.getConfig().getStringList("Properties.DisabledWorlds"));
 	}
+	
+	/**
+	 * Check if the player has the BendingBoard toggled off (disabled)
+	 * @param player {@link Player} to check toggled
+	 * @return true if player has the BendingBoard toggled off
+	 */
+	public static boolean isDisabled(Player player) {
+		return disabledPlayers.contains(player.getUniqueId());
+	}
 
 	/**
 	 * Force toggle the scoreboard for when a player changes worlds (for example when teleporting to a world where bending is disabled)
-	 * @param player
+	 * @param player {@link Player} to force toggle for
 	 */
 	public static void forceToggleScoreboard(Player player) {
 		if (disabledWorlds.contains(player.getWorld().getName())) {

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -39,21 +39,18 @@ public final class BendingBoardManager {
 	private static boolean enabled;
 
 	public static void setup() {
-		initialize(true);
+		loadDisabledPlayers();
+		initialize();
 		Bukkit.getOnlinePlayers().forEach(BendingBoardManager::canUseScoreboard);
 	}
 
 	public static void reload() {
 		scoreboardPlayers.values().forEach(BendingBoardInstance::disableScoreboard);
 		scoreboardPlayers.clear();
-		initialize(false);
+		initialize();
 	}
 
-	private static void initialize(boolean initial) {
-		if (initial) {
-			loadDisabledPlayers();
-		}
-		
+	private static void initialize() {
 		enabled = ConfigManager.getConfig().getBoolean("Properties.BendingBoard");
 		disabledWorlds.clear();
 		disabledWorlds.addAll(ConfigManager.getConfig().getStringList("Properties.DisabledWorlds"));
@@ -135,11 +132,13 @@ public final class BendingBoardManager {
 
 	public static void updateBoard(Player player, String abilityName, boolean cooldown, int slot) {
 		if (canUseScoreboard(player)) {
+			if (MultiAbilityManager.hasMultiAbilityBound(player)) {
+				scoreboardPlayers.get(player).updateAll();
+			}
+			
 			if (abilityName == null || abilityName.isEmpty()) {
 				scoreboardPlayers.get(player).clearSlot(slot);
 				return;
-			} else if (MultiAbilityManager.hasMultiAbilityBound(player)) {
-				scoreboardPlayers.get(player).updateAll();
 			}
 			
 			CoreAbility coreAbility = CoreAbility.getAbility(abilityName);

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -146,8 +146,10 @@ public final class BendingBoardManager {
 				scoreboardPlayers.get(player).updateMisc(abilityName, coreAbility.getElement().getColor().asBungee());
 			} else if (coreAbility == null && trackedCooldowns.containsKey(abilityName)) {
 				scoreboardPlayers.get(player).updateMisc(abilityName, trackedCooldowns.get(abilityName));
+			} else if (coreAbility != null && slot > 0) {
+				scoreboardPlayers.get(player).setSlot(slot, abilityName, cooldown);
 			} else {
-				scoreboardPlayers.get(player).setAbility(abilityName, cooldown);
+				scoreboardPlayers.get(player).setAbilityCooldown(abilityName, cooldown);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.BendingPlayer;
@@ -52,8 +53,21 @@ public final class BendingBoardManager {
 
 	private static void initialize() {
 		enabled = ConfigManager.getConfig().getBoolean("Properties.BendingBoard");
+		
 		disabledWorlds.clear();
 		disabledWorlds.addAll(ConfigManager.getConfig().getStringList("Properties.DisabledWorlds"));
+		
+		if (ConfigManager.languageConfig.get().contains("Boards.Extra")) {
+			ConfigurationSection section = ConfigManager.languageConfig.get().getConfigurationSection("Board.Extras");
+			for (String key : section.getKeys(false)) {
+				try {
+					trackedCooldowns.put(key, ChatColor.of(section.getString(key)));
+				} catch (Exception e) {
+					ProjectKorra.plugin.getLogger().warning("Couldn't parse color from 'Board.Extras." + key + "', using white.");
+					trackedCooldowns.put(key, ChatColor.WHITE);
+				}
+			}
+		}
 	}
 	
 	/**

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -62,7 +62,6 @@ public final class BendingBoardManager {
 			for (String key : section.getKeys(false)) {
 				try {
 					trackedCooldowns.put(key, ChatColor.of(section.getString(key)));
-					ProjectKorra.plugin.getLogger().info("Tracking " + key + "");
 				} catch (Exception e) {
 					ProjectKorra.plugin.getLogger().warning("Couldn't parse color from 'Board.Extras." + key + "', using white.");
 					trackedCooldowns.put(key, ChatColor.WHITE);

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.BendingPlayer;
@@ -22,6 +21,8 @@ import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.util.MultiAbilityManager;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.storage.DBConnection;
+
+import net.md_5.bungee.api.ChatColor;
 
 /**
  * Manages every individual {@link BendingBoardInstance}
@@ -144,7 +145,7 @@ public final class BendingBoardManager {
 			
 			CoreAbility coreAbility = CoreAbility.getAbility(abilityName);
 			if (coreAbility != null && coreAbility instanceof ComboAbility) {
-				scoreboardPlayers.get(player).updateMisc(abilityName, coreAbility.getElement().getColor());
+				scoreboardPlayers.get(player).updateMisc(abilityName, coreAbility.getElement().getColor().asBungee());
 				return;
 			} else if (coreAbility == null && trackedCooldowns.containsKey(abilityName)) {
 				scoreboardPlayers.get(player).updateMisc(abilityName, trackedCooldowns.get(abilityName));

--- a/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -57,11 +57,12 @@ public final class BendingBoardManager {
 		disabledWorlds.clear();
 		disabledWorlds.addAll(ConfigManager.getConfig().getStringList("Properties.DisabledWorlds"));
 		
-		if (ConfigManager.languageConfig.get().contains("Boards.Extra")) {
+		if (ConfigManager.languageConfig.get().contains("Board.Extras")) {
 			ConfigurationSection section = ConfigManager.languageConfig.get().getConfigurationSection("Board.Extras");
 			for (String key : section.getKeys(false)) {
 				try {
 					trackedCooldowns.put(key, ChatColor.of(section.getString(key)));
+					ProjectKorra.plugin.getLogger().info("Tracking " + key + "");
 				} catch (Exception e) {
 					ProjectKorra.plugin.getLogger().warning("Couldn't parse color from 'Board.Extras." + key + "', using white.");
 					trackedCooldowns.put(key, ChatColor.WHITE);
@@ -157,9 +158,9 @@ public final class BendingBoardManager {
 			
 			CoreAbility coreAbility = CoreAbility.getAbility(abilityName);
 			if (coreAbility != null && coreAbility instanceof ComboAbility) {
-				scoreboardPlayers.get(player).updateMisc(abilityName, coreAbility.getElement().getColor().asBungee());
+				scoreboardPlayers.get(player).updateMisc(abilityName, coreAbility.getElement().getColor().asBungee(), cooldown);
 			} else if (coreAbility == null && trackedCooldowns.containsKey(abilityName)) {
-				scoreboardPlayers.get(player).updateMisc(abilityName, trackedCooldowns.get(abilityName));
+				scoreboardPlayers.get(player).updateMisc(abilityName, trackedCooldowns.get(abilityName), cooldown);
 			} else if (coreAbility != null && slot > 0) {
 				scoreboardPlayers.get(player).setSlot(slot, abilityName, cooldown);
 			} else {

--- a/src/com/projectkorra/projectkorra/command/BoardCommand.java
+++ b/src/com/projectkorra/projectkorra/command/BoardCommand.java
@@ -22,6 +22,6 @@ public class BoardCommand extends PKCommand {
 		if (!this.hasPermission(sender) || !this.isPlayer(sender) || !this.correctLength(sender, args.size(), 0, 0)) {
 			return;
 		}
-		BendingBoardManager.toggleScoreboard((Player) sender);
+		BendingBoardManager.toggleBoard((Player) sender, false);
 	}
 }

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -75,9 +75,9 @@ public class ConfigManager {
 			config.addDefault("Chat.Prefixes.Nonbender", "[Nonbender]");
 
 			config.addDefault("Board.Title", "&lAbilities");
-			config.addDefault("Board.SelectionPrefix", "> ");
-			config.addDefault("Board.SelectedColor", ChatColor.WHITE.toString());
-			config.addDefault("Board.NonSelectedColor", ChatColor.DARK_GRAY.toString());
+			config.addDefault("Board.Prefix.Text", "> ");
+			config.addDefault("Board.Prefix.SelectedColor", ChatColor.WHITE.toString());
+			config.addDefault("Board.Prefix.NonSelectedColor", ChatColor.DARK_GRAY.toString());
 			config.addDefault("Board.EmptySlot", "&8-- Slot {slot_number} --");
 			config.addDefault("Board.MiscSeparator", "  ------------");
 

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -76,10 +76,15 @@ public class ConfigManager {
 
 			config.addDefault("Board.Title", "&lAbilities");
 			config.addDefault("Board.Prefix.Text", "> ");
-			config.addDefault("Board.Prefix.SelectedColor", ChatColor.WHITE.toString());
-			config.addDefault("Board.Prefix.NonSelectedColor", ChatColor.DARK_GRAY.toString());
+			config.addDefault("Board.Prefix.SelectedColor", ChatColor.WHITE.getName());
+			config.addDefault("Board.Prefix.NonSelectedColor", ChatColor.DARK_GRAY.getName());
 			config.addDefault("Board.EmptySlot", "&8-- Slot {slot_number} --");
-			config.addDefault("Board.MiscSeparator", "  ------------");
+			config.addDefault("Board.MiscSeparator", "  ----------");
+			
+			if (!config.contains("Board.Extras")) {
+				config.addDefault("Board.Extras.RaiseEarthWall", ChatColor.GREEN.getName());
+				config.addDefault("Board.Extras.SurgeWave", ChatColor.AQUA.getName());
+			}
 
 			config.addDefault("Extras.Water.NightMessage", "Your waterbending has become empowered due to the moon rising.");
 			config.addDefault("Extras.Water.DayMessage", "You feel the empowering of your waterbending subside as the moon sets.");

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 
+import net.md_5.bungee.api.ChatColor;
+
 public class ConfigManager {
 
 	public static Config presetConfig;
@@ -73,7 +75,9 @@ public class ConfigManager {
 			config.addDefault("Chat.Prefixes.Nonbender", "[Nonbender]");
 
 			config.addDefault("Board.Title", "&lAbilities");
-			config.addDefault("Board.SelectionPrefix", ">  &r");
+			config.addDefault("Board.SelectionPrefix", "> ");
+			config.addDefault("Board.SelectedColor", ChatColor.WHITE.toString());
+			config.addDefault("Board.NonSelectedColor", ChatColor.DARK_GRAY.toString());
 			config.addDefault("Board.EmptySlot", "&8-- Slot {slot_number} --");
 			config.addDefault("Board.MiscSeparator", "  ------------");
 

--- a/src/com/projectkorra/projectkorra/event/PlayerBindChangeEvent.java
+++ b/src/com/projectkorra/projectkorra/event/PlayerBindChangeEvent.java
@@ -1,78 +1,84 @@
 package com.projectkorra.projectkorra.event;
 
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 /**
  * Called when a player binds or unbinds an ability
- *
- * @author savior67
  */
-public class PlayerBindChangeEvent extends Event {
+public class PlayerBindChangeEvent extends Event implements Cancellable {
 
-	private static final HandlerList handlers = new HandlerList();
+	private static final HandlerList HANDLERS = new HandlerList();
+	
+	private boolean cancelled = false;
+	
 	private final Player player;
 	private final String ability;
-	private final int slot; // slot is -1 if it is a multiability.
-	private final boolean isBinding; // true if the ability is being binded, otherwise false.
-	private final boolean isMultiAbility; // true if the ability is a multiability.
-	private boolean cancelled;
+	private final int slot; 
+	private final boolean isBinding, isMultiAbility; 
 
-	// bind event for abilities.
-	public PlayerBindChangeEvent(final Player player, final String ability, final int slot, final boolean isBinding) {
+	public PlayerBindChangeEvent(Player player, String ability, int slot, boolean isBinding, boolean isMultiAbility) {
 		this.player = player;
 		this.ability = ability;
 		this.slot = slot;
 		this.isBinding = isBinding;
-		this.cancelled = false;
-		this.isMultiAbility = false;
-	}
-
-	// used for multi abilities.
-	public PlayerBindChangeEvent(final Player player, final String ability, final boolean isBinding) {
-		this.player = player;
-		this.ability = ability;
-		this.slot = -1;
-		this.isBinding = isBinding;
-		this.cancelled = false;
-		this.isMultiAbility = true;
-	}
-
-	public String getAbility() {
-		return this.ability;
-	}
-
-	@Override
-	public HandlerList getHandlers() {
-		return handlers;
-	}
-
-	public static HandlerList getHandlerList() {
-		return handlers;
+		this.isMultiAbility = isMultiAbility;
 	}
 
 	public Player getPlayer() {
 		return this.player;
 	}
 
+	public String getAbility() {
+		return this.ability;
+	}
+
+	/**
+	 * Get the slot being changed. 
+	 * <ul>
+	 * <li>In the case of binding a multiability, returns 0
+	 * <li>In the case of unbinding a multiability, returns the original slot
+	 * </ul>
+	 * @return affected slot
+	 */
 	public int getSlot() {
 		return this.slot;
 	}
 
+	/**
+	 * Get whether this event is binding or unbinding an ability
+	 * @return true if binding, false if unbinding
+	 */
 	public boolean isBinding() {
 		return this.isBinding;
 	}
 
-	public boolean isCancelled() {
-		return this.cancelled;
-	}
-
+	/**
+	 * Get whether this event was caused by a multiability or not
+	 * @return true if caused by multiability
+	 */
 	public boolean isMultiAbility() {
 		return this.isMultiAbility;
 	}
 
+	@Override
+	public boolean isCancelled() {
+		return this.cancelled;
+	}
+
+	@Override
 	public void setCancelled(final boolean cancelled) {
 		this.cancelled = cancelled;
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
 	}
 }

--- a/src/com/projectkorra/projectkorra/event/PlayerBindChangeEvent.java
+++ b/src/com/projectkorra/projectkorra/event/PlayerBindChangeEvent.java
@@ -26,6 +26,10 @@ public class PlayerBindChangeEvent extends Event implements Cancellable {
 		this.isBinding = isBinding;
 		this.isMultiAbility = isMultiAbility;
 	}
+	
+	public PlayerBindChangeEvent(Player player, String ability, boolean isBinding, boolean isMultiAbility) {
+		this(player, ability, player.getInventory().getHeldItemSlot(), isBinding, isMultiAbility);
+	}
 
 	public Player getPlayer() {
 		return this.player;
@@ -36,7 +40,7 @@ public class PlayerBindChangeEvent extends Event implements Cancellable {
 	}
 
 	/**
-	 * Get the slot being changed. 
+	 * Get the slot being changed. Binding normal abilities will return the slot that it is being bound to / unbound from
 	 * <ul>
 	 * <li>In the case of binding a multiability, returns 0
 	 * <li>In the case of unbinding a multiability, returns the original slot

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
@@ -167,8 +167,13 @@ public class WaterArmsFreeze extends IceAbility {
 	}
 
 	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
+
+	@Override
 	public String getName() {
-		return "WaterArms";
+		return "WaterArmsFreeze";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
@@ -278,8 +278,13 @@ public class WaterArmsSpear extends WaterAbility {
 	}
 
 	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
+
+	@Override
 	public String getName() {
-		return "WaterArms";
+		return "WaterArmsSpear";
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -427,8 +427,13 @@ public class WaterArmsWhip extends WaterAbility {
 	}
 
 	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
+
+	@Override
 	public String getName() {
-		return "WaterArms";
+		return "WaterArmsWhip";
 	}
 
 	@Override


### PR DESCRIPTION
## Additions
* Adds `BendingBoardManager#isDisabled(Player)` to check if a Player has the BendingBoard disabled.
* Adds much needed documentation to BendingBoardManager
* Adds `element` option for the BendingBoard prefix colors

## Fixes
* Fixes board flickering.
* Fixes WaterArms showing up under ice abilities and as an ice ability in some displays

## Misc. Changes
* Changes prefix to have main and alternate color config options for the active and non-active slots respectively
* Changes miscellaneous section to work more effectively.
* Cleans up some SQL statements to follow proper syntax casing conventions.
* Optimizes board code in general.
* Changes `BendingBoardInstance` to `BendingBoard`
* Updates documentation for `BendingBoardManager`
* Merges `BendingBoardManager#toggleBoard(Player)` and `BendingBoardManager#forceToggleBoard(Player)` into the same method with a `force` boolean parameter `BendingBoardManager#toggleBoard(Player, boolean)`
* Changes `BendingBoardManager#canUseScoreboard` to `BendingBoardManager#getBoard : Optional<BendingBoard>`
* Adds `Board.Extras` section with defaults for server owners to add trackable miscellaneous names on the bendingboard
* Standardizes the PlayerBindChangeEvent so that it is called before the bind changes and is actually cancellable
* Cleans up the MultiAbilityManager codewise
* Changes ChatColor import in BendingBoard to the bungee import, allowing for hex colors in the board config options
* Changes WaterArms sub-abilities (freeze, spear, whip) to be hidden (for the aforementioned WaterArms fix)
* Changes BendingBoard to update when elements are added
