### PR TITLE
Fix BendingBoard IllegalStateException

### DIFF
--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -70,10 +70,10 @@ public class BendingBoard {
 		}
 
 		public void clear(boolean formNewTeam) {
-			String prefix = team.getPrefix(), suffix = team.getSuffix();
 			board.resetScores(entry);
 			team.unregister();
 			if (formNewTeam) {
+				String prefix = team.getPrefix(), suffix = team.getSuffix();
 				formTeam();
 				update(prefix, suffix);
 			}

--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -63,20 +63,20 @@ public class BendingBoard {
 			this.slot = slot + 1;
 			set();
 		}
-		
+
 		public void decreaseSlot() {
 			--this.slot;
-			String prefix = team.getPrefix(), suffix = team.getSuffix();
-			this.board.resetScores(entry);
-			this.team.unregister();
-			this.formTeam();
-			this.update(prefix, suffix);
-			next.ifPresent(BoardSlot::decreaseSlot);
+			clear(true);
 		}
-		
-		public void clear() {
+
+		public void clear(boolean formNewTeam) {
+			String prefix = team.getPrefix(), suffix = team.getSuffix();
 			board.resetScores(entry);
 			team.unregister();
+			if (formNewTeam) {
+				formTeam();
+				update(prefix, suffix);
+			}
 			next.ifPresent(BoardSlot::decreaseSlot);
 		}
 		
@@ -235,7 +235,7 @@ public class BendingBoard {
 					miscTail = null;
 				}
 				
-				slot.clear();
+				slot.clear(false);
 				return null;
 			});
 				

--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -70,10 +70,10 @@ public class BendingBoard {
 		}
 
 		public void clear(boolean formNewTeam) {
+			String prefix = team.getPrefix(), suffix = team.getSuffix();
 			board.resetScores(entry);
 			team.unregister();
 			if (formNewTeam) {
-				String prefix = team.getPrefix(), suffix = team.getSuffix();
 				formTeam();
 				update(prefix, suffix);
 			}


### PR DESCRIPTION
## Fixes
- Fixes BendingBoard IllegalStateException thrown when team is unregistered twice
- When a combo/extra ability cooldown ended, it would be removed from the scoreboard misc section but would throw an IllegalStateException because Team#unregister was being called twice it seemed.