### PR TITLE
Remove unneeded check in ElementalAbility

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -77,10 +77,8 @@ public abstract class ElementalAbility extends CoreAbility {
 		iterator.forEachRemaining(next -> {
 			if (next.startsWith("#")) {
 				NamespacedKey key = NamespacedKey.minecraft(next.replaceFirst("#", ""));
-				if (!Bukkit.getTag(Tag.REGISTRY_BLOCKS, key, Material.class).getValues().isEmpty()) {
-					for (Material material : Bukkit.getTag(Tag.REGISTRY_BLOCKS, key, Material.class).getValues()) {
-						outputSet.add(material.toString());
-					}
+				for (Material material : Bukkit.getTag(Tag.REGISTRY_BLOCKS, key, Material.class).getValues()) {
+					outputSet.add(material.toString());
 				}
 			} else {
 				outputSet.add(next.toUpperCase());

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -463,83 +463,84 @@ public class ConfigManager {
 			earthBlocks.add("#emerald_ores"); // added in 1.17
 			earthBlocks.add("#lapis_ores"); // added in 1.17
 			earthBlocks.add("#redstone_ores"); // added in 1.17
-			earthBlocks.add("CALCITE"); // use Material in 1.17
-			earthBlocks.add("DRIPSTONE_BLOCK"); // use Material in 1.17
-			earthBlocks.add("LARGE_AMETHYST_BUD"); // use Material in 1.17
-			earthBlocks.add("MEDIUM_AMETHYST_BUD"); // use Material in 1.17
-			earthBlocks.add("SMALL_AMETHYST_BUD"); // use Material in 1.17
-			earthBlocks.add(Material.ANCIENT_DEBRIS.toString());
-			earthBlocks.add(Material.CLAY.toString());
-			earthBlocks.add(Material.COAL_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.COARSE_DIRT.toString());
-			earthBlocks.add(Material.COBBLESTONE.toString());
-			earthBlocks.add(Material.COBBLESTONE_SLAB.toString());
-			earthBlocks.add(Material.DIAMOND_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.DIRT.toString());
-			earthBlocks.add(Material.EMERALD_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.GRASS_BLOCK.toString());
-			earthBlocks.add(Material.GRASS_PATH.toString());
-			earthBlocks.add(Material.GRAVEL.toString());
-			earthBlocks.add(Material.LAPIS_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.MYCELIUM.toString());
-			earthBlocks.add(Material.PODZOL.toString());
-			earthBlocks.add(Material.REDSTONE_ORE.toString()); // no longer needed in 1.17
-			earthBlocks.add(Material.STONE_SLAB.toString());
+			earthBlocks.add("CALCITE");
+			earthBlocks.add("DRIPSTONE_BLOCK");
+			earthBlocks.add("LARGE_AMETHYST_BUD");
+			earthBlocks.add("MEDIUM_AMETHYST_BUD");
+			earthBlocks.add("SMALL_AMETHYST_BUD");
+			earthBlocks.add("ANCIENT_DEBRIS");
+			earthBlocks.add("CLAY");
+			earthBlocks.add("COAL_ORE"); // no longer needed in 1.17+
+			earthBlocks.add("COARSE_DIRT");
+			earthBlocks.add("COBBLESTONE");
+			earthBlocks.add("COBBLESTONE_SLAB");
+			earthBlocks.add("DIAMOND_ORE"); // no longer needed in 1.17+
+			earthBlocks.add("DIRT");
+			earthBlocks.add("EMERALD_ORE"); // no longer needed in 1.17+
+			earthBlocks.add("GRASS_BLOCK");
+			earthBlocks.add("GRASS_PATH");
+			earthBlocks.add("DIRT_PATH"); // renamed from grass_path in 1.17
+			earthBlocks.add("GRAVEL");
+			earthBlocks.add("LAPIS_ORE"); // no longer needed in 1.17+
+			earthBlocks.add("MYCELIUM");
+			earthBlocks.add("PODZOL");
+			earthBlocks.add("REDSTONE_ORE"); // no longer needed in 1.17+
+			earthBlocks.add("STONE_SLAB");
 
 			final ArrayList<String> metalBlocks = new ArrayList<String>();
 			metalBlocks.add("#copper_ores"); // added in 1.17
 			metalBlocks.add("#gold_ores"); // added in 1.16.1
 			metalBlocks.add("#iron_ores"); // added in 1.17
-			metalBlocks.add("COPPER_BLOCK"); // use Material in 1.17
-			metalBlocks.add("CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("CUT_COPPER_SLAB");// use Material in 1.17
-			metalBlocks.add("CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add("EXPOSED_COPPER"); // use Material in 1.17
-			metalBlocks.add("EXPOSED_CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("EXPOSED_CUT_COPPER_SLAB"); // use Material in 1.17
-			metalBlocks.add("EXPOSED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add("OXIDIZED_COPPER"); // use Material in 1.17
-			metalBlocks.add("OXIDIZED_CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("OXIDIZED_CUT_COPPER_SLAB"); // use Material in 1.17
-			metalBlocks.add("OXIDIZED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add("RAW_COPPER_BLOCK"); // use Material in 1.17
-			metalBlocks.add("RAW_GOLD_BLOCK"); // use Material in 1.17
-			metalBlocks.add("RAW_IRON_BLOCK"); // use Material in 1.17
-			metalBlocks.add("WAXED_COPPER_BLOCK"); // use Material in 1.17
-			metalBlocks.add("WAXED_CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("WAXED_CUT_COPPER_SLAB"); // use Material in 1.17
-			metalBlocks.add("WAXED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add("WAXED_EXPOSED_COPPER"); // use Material in 1.17
-			metalBlocks.add("WAXED_EXPOSED_CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("WAXED_EXPOSED_CUT_COPPER_SLAB"); // use Material in 1.17
-			metalBlocks.add("WAXED_EXPOSED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add("WAXED_OXIDIZED_COPPER"); // use Material in 1.17
-			metalBlocks.add("WAXED_OXIDIZED_CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("WAXED_OXIDIZED_CUT_COPPER_SLAB"); // use Material in 1.17
-			metalBlocks.add("WAXED_OXIDIZED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add("WAXED_WEATHERED_COPPER"); // use Material in 1.17
-			metalBlocks.add("WAXED_WEATHERED_CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("WAXED_WEATHERED_CUT_COPPER_SLAB"); // use Material in 1.17
-			metalBlocks.add("WAXED_WEATHERED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add("WEATHERED_COPPER"); // use Material in 1.17
-			metalBlocks.add("WEATHERED_CUT_COPPER"); // use Material in 1.17
-			metalBlocks.add("WEATHERED_CUT_COPPER_SLAB"); // use Material in 1.17
-			metalBlocks.add("WEATHERED_CUT_COPPER_STAIRS"); // use Material in 1.17
-			metalBlocks.add(Material.CHAIN.toString());
-			metalBlocks.add(Material.GILDED_BLACKSTONE.toString());
-			metalBlocks.add(Material.GOLD_BLOCK.toString());
-			metalBlocks.add(Material.IRON_BLOCK.toString());
-			metalBlocks.add(Material.IRON_ORE.toString()); // no longer needed in 1.17
-			metalBlocks.add(Material.NETHERITE_BLOCK.toString());
-			metalBlocks.add(Material.NETHER_QUARTZ_ORE.toString());
-			metalBlocks.add(Material.QUARTZ_BLOCK.toString());
+			metalBlocks.add("COPPER_BLOCK");
+			metalBlocks.add("CUT_COPPER");
+			metalBlocks.add("CUT_COPPER_SLAB");
+			metalBlocks.add("CUT_COPPER_STAIRS");
+			metalBlocks.add("EXPOSED_COPPER");
+			metalBlocks.add("EXPOSED_CUT_COPPER");
+			metalBlocks.add("EXPOSED_CUT_COPPER_SLAB");
+			metalBlocks.add("EXPOSED_CUT_COPPER_STAIRS");
+			metalBlocks.add("OXIDIZED_COPPER");
+			metalBlocks.add("OXIDIZED_CUT_COPPER");
+			metalBlocks.add("OXIDIZED_CUT_COPPER_SLAB");
+			metalBlocks.add("OXIDIZED_CUT_COPPER_STAIRS");
+			metalBlocks.add("RAW_COPPER_BLOCK");
+			metalBlocks.add("RAW_GOLD_BLOCK");
+			metalBlocks.add("RAW_IRON_BLOCK");
+			metalBlocks.add("WAXED_COPPER_BLOCK");
+			metalBlocks.add("WAXED_CUT_COPPER");
+			metalBlocks.add("WAXED_CUT_COPPER_SLAB");
+			metalBlocks.add("WAXED_CUT_COPPER_STAIRS");
+			metalBlocks.add("WAXED_EXPOSED_COPPER");
+			metalBlocks.add("WAXED_EXPOSED_CUT_COPPER");
+			metalBlocks.add("WAXED_EXPOSED_CUT_COPPER_SLAB");
+			metalBlocks.add("WAXED_EXPOSED_CUT_COPPER_STAIRS");
+			metalBlocks.add("WAXED_OXIDIZED_COPPER");
+			metalBlocks.add("WAXED_OXIDIZED_CUT_COPPER");
+			metalBlocks.add("WAXED_OXIDIZED_CUT_COPPER_SLAB");
+			metalBlocks.add("WAXED_OXIDIZED_CUT_COPPER_STAIRS");
+			metalBlocks.add("WAXED_WEATHERED_COPPER");
+			metalBlocks.add("WAXED_WEATHERED_CUT_COPPER");
+			metalBlocks.add("WAXED_WEATHERED_CUT_COPPER_SLAB");
+			metalBlocks.add("WAXED_WEATHERED_CUT_COPPER_STAIRS");
+			metalBlocks.add("WEATHERED_COPPER");
+			metalBlocks.add("WEATHERED_CUT_COPPER");
+			metalBlocks.add("WEATHERED_CUT_COPPER_SLAB");
+			metalBlocks.add("WEATHERED_CUT_COPPER_STAIRS");
+			metalBlocks.add("CHAIN");
+			metalBlocks.add("GILDED_BLACKSTONE");
+			metalBlocks.add("GOLD_BLOCK");
+			metalBlocks.add("IRON_BLOCK");
+			metalBlocks.add("IRON_ORE"); // no longer needed in 1.17+
+			metalBlocks.add("NETHERITE_BLOCK");
+			metalBlocks.add("NETHER_QUARTZ_ORE");
+			metalBlocks.add("QUARTZ_BLOCK");
 
 			final ArrayList<String> sandBlocks = new ArrayList<String>();
 			sandBlocks.add("#sand");
-			sandBlocks.add(Material.RED_SANDSTONE.toString());
-			sandBlocks.add(Material.RED_SANDSTONE_SLAB.toString());
-			sandBlocks.add(Material.SANDSTONE.toString());
-			sandBlocks.add(Material.SANDSTONE_SLAB.toString());
+			sandBlocks.add("RED_SANDSTONE");
+			sandBlocks.add("RED_SANDSTONE_SLAB");
+			sandBlocks.add("SANDSTONE");
+			sandBlocks.add("SANDSTONE_SLAB");
 
 			final ArrayList<String> iceBlocks = new ArrayList<String>();
 			iceBlocks.add("#ice");
@@ -549,41 +550,41 @@ public class ConfigManager {
 			plantBlocks.add("#flowers");
 			plantBlocks.add("#leaves");
 			plantBlocks.add("#saplings");
-			plantBlocks.add("BIG_DRIPLEAF"); // use Material in 1.17
-			plantBlocks.add("HANGING_ROOTS"); // use Material in 1.17
-			plantBlocks.add("MOSS_BLOCK"); // use Material in 1.17
-			plantBlocks.add("MOSS_CARPET"); // use Material in 1.17
-			plantBlocks.add("SMALL_DRIPLEAF"); // use Material in 1.17
-			plantBlocks.add("SPORE_BLOSSOM"); // use Material in 1.17
-			plantBlocks.add(Material.BROWN_MUSHROOM.toString());
-			plantBlocks.add(Material.BROWN_MUSHROOM_BLOCK.toString());
-			plantBlocks.add(Material.CACTUS.toString());
-			plantBlocks.add(Material.CRIMSON_FUNGUS.toString());
-			plantBlocks.add(Material.CRIMSON_ROOTS.toString());
-			plantBlocks.add(Material.FERN.toString());
-			plantBlocks.add(Material.GRASS.toString());
-			plantBlocks.add(Material.LARGE_FERN.toString());
-			plantBlocks.add(Material.LILY_PAD.toString());
-			plantBlocks.add(Material.MELON.toString());
-			plantBlocks.add(Material.MELON_STEM.toString());
-			plantBlocks.add(Material.MUSHROOM_STEM.toString());
-			plantBlocks.add(Material.NETHER_SPROUTS.toString());
-			plantBlocks.add(Material.PUMPKIN.toString());
-			plantBlocks.add(Material.PUMPKIN_STEM.toString());
-			plantBlocks.add(Material.RED_MUSHROOM.toString());
-			plantBlocks.add(Material.RED_MUSHROOM_BLOCK.toString());
-			plantBlocks.add(Material.SUGAR_CANE.toString());
-			plantBlocks.add(Material.TALL_GRASS.toString());
-			plantBlocks.add(Material.TWISTING_VINES_PLANT.toString());
-			plantBlocks.add(Material.VINE.toString());
-			plantBlocks.add(Material.WARPED_FUNGUS.toString());
-			plantBlocks.add(Material.WARPED_ROOTS.toString());
-			plantBlocks.add(Material.WEEPING_VINES_PLANT.toString());
+			plantBlocks.add("BIG_DRIPLEAF");
+			plantBlocks.add("HANGING_ROOTS");
+			plantBlocks.add("MOSS_BLOCK");
+			plantBlocks.add("MOSS_CARPET");
+			plantBlocks.add("SMALL_DRIPLEAF");
+			plantBlocks.add("SPORE_BLOSSOM");
+			plantBlocks.add("BROWN_MUSHROOM");
+			plantBlocks.add("BROWN_MUSHROOM_BLOCK");
+			plantBlocks.add("CACTUS");
+			plantBlocks.add("CRIMSON_FUNGUS");
+			plantBlocks.add("CRIMSON_ROOTS");
+			plantBlocks.add("FERN");
+			plantBlocks.add("GRASS");
+			plantBlocks.add("LARGE_FERN");
+			plantBlocks.add("LILY_PAD");
+			plantBlocks.add("MELON");
+			plantBlocks.add("MELON_STEM");
+			plantBlocks.add("MUSHROOM_STEM");
+			plantBlocks.add("NETHER_SPROUTS");
+			plantBlocks.add("PUMPKIN");
+			plantBlocks.add("PUMPKIN_STEM");
+			plantBlocks.add("RED_MUSHROOM");
+			plantBlocks.add("RED_MUSHROOM_BLOCK");
+			plantBlocks.add("SUGAR_CANE");
+			plantBlocks.add("TALL_GRASS");
+			plantBlocks.add("TWISTING_VINES_PLANT");
+			plantBlocks.add("VINE");
+			plantBlocks.add("WARPED_FUNGUS");
+			plantBlocks.add("WARPED_ROOTS");
+			plantBlocks.add("WEEPING_VINES_PLANT");
 
 			final ArrayList<String> snowBlocks = new ArrayList<>();
 			snowBlocks.add("#snow"); // added in 1.17
-			snowBlocks.add(Material.SNOW.toString()); // no longer needed in 1.17
-			snowBlocks.add(Material.SNOW_BLOCK.toString()); // no longer needed in 1.17
+			snowBlocks.add("SNOW"); // no longer needed in 1.17+
+			snowBlocks.add("SNOW_BLOCK"); // no longer needed in 1.17+
 
 			config.addDefault("Properties.UpdateChecker", true);
 			config.addDefault("Properties.Statistics", true);


### PR DESCRIPTION
Also change to strings for material names in ConfigManager instead of Material values. Adds DIRT_PATH for 1.17+, and leaves GRASS_PATH for 1.16.

Thank you for pointing out the isEmpty issue Emily (https://github.com/emilyy-dev)

If I need to remove the ConfigManager changes to avoid conflicts, let me know.