### PR TITLE
Misc. Cooldown fixes + minor fix

### DIFF
--- a/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
@@ -30,7 +30,7 @@ public class JetBlast extends FireAbility implements ComboAbility {
 	public JetBlast(final Player player) {
 		super(player);
 
-		if (!this.bPlayer.canBendIgnoreBinds(this)) {
+		if (!this.bPlayer.canBendIgnoreBinds(this) || this.bPlayer.isOnCooldown("FireJet")) {
 			return;
 		}
 
@@ -96,6 +96,8 @@ public class JetBlast extends FireAbility implements ComboAbility {
 			fs.setCollides(false);
 			fs.runTaskTimer(ProjectKorra.plugin, 0, 1L);
 			this.tasks.add(fs);
+		} else {
+			remove();
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
@@ -39,11 +39,12 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 	public JetBlaze(final Player player) {
 		super(player);
 
-		if (!this.bPlayer.canBendIgnoreBinds(this)) {
+		if (!this.bPlayer.canBendIgnoreBinds(this) || this.bPlayer.isOnCooldown("FireJet")) {
 			return;
 		}
 
 		this.firstTime = true;
+		this.progressCounter = 0;
 		this.time = System.currentTimeMillis();
 		this.affectedEntities = new ArrayList<>();
 		this.tasks = new ArrayList<>();
@@ -108,9 +109,12 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 			fs.setFireTicks(this.fireTicks);
 			fs.runTaskTimer(ProjectKorra.plugin, 0, 1L);
 			this.tasks.add(fs);
+			this.progressCounter++;
 			if (this.progressCounter % 4 == 0) {
 				this.player.getWorld().playSound(this.player.getLocation(), Sound.ENTITY_CREEPER_PRIMED, 1, 0F);
 			}
+		} else {
+			remove();
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
@@ -152,13 +152,8 @@ public class IceBlast extends IceAbility {
 			if (this.source != null) {
 				this.source.revertBlock();
 			}
+			this.bPlayer.addCooldown(this);
 			this.progressing = false;
-		}
-
-		if (this.player.isOnline()) {
-			if (this.bPlayer != null) {
-				this.bPlayer.addCooldown(this);
-			}
 		}
 	}
 


### PR DESCRIPTION
## Changes
* IceBlast changed so it only goes on cooldown after it has been activated. This way, when a player chooses not to fire it, or walks too far from the source, the ability doesn't become unusable, staying in line with other core abilities.
* Both JetCombos now check if FireJet is on cooldown before starting. This prevents the abilities from 'progressing' and going on cooldown without actually activating.
* Both JetCombos will also remove if the player no longer has an active instance of FireJet, which will sync the application of cooldowns if the player chooses to disengage from a jet early.
* Fixed the progressCounter's incrementation in JetBlaze's class, so the if-statement used in playing sounds works properly.
