### PR TITLE
Fix RapidPunch adding cooldown before start

### DIFF
--- a/src/com/projectkorra/projectkorra/chiblocking/RapidPunch.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/RapidPunch.java
@@ -35,8 +35,10 @@ public class RapidPunch extends ChiAbility {
 		this.cooldown = getConfig().getLong("Abilities.Chi.RapidPunch.Cooldown");
 		this.interval = getConfig().getLong("Abilities.Chi.RapidPunch.Interval");
 		this.target = targetentity;
-		this.bPlayer.addCooldown(this);
 		this.start();
+		if(!isRemoved()) {
+			this.bPlayer.addCooldown(this);
+		}
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/chiblocking/RapidPunch.java
+++ b/src/com/projectkorra/projectkorra/chiblocking/RapidPunch.java
@@ -36,7 +36,7 @@ public class RapidPunch extends ChiAbility {
 		this.interval = getConfig().getLong("Abilities.Chi.RapidPunch.Interval");
 		this.target = targetentity;
 		this.start();
-		if(!isRemoved()) {
+		if (!isRemoved()) {
 			this.bPlayer.addCooldown(this);
 		}
 	}


### PR DESCRIPTION
## Fixes
* Fixes RapidPunch adding cooldown before it starts. With this fix, addon developers will be able to prevent the ability from getting activated without getting it on cooldown.
