### PR TITLE
Remove BARRIER ParticleEffect for 1.16, 1.17, and 1.18 compatibility

### DIFF
--- a/src/com/projectkorra/projectkorra/util/ParticleEffect.java
+++ b/src/com/projectkorra/projectkorra/util/ParticleEffect.java
@@ -9,8 +9,6 @@ public enum ParticleEffect {
 	
 	ASH (Particle.ASH),
 	
-	BARRIER (Particle.BARRIER),
-	
 	/**
 	 * Applicable data: {@link BlockData}
 	 */


### PR DESCRIPTION
yeah what the title says
