### PR TITLE
Fix AbilityDamageEntityEvent Being Called Unnecessarily

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -39,7 +39,6 @@ import org.bukkit.event.entity.EntityDamageByBlockEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
@@ -144,7 +143,6 @@ import com.projectkorra.projectkorra.event.HorizontalVelocityChangeEvent;
 import com.projectkorra.projectkorra.event.PlayerBindChangeEvent;
 import com.projectkorra.projectkorra.event.PlayerChangeElementEvent;
 import com.projectkorra.projectkorra.event.PlayerChangeSubElementEvent;
-import com.projectkorra.projectkorra.event.PlayerCooldownChangeEvent;
 import com.projectkorra.projectkorra.event.PlayerJumpEvent;
 import com.projectkorra.projectkorra.event.PlayerStanceChangeEvent;
 import com.projectkorra.projectkorra.firebending.Blaze;
@@ -526,12 +524,6 @@ public class PKListener implements Listener {
 		if (FireDamageTimer.isEnflamed(entity) && event.getCause() == DamageCause.FIRE_TICK) {
 			event.setCancelled(true);
 			FireDamageTimer.dealFlameDamage(entity);
-		}
-
-		if (entity instanceof LivingEntity && TempArmor.hasTempArmor((LivingEntity) entity)) {
-			if (event.isApplicable(DamageModifier.ARMOR)) {
-				event.setDamage(DamageModifier.ARMOR, 0);
-			}
 		}
 
 		if (entity instanceof Player) {
@@ -2033,7 +2025,7 @@ public class PKListener implements Listener {
 		final Player player = event.getBendingPlayer().getPlayer();
 		BendingBoardManager.canUseScoreboard(player);
 	}
-
+	
 	public static HashMap<Player, String> getBendingPlayerDeath() {
 		return BENDING_PLAYER_DEATH;
 	}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -2025,7 +2025,7 @@ public class PKListener implements Listener {
 		final Player player = event.getBendingPlayer().getPlayer();
 		BendingBoardManager.canUseScoreboard(player);
 	}
-	
+
 	public static HashMap<Player, String> getBendingPlayerDeath() {
 		return BENDING_PLAYER_DEATH;
 	}

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -1,13 +1,14 @@
 package com.projectkorra.projectkorra.util;
 
 import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
 
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.command.Commands;
@@ -28,64 +29,76 @@ public class DamageHandler {
 	 * @param damage The amount of damage to deal
 	 */
 	public static void damageEntity(final Entity entity, Player source, double damage, final Ability ability, boolean ignoreArmor) {
-		if (entity instanceof LivingEntity && TempArmor.hasTempArmor((LivingEntity) entity)) {
-			ignoreArmor = true;
-		}
 		if (ability == null) {
 			return;
 		}
+		
+		if (entity instanceof LivingEntity) {
+			if (((LivingEntity) entity).getNoDamageTicks() > 0) {
+				return;
+			}
+			
+			if (TempArmor.hasTempArmor((LivingEntity) entity)) {
+				ignoreArmor = true;
+			}
+		}
+		
 		if (source == null) {
 			source = ability.getPlayer();
 		}
 
 		final AbilityDamageEntityEvent damageEvent = new AbilityDamageEntityEvent(entity, ability, damage, ignoreArmor);
+		
+		if (entity instanceof Player && Commands.invincible.contains(entity.getName())) {
+			damageEvent.setCancelled(true);
+		}
+		
 		Bukkit.getServer().getPluginManager().callEvent(damageEvent);
-		if (entity instanceof LivingEntity) {
-			if (entity instanceof Player && Commands.invincible.contains(entity.getName())) {
-				damageEvent.setCancelled(true);
+		
+		if (entity instanceof LivingEntity && !damageEvent.isCancelled()) {
+			LivingEntity lent = (LivingEntity) entity;
+			damage = Math.max(0, damageEvent.getDamage());
+			
+			if (damageEvent.doesIgnoreArmor() && damage > 0) {
+				double defense = lent.getAttribute(Attribute.GENERIC_ARMOR).getValue();
+				double toughness = lent.getAttribute(Attribute.GENERIC_ARMOR_TOUGHNESS).getValue();
+				damage /= 1 - (Math.min(20, Math.max(defense / 5, defense - 4 * damage / (toughness + 8)))) / 25;
 			}
-			if (!damageEvent.isCancelled()) {
-				damage = damageEvent.getDamage();
-				if (Bukkit.getPluginManager().isPluginEnabled("NoCheatPlus") && source != null) {
-					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_REACH);
-					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_DIRECTION);
-					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_NOSWING);
-					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_SPEED);
-					NCPExemptionManager.exemptPermanently(source, CheckType.COMBINED_IMPROBABLE);
-					NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_SELFHIT);
-				}
+			
+			if (Bukkit.getPluginManager().isPluginEnabled("NoCheatPlus") && source != null) {
+				NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_REACH);
+				NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_DIRECTION);
+				NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_NOSWING);
+				NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_SPEED);
+				NCPExemptionManager.exemptPermanently(source, CheckType.COMBINED_IMPROBABLE);
+				NCPExemptionManager.exemptPermanently(source, CheckType.FIGHT_SELFHIT);
+			}
 
-				if (((LivingEntity) entity).getHealth() - damage <= 0 && !entity.isDead()) {
-					final EntityBendingDeathEvent event = new EntityBendingDeathEvent(entity, damage, ability);
-					Bukkit.getServer().getPluginManager().callEvent(event);
-				}
+			if (lent.getHealth() - damage <= 0 && !entity.isDead()) {
+				final EntityBendingDeathEvent event = new EntityBendingDeathEvent(entity, damage, ability);
+				Bukkit.getServer().getPluginManager().callEvent(event);
+			}
 
-				final EntityDamageByEntityEvent finalEvent = new EntityDamageByEntityEvent(source, entity, DamageCause.CUSTOM, damage);
-				final double prevHealth = ((LivingEntity) entity).getHealth();
-				((LivingEntity) entity).damage(damage, source);
-				final double nextHealth = ((LivingEntity) entity).getHealth();
-				entity.setLastDamageCause(finalEvent);
-				if (ignoreArmor) {
-					if (finalEvent.isApplicable(DamageModifier.ARMOR)) {
-						finalEvent.setDamage(DamageModifier.ARMOR, 0);
-					}
-				}
+			final EntityDamageByEntityEvent finalEvent = new EntityDamageByEntityEvent(source, entity, DamageCause.CUSTOM, damage);
+			final double prevHealth = lent.getHealth();
+			lent.damage(damage, source);
+			final double nextHealth = lent.getHealth();
+			entity.setLastDamageCause(finalEvent);
 
-				if (Bukkit.getPluginManager().isPluginEnabled("NoCheatPlus") && source != null) {
-					NCPExemptionManager.unexempt(source, CheckType.FIGHT_REACH);
-					NCPExemptionManager.unexempt(source, CheckType.FIGHT_DIRECTION);
-					NCPExemptionManager.unexempt(source, CheckType.FIGHT_NOSWING);
-					NCPExemptionManager.unexempt(source, CheckType.FIGHT_SPEED);
-					NCPExemptionManager.unexempt(source, CheckType.COMBINED_IMPROBABLE);
-					NCPExemptionManager.unexempt(source, CheckType.FIGHT_SELFHIT);
-				}
+			if (Bukkit.getPluginManager().isPluginEnabled("NoCheatPlus") && source != null) {
+				NCPExemptionManager.unexempt(source, CheckType.FIGHT_REACH);
+				NCPExemptionManager.unexempt(source, CheckType.FIGHT_DIRECTION);
+				NCPExemptionManager.unexempt(source, CheckType.FIGHT_NOSWING);
+				NCPExemptionManager.unexempt(source, CheckType.FIGHT_SPEED);
+				NCPExemptionManager.unexempt(source, CheckType.COMBINED_IMPROBABLE);
+				NCPExemptionManager.unexempt(source, CheckType.FIGHT_SELFHIT);
+			}
 
-				if (prevHealth != nextHealth) {
-					if (entity instanceof Player) {
-						StatisticsMethods.addStatisticAbility(source.getUniqueId(), CoreAbility.getAbility(ability.getName()), Statistic.PLAYER_DAMAGE, (long) damage);
-					}
-					StatisticsMethods.addStatisticAbility(source.getUniqueId(), CoreAbility.getAbility(ability.getName()), Statistic.TOTAL_DAMAGE, (long) damage);
+			if (prevHealth != nextHealth) {
+				if (entity instanceof Player) {
+					StatisticsMethods.addStatisticAbility(source.getUniqueId(), CoreAbility.getAbility(ability.getName()), Statistic.PLAYER_DAMAGE, (long) damage);
 				}
+				StatisticsMethods.addStatisticAbility(source.getUniqueId(), CoreAbility.getAbility(ability.getName()), Statistic.TOTAL_DAMAGE, (long) damage);
 			}
 		}
 


### PR DESCRIPTION
## Fixes
* Fixes AbilityDamageEntityEvent being called unnecessarily
* Fixes ignoreArmor param for `DamageHandler#damageEntity`

## Misc. Changes
* Cleans up `DamageHandler#damageEntity` code
