### PR TITLE
Fix for WaterArms responsiveness issues

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -205,12 +205,6 @@ public class WaterArms extends WaterAbility {
 	}
 
 	private boolean canPlaceBlock(final Block block) {
-		if (TempBlock.isTempBlock(block)) {
-			if (this.external.contains(TempBlock.get(block))) {
-				return false;
-			}
-		}
-
 		return isWaterbendable(block.getType()) || isIce(block) || isWater(block) || ElementalAbility.isAir(block.getType());
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -322,11 +322,13 @@ public class WaterArms extends WaterAbility {
 		if (TempBlock.isTempBlock(b)) {
 			final TempBlock tb = TempBlock.get(b);
 
-			if (this.right.contains(b) || this.left.contains(b)) {
-				tb.setType(data);
-				tb.setRevertTime(revertTime);
-			} else {
-				this.external.add(tb);
+			if (!external.contains(tb)) {
+				if (this.right.contains(b) || this.left.contains(b)) {
+					tb.setType(data);
+					tb.setRevertTime(revertTime);
+				} else {
+					this.external.add(tb);
+				}
 			}
 		} else {
 			new TempBlock(b, data, revertTime);


### PR DESCRIPTION
## Changes
* Removed the ``external.contains()`` check from the ``canPlaceBlock()`` method and moved it into ``addBlock()``. This fixes behavior in the ``displayRightArm()`` and ``displayLeftArm()`` where they would sometimes return false when attempting to place a new block over a pre-existing block. This change will fix responsiveness issues that players have been experiencing while using WaterArms Spear or Whip.