### PR TITLE
Add EarthSmash and ChargedFireBlast min/max damage options

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -776,7 +776,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.GrabRange", 16);
 			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.ChargeTime", 1500);
 			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.Cooldown", 0);
-			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.Damage", 7);
+			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.MinimumDamage", 3);
+			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.MaximumDamage", 7);
 			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.Knockback", 4.5);
 			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.FlightSpeed", 1.0);
 			config.addDefault("Abilities.Avatar.AvatarState.Earth.EarthSmash.FlightTimer", 10000);
@@ -792,7 +793,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireBurst.Damage", 3);
 			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireBurst.Cooldown", 0);
 			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireBlast.Charged.ChargeTime", 1500);
-			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireBlast.Charged.Damage", 5);
+			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireBlast.Charged.MinimumDamage", 3);
+			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireBlast.Charged.MaximumDamage", 5);
 			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireKick.Damage", 5);
 			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireKick.Range", 9);
 			config.addDefault("Abilities.Avatar.AvatarState.Fire.FireSpin.Damage", 5);
@@ -1344,7 +1346,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.EarthSmash.SelectRange", 12);
 			config.addDefault("Abilities.Earth.EarthSmash.ChargeTime", 1500);
 			config.addDefault("Abilities.Earth.EarthSmash.Cooldown", 3000);
-			config.addDefault("Abilities.Earth.EarthSmash.Damage", 5);
+			config.addDefault("Abilities.Earth.EarthSmash.MinimumDamage", 2);
+			config.addDefault("Abilities.Earth.EarthSmash.MaximumDamage", 5);
 			config.addDefault("Abilities.Earth.EarthSmash.Knockback", 3.5);
 			config.addDefault("Abilities.Earth.EarthSmash.Knockup", 0.15);
 			config.addDefault("Abilities.Earth.EarthSmash.Lift.Knockup", 1.1);
@@ -1442,7 +1445,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.FireBlast.Charged.ChargeTime", 3000);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.Cooldown", 2000);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.CollisionRadius", 2);
-			config.addDefault("Abilities.Fire.FireBlast.Charged.Damage", 4);
+			config.addDefault("Abilities.Fire.FireBlast.Charged.MinimumDamage", 2);
+			config.addDefault("Abilities.Fire.FireBlast.Charged.MaximumDamage", 4);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.DamageRadius", 4);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.DamageBlocks", true);
 			config.addDefault("Abilities.Fire.FireBlast.Charged.ExplosionRadius", 1);

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -58,8 +58,10 @@ public class EarthSmash extends EarthAbility {
 	private double grabRange;
 	@Attribute("ShootRange")
 	private double shootRange;
-	@Attribute(Attribute.DAMAGE)
-	private double damage;
+	@Attribute("Min" + Attribute.DAMAGE)
+	private double minDamage;
+	@Attribute("Max" + Attribute.DAMAGE)
+	private double maxDamage;
 	@Attribute(Attribute.KNOCKBACK)
 	private double knockback;
 	@Attribute(Attribute.KNOCKUP)
@@ -156,7 +158,8 @@ public class EarthSmash extends EarthAbility {
 		this.selectRange = getConfig().getDouble("Abilities.Earth.EarthSmash.SelectRange");
 		this.grabRange = getConfig().getDouble("Abilities.Earth.EarthSmash.Grab.Range");
 		this.shootRange = getConfig().getDouble("Abilities.Earth.EarthSmash.Shoot.Range");
-		this.damage = getConfig().getDouble("Abilities.Earth.EarthSmash.Damage");
+		this.minDamage = getConfig().getDouble("Abilities.Earth.EarthSmash.MinimumDamage");
+		this.maxDamage = getConfig().getDouble("Abilities.Earth.EarthSmash.MaximumDamage");
 		this.knockback = getConfig().getDouble("Abilities.Earth.EarthSmash.Knockback");
 		this.knockup = getConfig().getDouble("Abilities.Earth.EarthSmash.Knockup");
 		this.liftKnockup = getConfig().getDouble("Abilities.Earth.EarthSmash.Lift.Knockup");
@@ -172,7 +175,8 @@ public class EarthSmash extends EarthAbility {
 			this.grabRange = getConfig().getDouble("Abilities.Avatar.AvatarState.Earth.EarthSmash.GrabRange");
 			this.chargeTime = getConfig().getLong("Abilities.Avatar.AvatarState.Earth.EarthSmash.ChargeTime");
 			this.cooldown = getConfig().getLong("Abilities.Avatar.AvatarState.Earth.EarthSmash.Cooldown");
-			this.damage = getConfig().getDouble("Abilities.Avatar.AvatarState.Earth.EarthSmash.Damage");
+			this.minDamage = getConfig().getDouble("Abilities.Avatar.AvatarState.Earth.EarthSmash.MinimumDamage");
+			this.maxDamage = getConfig().getDouble("Abilities.Avatar.AvatarState.Earth.EarthSmash.MaximumDamage");
 			this.knockback = getConfig().getDouble("Abilities.Avatar.AvatarState.Earth.EarthSmash.Knockback");
 			this.flightSpeed = getConfig().getDouble("Abilities.Avatar.AvatarState.Earth.EarthSmash.FlightSpeed");
 			this.flightDuration = getConfig().getLong("Abilities.Avatar.AvatarState.Earth.EarthSmash.FlightTimer");
@@ -580,7 +584,13 @@ public class EarthSmash extends EarthAbility {
 					continue;
 				}
 				this.affectedEntities.add(entity);
-				final double damage = this.currentBlocks.size() / 13.0 * this.damage;
+				double damage = this.currentBlocks.size() / 13.0 * this.maxDamage;
+				if (damage < this.minDamage) {
+					damage = this.minDamage;
+				} else if (damage > this.maxDamage){
+					damage = this.maxDamage;
+				}
+
 				DamageHandler.damageEntity(entity, damage, this);
 				final Vector travelVec = GeneralMethods.getDirection(this.location, entity.getLocation());
 				GeneralMethods.setVelocity(this, entity, travelVec.setY(this.knockup).normalize().multiply(this.knockback));
@@ -886,12 +896,20 @@ public class EarthSmash extends EarthAbility {
 		this.shootRange = shootRange;
 	}
 
-	public double getDamage() {
-		return this.damage;
+	public double getMaxDamage() {
+		return this.maxDamage;
 	}
 
-	public void setDamage(final double damage) {
-		this.damage = damage;
+	public void setMaxDamage(final double maxDamage) {
+		this.maxDamage = maxDamage;
+	}
+
+	public double getMinDamage() {
+		return this.minDamage;
+	}
+
+	public void setMinDamage(final double minDamage) {
+		this.minDamage = minDamage;
 	}
 
 	public double getKnockback() {

--- a/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -587,8 +587,6 @@ public class EarthSmash extends EarthAbility {
 				double damage = this.currentBlocks.size() / 13.0 * this.maxDamage;
 				if (damage < this.minDamage) {
 					damage = this.minDamage;
-				} else if (damage > this.maxDamage){
-					damage = this.maxDamage;
 				}
 
 				DamageHandler.damageEntity(entity, damage, this);

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -185,8 +185,6 @@ public class FireBlastCharged extends FireAbility {
 		double damage = slope * (distance - this.innerRadius) + this.maxDamage;
 		if (damage < this.minDamage) {
 			damage = this.minDamage;
-		} else if (damage > this.maxDamage){
-			damage = this.maxDamage;
 		}
 
 		DamageHandler.damageEntity(entity, damage, this);
@@ -225,11 +223,8 @@ public class FireBlastCharged extends FireAbility {
 						if (entity.getWorld().equals(this.location.getWorld())) {
 							damage = slope * (entity.getLocation().distance(this.location) - this.innerRadius) + this.maxDamage;
 						}
-
 						if (damage < this.minDamage) {
 							damage = this.minDamage;
-						} else if (damage > this.maxDamage){
-							damage = this.maxDamage;
 						}
 
 						DamageHandler.damageEntity(entity, damage, this);


### PR DESCRIPTION
## Additions
* Adds minimum and maximum damage values to EarthSmash and ChargedFireBlast, as well as logic to utilize them.
* Adds config options to specify minimum and maximum damage.

This comes from this suggestion: https://discord.com/channels/292809844803502080/752662625984184460/867492947943751740