### PR TITLE
Fixes for 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.16.1-R0.1-SNAPSHOT</version>
+      <version>1.18-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <!-- lang3 -->

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -589,20 +589,20 @@ public class GeneralMethods {
 		loc.setY(loc.getY() + (Math.random() * 2 - 1) * yOffset);
 		loc.setZ(loc.getZ() + (Math.random() * 2 - 1) * zOffset);
 
-		if (type != ParticleEffect.RED_DUST && type != ParticleEffect.REDSTONE && type != ParticleEffect.SPELL_MOB && type != ParticleEffect.MOB_SPELL && type != ParticleEffect.SPELL_MOB_AMBIENT && type != ParticleEffect.MOB_SPELL_AMBIENT) {
-			type = ParticleEffect.RED_DUST;
+		if (type != ParticleEffect.REDSTONE && type != ParticleEffect.REDSTONE && type != ParticleEffect.SPELL_MOB && type != ParticleEffect.SPELL_MOB_AMBIENT) {
+			type = ParticleEffect.REDSTONE;
 		}
 		type.display(loc, 0, red, green, blue);
 	}
 
 	@Deprecated
 	public static void displayColoredParticle(final Location loc, final String hexVal) {
-		displayColoredParticle(loc, ParticleEffect.RED_DUST, hexVal, 0, 0, 0);
+		displayColoredParticle(loc, ParticleEffect.REDSTONE, hexVal, 0, 0, 0);
 	}
 
 	@Deprecated
 	public static void displayColoredParticle(final Location loc, final String hexVal, final float xOffset, final float yOffset, final float zOffset) {
-		displayColoredParticle(loc, ParticleEffect.RED_DUST, hexVal, xOffset, yOffset, zOffset);
+		displayColoredParticle(loc, ParticleEffect.REDSTONE, hexVal, xOffset, yOffset, zOffset);
 	}
 
 	public static void displayColoredParticle(String hexVal, final Location loc, final int amount, final double offsetX, final double offsetY, final double offsetZ) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -468,23 +468,24 @@ public class ConfigManager {
 			earthBlocks.add("LARGE_AMETHYST_BUD"); // use Material in 1.17
 			earthBlocks.add("MEDIUM_AMETHYST_BUD"); // use Material in 1.17
 			earthBlocks.add("SMALL_AMETHYST_BUD"); // use Material in 1.17
-			earthBlocks.add(Material.ANCIENT_DEBRIS.toString());
-			earthBlocks.add(Material.CLAY.toString());
-			earthBlocks.add(Material.COAL_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.COARSE_DIRT.toString());
-			earthBlocks.add(Material.COBBLESTONE.toString());
-			earthBlocks.add(Material.COBBLESTONE_SLAB.toString());
-			earthBlocks.add(Material.DIAMOND_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.DIRT.toString());
-			earthBlocks.add(Material.EMERALD_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.GRASS_BLOCK.toString());
-			earthBlocks.add(Material.GRASS_PATH.toString());
-			earthBlocks.add(Material.GRAVEL.toString());
-			earthBlocks.add(Material.LAPIS_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.MYCELIUM.toString());
-			earthBlocks.add(Material.PODZOL.toString());
-			earthBlocks.add(Material.REDSTONE_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.STONE_SLAB.toString());
+			earthBlocks.add("ANCIENT_DEBRIS");
+			earthBlocks.add("CLAY");
+			earthBlocks.add("COAL_ORE"); // no longer needed in 1.17
+			earthBlocks.add("COARSE_DIRT");
+			earthBlocks.add("COBBLESTONE");
+			earthBlocks.add("COBBLESTONE_SLAB");
+			earthBlocks.add("DIAMOND_ORE"); // no longer needed in 1.17
+			earthBlocks.add("DIRT");
+			earthBlocks.add("EMERALD_ORE"); // no longer needed in 1.17
+			earthBlocks.add("GRASS_BLOCK");
+			earthBlocks.add("GRASS_PATH");
+			earthBlocks.add("DIRT_PATH");
+			earthBlocks.add("GRAVEL");
+			earthBlocks.add("LAPIS_ORE"); // no longer needed in 1.17
+			earthBlocks.add("MYCELIUM");
+			earthBlocks.add("PODZOL");
+			earthBlocks.add("REDSTONE_ORE"); // no longer needed in 1.17
+			earthBlocks.add("STONE_SLAB");
 
 			final ArrayList<String> metalBlocks = new ArrayList<String>();
 			metalBlocks.add("#copper_ores"); // added in 1.17
@@ -525,21 +526,22 @@ public class ConfigManager {
 			metalBlocks.add("WEATHERED_CUT_COPPER"); // use Material in 1.17
 			metalBlocks.add("WEATHERED_CUT_COPPER_SLAB"); // use Material in 1.17
 			metalBlocks.add("WEATHERED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add(Material.CHAIN.toString());
-			metalBlocks.add(Material.GILDED_BLACKSTONE.toString());
-			metalBlocks.add(Material.GOLD_BLOCK.toString());
-			metalBlocks.add(Material.IRON_BLOCK.toString());
-			metalBlocks.add(Material.IRON_ORE.toString()); // no longer needed in 1.17
-			metalBlocks.add(Material.NETHERITE_BLOCK.toString());
-			metalBlocks.add(Material.NETHER_QUARTZ_ORE.toString());
-			metalBlocks.add(Material.QUARTZ_BLOCK.toString());
+			metalBlocks.add("CHAIN");
+			metalBlocks.add("GILDED_BLACKSTONE");
+			metalBlocks.add("GOLD_BLOCK");
+			metalBlocks.add("GOLD_ORE");
+			metalBlocks.add("IRON_BLOCK");
+			metalBlocks.add("IRON_ORE"); // no longer needed in 1.17
+			metalBlocks.add("NETHERITE_BLOCK");
+			metalBlocks.add("NETHER_QUARTZ_ORE");
+			metalBlocks.add("QUARTZ_BLOCK");
 
 			final ArrayList<String> sandBlocks = new ArrayList<String>();
 			sandBlocks.add("#sand");
-			sandBlocks.add(Material.RED_SANDSTONE.toString());
-			sandBlocks.add(Material.RED_SANDSTONE_SLAB.toString());
-			sandBlocks.add(Material.SANDSTONE.toString());
-			sandBlocks.add(Material.SANDSTONE_SLAB.toString());
+			sandBlocks.add("RED_SANDSTONE");
+			sandBlocks.add("RED_SANDSTONE_SLAB");
+			sandBlocks.add("SANDSTONE");
+			sandBlocks.add("SANDSTONE_SLAB");
 
 			final ArrayList<String> iceBlocks = new ArrayList<String>();
 			iceBlocks.add("#ice");
@@ -555,35 +557,35 @@ public class ConfigManager {
 			plantBlocks.add("MOSS_CARPET"); // use Material in 1.17
 			plantBlocks.add("SMALL_DRIPLEAF"); // use Material in 1.17
 			plantBlocks.add("SPORE_BLOSSOM"); // use Material in 1.17
-			plantBlocks.add(Material.BROWN_MUSHROOM.toString());
-			plantBlocks.add(Material.BROWN_MUSHROOM_BLOCK.toString());
-			plantBlocks.add(Material.CACTUS.toString());
-			plantBlocks.add(Material.CRIMSON_FUNGUS.toString());
-			plantBlocks.add(Material.CRIMSON_ROOTS.toString());
-			plantBlocks.add(Material.FERN.toString());
-			plantBlocks.add(Material.GRASS.toString());
-			plantBlocks.add(Material.LARGE_FERN.toString());
-			plantBlocks.add(Material.LILY_PAD.toString());
-			plantBlocks.add(Material.MELON.toString());
-			plantBlocks.add(Material.MELON_STEM.toString());
-			plantBlocks.add(Material.MUSHROOM_STEM.toString());
-			plantBlocks.add(Material.NETHER_SPROUTS.toString());
-			plantBlocks.add(Material.PUMPKIN.toString());
-			plantBlocks.add(Material.PUMPKIN_STEM.toString());
-			plantBlocks.add(Material.RED_MUSHROOM.toString());
-			plantBlocks.add(Material.RED_MUSHROOM_BLOCK.toString());
-			plantBlocks.add(Material.SUGAR_CANE.toString());
-			plantBlocks.add(Material.TALL_GRASS.toString());
-			plantBlocks.add(Material.TWISTING_VINES_PLANT.toString());
-			plantBlocks.add(Material.VINE.toString());
-			plantBlocks.add(Material.WARPED_FUNGUS.toString());
-			plantBlocks.add(Material.WARPED_ROOTS.toString());
-			plantBlocks.add(Material.WEEPING_VINES_PLANT.toString());
+			plantBlocks.add("BROWN_MUSHROOM");
+			plantBlocks.add("BROWN_MUSHROOM_BLOCK");
+			plantBlocks.add("CACTUS");
+			plantBlocks.add("CRIMSON_FUNGUS");
+			plantBlocks.add("CRIMSON_ROOTS");
+			plantBlocks.add("FERN");
+			plantBlocks.add("GRASS");
+			plantBlocks.add("LARGE_FERN");
+			plantBlocks.add("LILY_PAD");
+			plantBlocks.add("MELON");
+			plantBlocks.add("MELON_STEM");
+			plantBlocks.add("MUSHROOM_STEM");
+			plantBlocks.add("NETHER_SPROUTS");
+			plantBlocks.add("PUMPKIN");
+			plantBlocks.add("PUMPKIN_STEM");
+			plantBlocks.add("RED_MUSHROOM");
+			plantBlocks.add("RED_MUSHROOM_BLOCK");
+			plantBlocks.add("SUGAR_CANE");
+			plantBlocks.add("TALL_GRASS");
+			plantBlocks.add("TWISTING_VINES_PLANT");
+			plantBlocks.add("VINE");
+			plantBlocks.add("WARPED_FUNGUS");
+			plantBlocks.add("WARPED_ROOTS");
+			plantBlocks.add("WEEPING_VINES_PLANT");
 
 			final ArrayList<String> snowBlocks = new ArrayList<>();
 			snowBlocks.add("#snow"); // added in 1.17
-			snowBlocks.add(Material.SNOW.toString()); // no longer needed in 1.17
-			snowBlocks.add(Material.SNOW_BLOCK.toString()); // no longer needed in 1.17
+			snowBlocks.add("SNOW"); // no longer needed in 1.17
+			snowBlocks.add("SNOW_BLOCK"); // no longer needed in 1.17
 
 			config.addDefault("Properties.UpdateChecker", true);
 			config.addDefault("Properties.Statistics", true);

--- a/src/com/projectkorra/projectkorra/util/ParticleEffect.java
+++ b/src/com/projectkorra/projectkorra/util/ParticleEffect.java
@@ -1,115 +1,164 @@
 package com.projectkorra.projectkorra.util;
 
+import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Particle.DustOptions;
+import org.bukkit.Particle.DustTransition;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.ItemStack;
 
 public enum ParticleEffect {
 	
-	ASH (Particle.ASH),
-	
-	BARRIER (Particle.BARRIER),
+	ASH,
 	
 	/**
-	 * Applicable data: {@link BlockData}
+	 * Uses BLOCK_MARKER with BARRIER block data
 	 */
-	BLOCK_CRACK (Particle.BLOCK_CRACK),
+	BARRIER (Particle.BLOCK_MARKER, Material.BARRIER.createBlockData()),
 	
 	/**
-	 * Applicable data: {@link BlockData}
+	 * Applicable data: {@link BlockData}, defaults to DIRT block data
 	 */
-	BLOCK_DUST (Particle.BLOCK_DUST),
-	BUBBLE_COLUMN_UP (Particle.BUBBLE_COLUMN_UP),
-	BUBBLE_POP (Particle.BUBBLE_POP),
-	CAMPFIRE_COSY_SMOKE (Particle.CAMPFIRE_COSY_SMOKE),
-	CAMPFIRE_SIGNAL_SMOKE (Particle.CAMPFIRE_SIGNAL_SMOKE),
-	CLOUD (Particle.CLOUD),
-	COMPOSTER (Particle.COMPOSTER),
-	CRIMSON_SPORE (Particle.CRIMSON_SPORE),
-	CRIT (Particle.CRIT),
-	CRIT_MAGIC (Particle.CRIT_MAGIC), @Deprecated MAGIC_CRIT (Particle.CRIT_MAGIC),
-	CURRENT_DOWN (Particle.CURRENT_DOWN),
-	DAMAGE_INDICATOR (Particle.DAMAGE_INDICATOR),
-	DOLPHIN (Particle.DOLPHIN),
-	DRAGON_BREATH (Particle.DRAGON_BREATH),
-	DRIP_LAVA (Particle.DRIP_LAVA),
-	DRIP_WATER (Particle.DRIP_WATER),
-	DRIPPING_HONEY (Particle.DRIPPING_HONEY),
-	DRIPPING_OBSIDIAN_TEAR (Particle.DRIPPING_OBSIDIAN_TEAR),
-	ENCHANTMENT_TABLE (Particle.ENCHANTMENT_TABLE),
-	END_ROD (Particle.END_ROD),
-	EXPLOSION_HUGE (Particle.EXPLOSION_HUGE), @Deprecated HUGE_EXPLOSION (Particle.EXPLOSION_HUGE),
-	EXPLOSION_LARGE (Particle.EXPLOSION_LARGE), @Deprecated LARGE_EXPLODE (Particle.EXPLOSION_LARGE),
-	EXPLOSION_NORMAL (Particle.EXPLOSION_NORMAL), @Deprecated EXPLODE (Particle.EXPLOSION_NORMAL),
+	BLOCK_CRACK (Material.DIRT.createBlockData()),
 	
 	/**
-	 * Applicable data: {@link BlockData}
+	 * Applicable data: {@link BlockData}, defaults to DIRT block data
 	 */
-	FALLING_DUST (Particle.FALLING_DUST),
-	FALLING_HONEY (Particle.FALLING_HONEY),
-	FALLING_LAVA (Particle.FALLING_LAVA),
-	FALLING_NECTAR (Particle.FALLING_NECTAR),
-	FALLING_OBSIDIAN_TEAR (Particle.FALLING_OBSIDIAN_TEAR),
-	FALLING_WATER (Particle.FALLING_WATER),
-	FIREWORKS_SPARK (Particle.FIREWORKS_SPARK),
-	FLAME (Particle.FLAME),
-	FLASH (Particle.FLASH),
-	HEART (Particle.HEART),
+	BLOCK_DUST (Material.DIRT.createBlockData()),
+
+	/**
+	 * Applicable data: {@link BlockData}, defaults to DIRT block data
+	 */
+	BLOCK_MARKER (Material.DIRT.createBlockData()),
+	BUBBLE_COLUMN_UP,
+	BUBBLE_POP,
+	CAMPFIRE_COSY_SMOKE,
+	CAMPFIRE_SIGNAL_SMOKE,
+	CLOUD,
+	COMPOSTER,
+	CRIMSON_SPORE,
+	CRIT,
+	CRIT_MAGIC,
+	CURRENT_DOWN,
+	DAMAGE_INDICATOR,
+	DOLPHIN,
+	DRAGON_BREATH,
+	DRIP_LAVA,
+	DRIP_WATER,
+	DRIPPING_DRIPSTONE_LAVA,
+	DRIPPING_DRIPSTONE_WATER,
+	DRIPPING_HONEY,
+	DRIPPING_OBSIDIAN_TEAR,
+
+	/**
+	 * Applicable data: {@link DustTransition}, defaults to a blue -> green transition of size 1
+	 */
+	DUST_COLOR_TRANSITION (new DustTransition(Color.BLUE, Color.GREEN, 1.0f)),
+	ELECTRIC_SPARK,
+	ENCHANTMENT_TABLE,
+	END_ROD,
+	EXPLOSION_HUGE,
+	EXPLOSION_LARGE,
+	EXPLOSION_NORMAL,
+	FALLING_DRIPSTONE_LAVA,
+	FALLING_DRIPSTONE_WATER,
+
+	/**
+	 * Applicable data: {@link BlockData}, defaults to DIRT block data
+	 */
+	FALLING_DUST (Material.DIRT.createBlockData()),
+	FALLING_HONEY,
+	FALLING_LAVA,
+	FALLING_NECTAR,
+	FALLING_OBSIDIAN_TEAR,
+	FALLING_SPORE_BLOSSOM,
+	FALLING_WATER,
+	FIREWORKS_SPARK,
+	FLAME,
+	FLASH,
+	GLOW,
+	GLOW_SQUID_INK,
+	HEART,
 	
 	/**
-	 * Applicable data: {@link ItemStack}
+	 * Applicable data: {@link ItemStack}, defaults to DIRT item stack
 	 */
-	ITEM_CRACK (Particle.ITEM_CRACK),
-	LANDING_HONEY (Particle.LANDING_HONEY),
-	LANDING_LAVA (Particle.LANDING_LAVA),
-	LANDING_OBSIDIAN_TEAR (Particle.LANDING_OBSIDIAN_TEAR),
-	LAVA (Particle.LAVA),
-	MOB_APPEARANCE (Particle.MOB_APPEARANCE),
-	NAUTILUS (Particle.NAUTILUS),
-	NOTE (Particle.NOTE),
-	PORTAL (Particle.PORTAL),
+	ITEM_CRACK (new ItemStack(Material.DIRT)),
+	LANDING_HONEY,
+	LANDING_LAVA,
+	LANDING_OBSIDIAN_TEAR,
+	LAVA,
+	MOB_APPEARANCE,
+	NAUTILUS,
+	NOTE,
+	PORTAL,
 	
 	/**
-	 * Applicable data: {@link DustOptions}
+	 * Applicable data: {@link DustOptions}, defaults to red color of size 1
 	 */
-	REDSTONE (Particle.REDSTONE), @Deprecated RED_DUST (Particle.REDSTONE),
-	REVERSE_PORTAL (Particle.REVERSE_PORTAL),
-	SLIME (Particle.SLIME),
-	SMOKE_NORMAL (Particle.SMOKE_NORMAL), @Deprecated SMOKE (Particle.SMOKE_NORMAL),
-	SMOKE_LARGE (Particle.SMOKE_LARGE), @Deprecated LARGE_SMOKE (Particle.SMOKE_LARGE),
-	SNEEZE (Particle.SNEEZE),
-	SNOW_SHOVEL (Particle.SNOW_SHOVEL),
-	SNOWBALL (Particle.SNOWBALL), @Deprecated SNOWBALL_PROOF (Particle.SNOWBALL),
-	SOUL (Particle.SOUL),
-	SOUL_FIRE_FLAME (Particle.SOUL_FIRE_FLAME),
-	SPELL (Particle.SPELL),
-	SPELL_INSTANT (Particle.SPELL_INSTANT), @Deprecated INSTANT_SPELL (Particle.SPELL_INSTANT),
-	SPELL_MOB (Particle.SPELL_MOB), @Deprecated MOB_SPELL (Particle.SPELL_MOB),
-	SPELL_MOB_AMBIENT (Particle.SPELL_MOB_AMBIENT), @Deprecated MOB_SPELL_AMBIENT (Particle.SPELL_MOB_AMBIENT),
-	SPELL_WITCH (Particle.SPELL_WITCH), @Deprecated WITCH_SPELL (Particle.SPELL_WITCH),
-	SPIT (Particle.SPIT),
-	SQUID_INK (Particle.SQUID_INK),
-	SUSPENDED (Particle.SUSPENDED), @Deprecated SUSPEND (Particle.SUSPENDED),
-	SUSPENDED_DEPTH (Particle.SUSPENDED_DEPTH), @Deprecated DEPTH_SUSPEND (Particle.SUSPENDED_DEPTH),
-	SWEEP_ATTACK (Particle.SWEEP_ATTACK),
-	TOTEM (Particle.TOTEM),
-	TOWN_AURA (Particle.TOWN_AURA),
-	VILLAGER_ANGRY (Particle.VILLAGER_ANGRY), @Deprecated ANGRY_VILLAGER (Particle.VILLAGER_ANGRY),
-	VILLAGER_HAPPY (Particle.VILLAGER_HAPPY), @Deprecated HAPPY_VILLAGER (Particle.VILLAGER_HAPPY),
-	WARPED_SPORE (Particle.WARPED_SPORE),
-	WATER_BUBBLE (Particle.WATER_BUBBLE), @Deprecated BUBBLE (Particle.WATER_BUBBLE),
-	WATER_DROP (Particle.WATER_DROP),
-	WATER_SPLASH (Particle.WATER_SPLASH), @Deprecated SPLASH (Particle.WATER_SPLASH),
-	WATER_WAKE (Particle.WATER_WAKE), @Deprecated WAKE (Particle.WATER_WAKE),
-	WHITE_ASH (Particle.WHITE_ASH);
+	REDSTONE (new DustOptions(Color.RED, 1.0f)),
+	REVERSE_PORTAL,
+	SCRAPE,
+	SLIME,
+	SMOKE_NORMAL, 
+	SMOKE_LARGE,
+	SNEEZE,
+	SNOW_SHOVEL,
+	SNOWBALL,
+	SNOWFLAKE,
+	SOUL,
+	SOUL_FIRE_FLAME,
+	SPELL,
+	SPELL_INSTANT,
+	SPELL_MOB,
+	SPELL_MOB_AMBIENT,
+	SPELL_WITCH,
+	SPIT,
+	SPORE_BLOSSOM_AIR,
+	SQUID_INK,
+	SUSPENDED,
+	SUSPENDED_DEPTH,
+	SWEEP_ATTACK,
+	TOTEM,
+	TOWN_AURA,
+
+	/**
+	 * Applicable data: {@link Vibration}, has no default meaning it requires data each time.
+	 * Location and offsets will be ignored by spigot
+	 */
+	VIBRATION,
+	VILLAGER_ANGRY,
+	VILLAGER_HAPPY,
+	WARPED_SPORE,
+	WATER_BUBBLE,
+	WATER_DROP,
+	WATER_SPLASH,
+	WATER_WAKE,
+	WAX_OFF,
+	WAX_ON,
+	WHITE_ASH;
 	
 	Particle particle;
-	Class<?> dataClass;
+	Object defaultData = null;
 	
+	private ParticleEffect() {
+		this.particle = Particle.valueOf(this.toString());
+	}
+
+	private ParticleEffect(Object data) {
+		this();
+		this.defaultData = data;
+	}
+
 	private ParticleEffect(Particle particle) {
 		this.particle = particle;
-		this.dataClass = particle.getDataType();
+	}
+
+	private ParticleEffect(Particle particle, Object data) {
+		this(particle);
+		this.defaultData = data;
 	}
 	
 	public Particle getParticle() {
@@ -122,7 +171,7 @@ public enum ParticleEffect {
 	 * @param amount how many of the particle to display
 	 */
 	public void display(Location loc, int amount) {
-		display(loc, amount, 0, 0, 0);
+		display(loc, amount, 0, 0, 0, 0, null);
 	}
 	
 	/**
@@ -134,7 +183,7 @@ public enum ParticleEffect {
 	 * @param offsetZ random offset on the z axis
 	 */
 	public void display(Location loc, int amount, double offsetX, double offsetY, double offsetZ) {
-		display(loc, amount, offsetX, offsetY, offsetZ, 0);
+		display(loc, amount, offsetX, offsetY, offsetZ, 0, null);
 	}
 	
 	/**
@@ -147,7 +196,7 @@ public enum ParticleEffect {
 	 * @param extra extra data to affect the particle, usually affects speed or does nothing
 	 */
 	public void display(Location loc, int amount, double offsetX, double offsetY, double offsetZ, double extra) {
-		loc.getWorld().spawnParticle(particle, loc, amount, offsetX, offsetY, offsetZ, extra, null, true);
+		display(loc, amount, offsetX, offsetY, offsetZ, extra, null);
 	}
 	
 	/**
@@ -174,10 +223,10 @@ public enum ParticleEffect {
 	 * @param data data to display the particle with, only applicable on several particle types (check the enum)
 	 */
 	public void display(Location loc, int amount, double offsetX, double offsetY, double offsetZ, double extra, Object data) {
-		if (dataClass.isAssignableFrom(Void.class) || data == null || !dataClass.isAssignableFrom(data.getClass())) {
-			display(loc, amount, offsetX, offsetY, offsetZ, extra);
-		} else {
-			loc.getWorld().spawnParticle(particle, loc, amount, offsetX, offsetY, offsetZ, extra, data, true);
+		if (defaultData != null && data == null) {
+			data = defaultData;
 		}
+
+		loc.getWorld().spawnParticle(particle, loc, amount, offsetX, offsetY, offsetZ, extra, data, true);
 	}
 }


### PR DESCRIPTION
## Changes
* Changed ParticleEffect to be easier to write new particles in and have default data for applicable particles.
    * Particle defaults are written in the javadocs for the individual particles, can also just read the source code.
    * Added all the missing particles from the Spigot javadocs.
    * Removed duplicate particle effects that have been deprecated for a while.
* Changed material config values to strings so they are version independent.
    * Added DIRT_PATH to EarthBlocks config list and left GRASS_PATH in for version compatability.
* Updated pom to use 1.18 spigot, left plugin.yml unchanged.
* Closes #1187 
