### PR TITLE
Fix issues in Flight and FlightHandler

### DIFF
--- a/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -155,7 +155,7 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 
 	@Override
 	public void progress() {
-		if (!this.player.isOnline() || this.player.isDead()) {
+		if (!this.player.isOnline() || this.player.isDead() || !this.bPlayer.canBendIgnoreBinds(this)) {
 			this.remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/util/FlightHandler.java
+++ b/src/com/projectkorra/projectkorra/util/FlightHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.UUID;
 
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -130,8 +131,18 @@ public class FlightHandler extends Manager {
 	 */
 	private void wipeInstance(final Player player) {
 		final Flight flight = this.INSTANCES.get(player.getUniqueId());
-		player.setAllowFlight(flight.couldFly);
-		player.setFlying(flight.wasFlying);
+
+		if (player.getGameMode() == GameMode.SPECTATOR) {
+			player.setAllowFlight(true);
+			player.setFlying(true);
+		} else if (player.getGameMode() == GameMode.CREATIVE) {
+			player.setAllowFlight(true);
+			player.setFlying(flight.wasFlying);
+		} else {
+			player.setAllowFlight(flight.couldFly);
+			player.setFlying(flight.wasFlying);
+		}
+
 		flight.abilities.values().forEach(ability -> this.CLEANUP.remove(ability));
 		this.INSTANCES.remove(player.getUniqueId());
 	}


### PR DESCRIPTION
## Fixes
* Fixes Flight not ending when switching elements or changing to spectator mode while the ability is running.
* Fixes FlightHandler not properly respecting gamemode changes that occur while abilities are running.
  * If a player switched to spectator mode while an ability was running, it is very likely they would fall into the void and die.
  * If a player switched to creative mode while an ability was running, they might not have been able to fly.
  * This change has the potential to cause issues if abilities change a player's gamemode. Addon developers must resolve gamemode resets before reverting FlightHandler data.