### PR TITLE
Add Nether Gold and Gilded Blackstone support to Extraction

### DIFF
--- a/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
@@ -63,6 +63,16 @@ public class Extraction extends MetalAbility {
 					player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.QUARTZ, this.getAmount()));
 					type = Material.NETHERRACK;
 					break;
+				case NETHER_GOLD_ORE:
+					this.originBlock.setType(Material.NETHERRACK);
+					player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.GOLD_NUGGET, this.getAmount() * 6));
+					type = Material.NETHERRACK;
+					break;
+				case GILDED_BLACKSTONE:
+					this.originBlock.setType(Material.BLACKSTONE);
+					player.getWorld().dropItem(player.getLocation(), new ItemStack(Material.GOLD_NUGGET, this.getAmount() * 5));
+					type = Material.BLACKSTONE;
+					break;
 				default:
 					return;
 			}


### PR DESCRIPTION
## Additions
* Adds Nether Gold and Gilded Blackstone interactions to Extraction.
    * Nether Gold will give 6, 12, or 18 gold nuggets depending on the double and triple chance of Extraction.
    * Gilded Blackstone will give 5, 10, or 15 gold nuggets depending on the double and triple chance of Extraction.