### PR TITLE
Fix Clear Command not using PlayerBindChangeEvent

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -2010,7 +2010,11 @@ public class PKListener implements Listener {
 				
 			}.runTaskLater(ProjectKorra.plugin, 1);
 		} else {
-			BendingBoardManager.updateBoard(player, event.getAbility(), false, event.getSlot());
+			if (event.isBinding()) {
+				BendingBoardManager.updateBoard(player, event.getAbility(), false, event.getSlot());
+			} else {
+				BendingBoardManager.updateBoard(player, "", false, event.getSlot());
+			}
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/command/ClearCommand.java
+++ b/src/com/projectkorra/projectkorra/command/ClearCommand.java
@@ -10,8 +10,10 @@ import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.util.MultiAbilityManager;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
+import com.projectkorra.projectkorra.event.PlayerBindChangeEvent;
 
 /**
  * Executor for /bending clear. Extends {@link PKCommand}.
@@ -49,8 +51,19 @@ public class ClearCommand extends PKCommand {
 			bPlayer = BendingPlayer.getBendingPlayer(sender.getName());
 		}
 		if (args.size() == 0) {
-			bPlayer.getAbilities().clear();
 			for (int i = 1; i <= 9; i++) {
+				if (!bPlayer.getAbilities().containsKey(i)) {
+					continue;
+				}
+
+				PlayerBindChangeEvent event = new PlayerBindChangeEvent(bPlayer.getPlayer(), bPlayer.getAbilities().get(i), i, false, false);
+				ProjectKorra.plugin.getServer().getPluginManager().callEvent(event);
+				
+				if (event.isCancelled()) {
+					continue;
+				}
+
+				bPlayer.getAbilities().remove(i);
 				GeneralMethods.saveAbility(bPlayer, i, null);
 			}
 			GeneralMethods.sendBrandingMessage(sender, ChatColor.YELLOW + this.cleared);
@@ -60,7 +73,15 @@ public class ClearCommand extends PKCommand {
 				if (slot < 1 || slot > 9) {
 					GeneralMethods.sendBrandingMessage(sender, ChatColor.RED + this.wrongNumber);
 				}
+
 				if (bPlayer.getAbilities().get(slot) != null) {
+					PlayerBindChangeEvent event = new PlayerBindChangeEvent(bPlayer.getPlayer(), bPlayer.getAbilities().get(slot), slot, false, false);
+					ProjectKorra.plugin.getServer().getPluginManager().callEvent(event);
+					
+					if (event.isCancelled()) {
+						return;
+					}
+
 					bPlayer.getAbilities().remove(slot);
 					GeneralMethods.saveAbility(bPlayer, slot, null);
 					GeneralMethods.sendBrandingMessage(sender, ChatColor.YELLOW + this.clearedSlot.replace("{slot}", String.valueOf(slot)));


### PR DESCRIPTION
## Fixes
* Fixes the `/pk clear [#]` command not utilizing/respecting the PlayerBindChangeEvent.
    * Allows addon developers to properly cancel the effects of the `/pk clear [#]` command.
    * Fixes the Bending Board so that it properly updates in the event the `/pk clear [#]` command is used.