### PR TITLE
Added possibility to change default particles of elements with addons!

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/AirAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/AirAbility.java
@@ -90,52 +90,36 @@ public abstract class AirAbility extends ElementalAbility {
     }
 
     /**
-     * This method was used for the old collision detection system. Please see
-     * {@link Collision} for the new system.
-     * <p>
-     * Checks whether a location is within an AirShield.
-     *
-     * @param loc The location to check
-     * @return true If the location is inside an AirShield.
+     * Default function used in {@link AirAbility#playAirbendingParticles(CoreAbility, Location, int, double, double, double)}
      */
-    @Deprecated
-    public static boolean isWithinAirShield(final Location loc) {
-        final List<String> list = new ArrayList<String>();
-        list.add("AirShield");
-        return GeneralMethods.blockAbilities(null, list, loc, 0);
-    }
-
-    /**
-     * Plays an integer amount of air particles in a location.
-     *
-     * @param loc    The location to use
-     * @param amount The amount of particles
-     */
-    public static void playAirbendingParticles(final Location loc, final int amount) {
-        playAirbendingParticles(loc, amount, Math.random(), Math.random(), Math.random());
-    }
-
-    public static Functional.Particle airParticles = args -> {
-        Location loc = (Location) args[0];
-        int amount = (int) args[1];
-        double xOffset = (double) args[2];
-        double yOffset = (double) args[3];
-        double zOffset = (double) args[4];
-        getAirbendingParticles().display(loc, amount, xOffset, yOffset, zOffset);
+    public static Functional.Particle airParticles = (ability, location, amount, xOffset, yOffset, zOffset, extra, data) -> {
+        getAirbendingParticles().display(location, amount, xOffset, yOffset, zOffset);
     };
 
     /**
      * Plays an integer amount of air particles in a location with a given
      * xOffset, yOffset, and zOffset.
      *
+     * @param ability The ability this particle is spawned for
      * @param loc     The location to use
      * @param amount  The amount of particles
      * @param xOffset The xOffset to use
      * @param yOffset The yOffset to use
      * @param zOffset The zOffset to use
      */
-    public static void playAirbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
-        airParticles.play(loc, amount, xOffset, yOffset, zOffset);
+    public static void playAirbendingParticles(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        airParticles.play(ability, loc, amount, xOffset, yOffset, zOffset, 0, null);
+    }
+
+    /**
+     * Plays an integer amount of air particles in a location with random offsets.
+     *
+     * @param ability The ability this particle is spawned for
+     * @param loc     The location to use
+     * @param amount  The amount of particles
+     */
+    public static void playAirbendingParticles(final CoreAbility ability, final Location loc, final int amount) {
+        playAirbendingParticles(ability, loc, amount, Math.random(), Math.random(), Math.random());
     }
 
     /**
@@ -161,14 +145,13 @@ public abstract class AirAbility extends ElementalAbility {
     }
 
     /**
-     * This method was used for the old collision detection system. Please see
-     * {@link Collision} for the new system.
-     * <p>
      * Removes all air spouts in a location within a certain radius.
      *
      * @param loc    The location to use
      * @param radius The radius around the location to remove spouts in
      * @param source The player causing the removal
+     * @deprecated <b>This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
      */
     @Deprecated
     public static void removeAirSpouts(final Location loc, final double radius, final Player source) {
@@ -176,17 +159,61 @@ public abstract class AirAbility extends ElementalAbility {
     }
 
     /**
-     * This method was used for the old collision detection system. Please see
-     * {@link Collision} for the new system.
-     * <p>
      * Removes all air spouts in a location with a radius of 1.5.
      *
      * @param loc    The location to use
      * @param source The player causing the removal
+     * @deprecated <b>This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
      */
     @Deprecated
     public static void removeAirSpouts(final Location loc, final Player source) {
         removeAirSpouts(loc, 1.5, source);
+    }
+
+    /**
+     * Checks whether a location is within an AirShield.
+     *
+     * @param loc The location to check
+     * @return true If the location is inside an AirShield.
+     * @deprecated <b>This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
+     */
+    @Deprecated
+    public static boolean isWithinAirShield(final Location loc) {
+        final List<String> list = new ArrayList<String>();
+        list.add("AirShield");
+        return GeneralMethods.blockAbilities(null, list, loc, 0);
+    }
+
+    /**
+     * Plays an integer amount of air particles in a location.
+     *
+     * @param loc    The location to use
+     * @param amount The amount of particles
+     * @deprecated <b>Use {@link AirAbility#playAirbendingParticles(CoreAbility, Location, int)} instead.
+     */
+    @Deprecated
+    public static void playAirbendingParticles(final Location loc, final int amount) {
+        playAirbendingParticles(null, loc, amount);
+        //playAirbendingParticles(loc, amount, Math.random(), Math.random(), Math.random());// old
+    }
+
+    /**
+     * Plays an integer amount of air particles in a location with a given
+     * xOffset, yOffset, and zOffset.
+     *
+     * @param loc     The location to use
+     * @param amount  The amount of particles
+     * @param xOffset The xOffset to use
+     * @param yOffset The yOffset to use
+     * @param zOffset The zOffset to use
+     * @deprecated <b>Use {@link AirAbility#playAirbendingParticles(CoreAbility, Location, int, double, double, double)} instead.
+     */
+    @Deprecated
+    public static void playAirbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        playAirbendingParticles(null, loc, amount, xOffset, yOffset, zOffset);
+        //getAirbendingParticles().display(loc, amount, xOffset, yOffset, zOffset);// old
     }
 
 }

--- a/src/com/projectkorra/projectkorra/ability/AirAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/AirAbility.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.ability;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.projectkorra.projectkorra.ability.functional.Functional;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -19,164 +20,173 @@ import com.projectkorra.projectkorra.util.ParticleEffect;
 
 public abstract class AirAbility extends ElementalAbility {
 
-	public AirAbility(final Player player) {
-		super(player);
-	}
+    public AirAbility(final Player player) {
+        super(player);
+    }
 
-	@Override
-	public boolean isIgniteAbility() {
-		return false;
-	}
+    @Override
+    public boolean isIgniteAbility() {
+        return false;
+    }
 
-	@Override
-	public boolean isExplosiveAbility() {
-		return false;
-	}
+    @Override
+    public boolean isExplosiveAbility() {
+        return false;
+    }
 
-	@Override
-	public Element getElement() {
-		return Element.AIR;
-	}
+    @Override
+    public Element getElement() {
+        return Element.AIR;
+    }
 
-	@Override
-	public void handleCollision(final Collision collision) {
-		super.handleCollision(collision);
-		if (collision.isRemovingFirst()) {
-			ParticleEffect.BLOCK_CRACK.display(collision.getLocationFirst(), 10, 1, 1, 1, 0.1, Material.WHITE_WOOL.createBlockData());
-		}
-	}
+    @Override
+    public void handleCollision(final Collision collision) {
+        super.handleCollision(collision);
+        if (collision.isRemovingFirst()) {
+            ParticleEffect.BLOCK_CRACK.display(collision.getLocationFirst(), 10, 1, 1, 1, 0.1, Material.WHITE_WOOL.createBlockData());
+        }
+    }
 
-	/**
-	 * Breaks a breathbendng hold on an entity or one a player is inflicting on
-	 * an entity.
-	 *
-	 * @param entity The entity to be acted upon
-	 */
-	public static void breakBreathbendingHold(final Entity entity) {
-		if (Suffocate.isBreathbent(entity)) {
-			Suffocate.breakSuffocate(entity);
-			return;
-		}
+    /**
+     * Breaks a breathbendng hold on an entity or one a player is inflicting on
+     * an entity.
+     *
+     * @param entity The entity to be acted upon
+     */
+    public static void breakBreathbendingHold(final Entity entity) {
+        if (Suffocate.isBreathbent(entity)) {
+            Suffocate.breakSuffocate(entity);
+            return;
+        }
 
-		if (entity instanceof Player) {
-			final Player player = (Player) entity;
-			if (Suffocate.isChannelingSphere(player)) {
-				Suffocate.remove(player);
-			}
-		}
-	}
+        if (entity instanceof Player) {
+            final Player player = (Player) entity;
+            if (Suffocate.isChannelingSphere(player)) {
+                Suffocate.remove(player);
+            }
+        }
+    }
 
-	/**
-	 * Gets the Air Particles from the config.
-	 *
-	 * @return Config specified ParticleEffect
-	 */
-	public static ParticleEffect getAirbendingParticles() {
-		final String particle = getConfig().getString("Properties.Air.Particles");
-		if (particle == null) {
-			return ParticleEffect.CLOUD;
-		} else if (particle.equalsIgnoreCase("spell")) {
-			return ParticleEffect.SPELL;
-		} else if (particle.equalsIgnoreCase("blacksmoke")) {
-			return ParticleEffect.SMOKE_NORMAL;
-		} else if (particle.equalsIgnoreCase("smoke")) {
-			return ParticleEffect.CLOUD;
-		} else if (particle.equalsIgnoreCase("smallsmoke")) {
-			return ParticleEffect.SNOW_SHOVEL;
-		} else {
-			return ParticleEffect.CLOUD;
-		}
-	}
+    /**
+     * Gets the Air Particles from the config.
+     *
+     * @return Config specified ParticleEffect
+     */
+    public static ParticleEffect getAirbendingParticles() {
+        final String particle = getConfig().getString("Properties.Air.Particles");
+        if (particle == null) {
+            return ParticleEffect.CLOUD;
+        } else if (particle.equalsIgnoreCase("spell")) {
+            return ParticleEffect.SPELL;
+        } else if (particle.equalsIgnoreCase("blacksmoke")) {
+            return ParticleEffect.SMOKE_NORMAL;
+        } else if (particle.equalsIgnoreCase("smoke")) {
+            return ParticleEffect.CLOUD;
+        } else if (particle.equalsIgnoreCase("smallsmoke")) {
+            return ParticleEffect.SNOW_SHOVEL;
+        } else {
+            return ParticleEffect.CLOUD;
+        }
+    }
 
-	/**
-	 * This method was used for the old collision detection system. Please see
-	 * {@link Collision} for the new system.
-	 * <p>
-	 * Checks whether a location is within an AirShield.
-	 *
-	 * @param loc The location to check
-	 * @return true If the location is inside an AirShield.
-	 */
-	@Deprecated
-	public static boolean isWithinAirShield(final Location loc) {
-		final List<String> list = new ArrayList<String>();
-		list.add("AirShield");
-		return GeneralMethods.blockAbilities(null, list, loc, 0);
-	}
+    /**
+     * This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
+     * <p>
+     * Checks whether a location is within an AirShield.
+     *
+     * @param loc The location to check
+     * @return true If the location is inside an AirShield.
+     */
+    @Deprecated
+    public static boolean isWithinAirShield(final Location loc) {
+        final List<String> list = new ArrayList<String>();
+        list.add("AirShield");
+        return GeneralMethods.blockAbilities(null, list, loc, 0);
+    }
 
-	/**
-	 * Plays an integer amount of air particles in a location.
-	 *
-	 * @param loc The location to use
-	 * @param amount The amount of particles
-	 */
-	public static void playAirbendingParticles(final Location loc, final int amount) {
-		playAirbendingParticles(loc, amount, Math.random(), Math.random(), Math.random());
-	}
+    /**
+     * Plays an integer amount of air particles in a location.
+     *
+     * @param loc    The location to use
+     * @param amount The amount of particles
+     */
+    public static void playAirbendingParticles(final Location loc, final int amount) {
+        playAirbendingParticles(loc, amount, Math.random(), Math.random(), Math.random());
+    }
 
-	/**
-	 * Plays an integer amount of air particles in a location with a given
-	 * xOffset, yOffset, and zOffset.
-	 *
-	 * @param loc The location to use
-	 * @param amount The amount of particles
-	 * @param xOffset The xOffset to use
-	 * @param yOffset The yOffset to use
-	 * @param zOffset The zOffset to use
-	 */
-	public static void playAirbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
-		getAirbendingParticles().display(loc, amount, xOffset, yOffset, zOffset);
-	}
+    public static Functional.Particle airParticles = args -> {
+        Location loc = (Location) args[0];
+        int amount = (int) args[1];
+        double xOffset = (double) args[2];
+        double yOffset = (double) args[3];
+        double zOffset = (double) args[4];
+        getAirbendingParticles().display(loc, amount, xOffset, yOffset, zOffset);
+    };
 
-	/**
-	 * Plays the Airbending Sound at a location if enabled in the config.
-	 *
-	 * @param loc The location to play the sound at
-	 */
-	public static void playAirbendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Air.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Air.Sound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Air.Sound.Pitch");
+    /**
+     * Plays an integer amount of air particles in a location with a given
+     * xOffset, yOffset, and zOffset.
+     *
+     * @param loc     The location to use
+     * @param amount  The amount of particles
+     * @param xOffset The xOffset to use
+     * @param yOffset The yOffset to use
+     * @param zOffset The zOffset to use
+     */
+    public static void playAirbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        airParticles.play(loc, amount, xOffset, yOffset, zOffset);
+    }
 
-			Sound sound = Sound.ENTITY_CREEPER_HURT;
+    /**
+     * Plays the Airbending Sound at a location if enabled in the config.
+     *
+     * @param loc The location to play the sound at
+     */
+    public static void playAirbendingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Air.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Air.Sound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Air.Sound.Pitch");
 
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Air.Sound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Air.Sound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
+            Sound sound = Sound.ENTITY_CREEPER_HURT;
 
-	/**
-	 * This method was used for the old collision detection system. Please see
-	 * {@link Collision} for the new system.
-	 * <p>
-	 * Removes all air spouts in a location within a certain radius.
-	 *
-	 * @param loc The location to use
-	 * @param radius The radius around the location to remove spouts in
-	 * @param source The player causing the removal
-	 */
-	@Deprecated
-	public static void removeAirSpouts(final Location loc, final double radius, final Player source) {
-		AirSpout.removeSpouts(loc, radius, source);
-	}
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Air.Sound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Air.Sound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-	/**
-	 * This method was used for the old collision detection system. Please see
-	 * {@link Collision} for the new system.
-	 * <p>
-	 * Removes all air spouts in a location with a radius of 1.5.
-	 *
-	 * @param loc The location to use
-	 * @param source The player causing the removal
-	 */
-	@Deprecated
-	public static void removeAirSpouts(final Location loc, final Player source) {
-		removeAirSpouts(loc, 1.5, source);
-	}
+    /**
+     * This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
+     * <p>
+     * Removes all air spouts in a location within a certain radius.
+     *
+     * @param loc    The location to use
+     * @param radius The radius around the location to remove spouts in
+     * @param source The player causing the removal
+     */
+    @Deprecated
+    public static void removeAirSpouts(final Location loc, final double radius, final Player source) {
+        AirSpout.removeSpouts(loc, radius, source);
+    }
+
+    /**
+     * This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
+     * <p>
+     * Removes all air spouts in a location with a radius of 1.5.
+     *
+     * @param loc    The location to use
+     * @param source The player causing the removal
+     */
+    @Deprecated
+    public static void removeAirSpouts(final Location loc, final Player source) {
+        removeAirSpouts(loc, 1.5, source);
+    }
 
 }

--- a/src/com/projectkorra/projectkorra/ability/CombustionAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CombustionAbility.java
@@ -1,6 +1,9 @@
 package com.projectkorra.projectkorra.ability;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
+import org.bukkit.Location;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
@@ -9,6 +12,22 @@ public abstract class CombustionAbility extends FireAbility implements SubAbilit
 
 	public CombustionAbility(final Player player) {
 		super(player);
+	}
+
+	public static void playCombustionSound(final Location loc) {
+		if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+			final float volume = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Volume");
+			final float pitch = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Pitch");
+
+			Sound sound = Sound.ENTITY_FIREWORK_ROCKET_BLAST;
+			try {
+				sound = Sound.valueOf(getConfig().getString("Properties.Fire.CombustionSound.Sound"));
+			} catch (final IllegalArgumentException exception) {
+				ProjectKorra.log.warning("Your current value for 'Properties.Fire.CombustionSound.Sound' is not valid.");
+			} finally {
+				loc.getWorld().playSound(loc, sound, volume, pitch);
+			}
+		}
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -283,6 +283,20 @@ public abstract class EarthAbility extends ElementalAbility {
 		TEMP_AIR_LOCATIONS.put(info.getID(), info);
 	}
 
+	/**
+	 * Plays an integer amount of sand particles in a location with a given
+	 * xOffset, yOffset, zOffset, speed and color.
+	 * Deprecated. Use {@link SandAbility#displaySandParticle(CoreAbility, Location, int, double, double, double, double, boolean)} instead
+	 *
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 * @param xOffset The xOffset to use
+	 * @param yOffset The yOffset to use
+	 * @param zOffset The zOffset to use
+	 * @param speed The particle animation speed
+	 * @param red Use red sand for the particle
+	 */
+	@Deprecated
 	public static void displaySandParticle(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset, final double speed, final boolean red) {
 		if (amount <= 0) {
 			return;
@@ -499,57 +513,6 @@ public abstract class EarthAbility extends ElementalAbility {
 		}
 	}
 
-	public static void playMetalbendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Earth.MetalSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Earth.MetalSound.Pitch");
-
-			Sound sound = Sound.ENTITY_IRON_GOLEM_HURT;
-
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Earth.MetalSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Earth.MetalSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
-
-	public static void playSandbendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Earth.SandSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Earth.SandSound.Pitch");
-
-			Sound sound = Sound.BLOCK_SAND_BREAK;
-
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Earth.SandSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Earth.SandSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
-
-	public static void playLavabendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Earth.LavaSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Earth.LavaSound.Pitch");
-
-			Sound sound = Sound.BLOCK_LAVA_AMBIENT;
-
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Earth.LavaSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Earth.LavaSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
-
 	public static void removeAllEarthbendedBlocks() {
 		for (final Block block : MOVED_EARTH.keySet()) {
 			revertBlock(block);
@@ -668,5 +631,29 @@ public abstract class EarthAbility extends ElementalAbility {
 		if (isEarthRevertOn()) {
 			removeAllEarthbendedBlocks();
 		}
+	}
+
+	/**
+	 * @deprecated <b>Use {@link MetalAbility#playMetalbendingSound(Location)} instead.
+	 */
+	@Deprecated
+	public static void playMetalbendingSound(final Location loc) {
+		MetalAbility.playMetalbendingSound(loc);
+	}
+
+	/**
+	 * @deprecated <b>Use {@link SandAbility#playSandbendingSound(Location)} instead.
+	 */
+	@Deprecated
+	public static void playSandbendingSound(final Location loc) {
+		SandAbility.playSandbendingSound(loc);
+	}
+
+	/**
+	 * @deprecated <b>Used {@link LavaAbility#playLavabendingSound(Location)} instead.
+	 */
+	@Deprecated
+	public static void playLavabendingSound(final Location loc) {
+		LavaAbility.playLavabendingSound(loc);
 	}
 }

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -9,6 +9,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.ability.functional.Functional;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -31,298 +33,320 @@ import com.projectkorra.projectkorra.util.TempBlock;
 
 public abstract class FireAbility extends ElementalAbility {
 
-	private static final Map<Block, Player> SOURCE_PLAYERS = new ConcurrentHashMap<>();
-	private static final Set<BlockFace> IGNITE_FACES = new HashSet<>(Arrays.asList(BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.UP));
+    private static final Map<Block, Player> SOURCE_PLAYERS = new ConcurrentHashMap<>();
+    private static final Set<BlockFace> IGNITE_FACES = new HashSet<>(Arrays.asList(BlockFace.EAST, BlockFace.WEST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.UP));
 
-	public FireAbility(final Player player) {
-		super(player);
-	}
+    public FireAbility(final Player player) {
+        super(player);
+    }
 
-	@Override
-	public boolean isIgniteAbility() {
-		return true;
-	}
+    @Override
+    public boolean isIgniteAbility() {
+        return true;
+    }
 
-	@Override
-	public boolean isExplosiveAbility() {
-		return false;
-	}
+    @Override
+    public boolean isExplosiveAbility() {
+        return false;
+    }
 
-	@Override
-	public Element getElement() {
-		return Element.FIRE;
-	}
+    @Override
+    public Element getElement() {
+        return Element.FIRE;
+    }
 
-	@Override
-	public void handleCollision(final Collision collision) {
-		super.handleCollision(collision);
-		if (collision.isRemovingFirst()) {
-			ParticleEffect.BLOCK_CRACK.display(collision.getLocationFirst(), 10, 1, 1, 1, 0.1, getFireType().createBlockData());
-		}
-	}
-	/**
-	 * 
-	 * @return Material based on whether the player is a Blue Firebender, SOUL_FIRE if true, FIRE if false.
-	 */
-	public Material getFireType() {
-		return getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE) ? Material.SOUL_FIRE : Material.FIRE;
-	}
-	
-	/**
-	 * Returns if fire is allowed to completely replace blocks or if it should
-	 * place a temp fire block.
-	 */
-	public static boolean canFireGrief() {
-		return getConfig().getBoolean("Properties.Fire.FireGriefing");
-	}
+    @Override
+    public void handleCollision(final Collision collision) {
+        super.handleCollision(collision);
+        if (collision.isRemovingFirst()) {
+            ParticleEffect.BLOCK_CRACK.display(collision.getLocationFirst(), 10, 1, 1, 1, 0.1, getFireType().createBlockData());
+        }
+    }
 
-	/**
-	 * Creates a fire block meant to replace other blocks but reverts when the
-	 * fire dissipates or is destroyed.
-	 */
-	public void createTempFire(final Location loc) {
-		createTempFire(loc, getConfig().getLong("Properties.Fire.RevertTicks") + (long) ((new Random()).nextDouble() * getConfig().getLong("Properties.Fire.RevertTicks")));
-	}
+    /**
+     * @return Material based on whether the player is a Blue Firebender, SOUL_FIRE if true, FIRE if false.
+     */
+    public Material getFireType() {
+        return getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE) ? Material.SOUL_FIRE : Material.FIRE;
+    }
 
-	public void createTempFire(final Location loc, final long time) {
-		if(isIgnitable(loc.getBlock())) {
-			new TempBlock(loc.getBlock(), getFireType().createBlockData(), time);
-			SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
-		}
-	}
+    /**
+     * Returns if fire is allowed to completely replace blocks or if it should
+     * place a temp fire block.
+     */
+    public static boolean canFireGrief() {
+        return getConfig().getBoolean("Properties.Fire.FireGriefing");
+    }
 
-	public double getDayFactor(final double value) {
-		return (this.player != null ? value * getDayFactor(player.getWorld()) : value);
-	}
+    /**
+     * Creates a fire block meant to replace other blocks but reverts when the
+     * fire dissipates or is destroyed.
+     */
+    public void createTempFire(final Location loc) {
+        createTempFire(loc, getConfig().getLong("Properties.Fire.RevertTicks") + (long) ((new Random()).nextDouble() * getConfig().getLong("Properties.Fire.RevertTicks")));
+    }
 
-	public static double getDayFactor() {
-		return getConfig().getDouble("Properties.Fire.DayFactor");
-	}
+    public void createTempFire(final Location loc, final long time) {
+        if (isIgnitable(loc.getBlock())) {
+            new TempBlock(loc.getBlock(), getFireType().createBlockData(), time);
+            SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
+        }
+    }
 
-	/**
-	 * Gets the firebending dayfactor from the config multiplied by a specific
-	 * value if it is day.
-	 *
-	 * @param value The value
-	 * @param world The world to pass into {@link #isDay(World)}
-	 * @return value DayFactor multiplied by specified value when
-	 *         {@link #isDay(World)} is true <br />
-	 *         else <br />
-	 *         value The specified value in the parameters
-	 */
-	public static double getDayFactor(final double value, final World world) {
-		if (isDay(world)) {
-			return value * getDayFactor();
-		}
-		return value;
-	}
+    public double getDayFactor(final double value) {
+        return (this.player != null ? value * getDayFactor(player.getWorld()) : value);
+    }
 
-	public static double getDayFactor(final World world) {
-		return getDayFactor(1, world);
-	}
+    public static double getDayFactor() {
+        return getConfig().getDouble("Properties.Fire.DayFactor");
+    }
 
-	public static ChatColor getSubChatColor() {
-		return ChatColor.valueOf(ConfigManager.getConfig().getString("Properties.Chat.Colors.FireSub"));
-	}
+    /**
+     * Gets the firebending dayfactor from the config multiplied by a specific
+     * value if it is day.
+     *
+     * @param value The value
+     * @param world The world to pass into {@link #isDay(World)}
+     * @return value DayFactor multiplied by specified value when
+     * {@link #isDay(World)} is true <br />
+     * else <br />
+     * value The specified value in the parameters
+     */
+    public static double getDayFactor(final double value, final World world) {
+        if (isDay(world)) {
+            return value * getDayFactor();
+        }
+        return value;
+    }
 
-	/**
-	 * Can fire be placed in the provided block
-	 * @param block The block to check
-	 * @return True if fire can be placed here
-	 */
-	public static boolean isIgnitable(final Block block) {
-		return (block.getRelative(BlockFace.DOWN).getType().isSolid() && !block.getType().isSolid())
-				|| (GeneralMethods.isTransparent(block) && IGNITE_FACES.stream().map(face -> block.getRelative(face).getType()).anyMatch(FireAbility::isIgnitable));
-	}
+    public static double getDayFactor(final World world) {
+        return getDayFactor(1, world);
+    }
 
-	public static boolean isIgnitable(final Material material) {
-		return material.isFlammable() || material.isBurnable();
-	}
+    public static ChatColor getSubChatColor() {
+        return ChatColor.valueOf(ConfigManager.getConfig().getString("Properties.Chat.Colors.FireSub"));
+    }
 
-	/**
-	 * Create a fire block with the correct blockstate at the given position
-	 * @param position The position to test
-	 * @param blue If its soul fire or not
-	 * @return The fire blockstate
-	 */
-	public static BlockData createFireState(Block position, boolean blue) {
-		if (blue) return Material.SOUL_FIRE.createBlockData();
+    /**
+     * Can fire be placed in the provided block
+     *
+     * @param block The block to check
+     * @return True if fire can be placed here
+     */
+    public static boolean isIgnitable(final Block block) {
+        return (block.getRelative(BlockFace.DOWN).getType().isSolid() && !block.getType().isSolid())
+                || (GeneralMethods.isTransparent(block) && IGNITE_FACES.stream().map(face -> block.getRelative(face).getType()).anyMatch(FireAbility::isIgnitable));
+    }
 
-		Fire fire = (Fire) Material.FIRE.createBlockData();
-		if (position.getRelative(BlockFace.DOWN).getType().isSolid())
-			return fire; //Default fire for when there is a solid block bellow
-		for (BlockFace face : IGNITE_FACES) {
-			if (isIgnitable(position.getRelative(face).getType())) {
-				fire.setFace(face, true);
-			}
-		}
-		return fire;
-	}
+    public static boolean isIgnitable(final Material material) {
+        return material.isFlammable() || material.isBurnable();
+    }
 
-	/**
-	 * This method was used for the old collision detection system. Please see
-	 * {@link Collision} for the new system.
-	 * <p>
-	 * Checks whether a location is within a FireShield.
-	 *
-	 * @param loc The location to check
-	 * @return true If the location is inside a FireShield.
-	 */
-	@Deprecated
-	public static boolean isWithinFireShield(final Location loc) {
-		final List<String> list = new ArrayList<String>();
-		list.add("FireShield");
-		return GeneralMethods.blockAbilities(null, list, loc, 0);
-	}
+    /**
+     * Create a fire block with the correct blockstate at the given position
+     *
+     * @param position The position to test
+     * @param blue     If its soul fire or not
+     * @return The fire blockstate
+     */
+    public static BlockData createFireState(Block position, boolean blue) {
+        if (blue) return Material.SOUL_FIRE.createBlockData();
 
-	public static void playCombustionSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Pitch");
+        Fire fire = (Fire) Material.FIRE.createBlockData();
+        if (position.getRelative(BlockFace.DOWN).getType().isSolid())
+            return fire; //Default fire for when there is a solid block bellow
+        for (BlockFace face : IGNITE_FACES) {
+            if (isIgnitable(position.getRelative(face).getType())) {
+                fire.setFace(face, true);
+            }
+        }
+        return fire;
+    }
 
-			Sound sound = Sound.ENTITY_FIREWORK_ROCKET_BLAST;
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Fire.CombustionSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Fire.CombustionSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
+    /**
+     * This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
+     * <p>
+     * Checks whether a location is within a FireShield.
+     *
+     * @param loc The location to check
+     * @return true If the location is inside a FireShield.
+     */
+    @Deprecated
+    public static boolean isWithinFireShield(final Location loc) {
+        final List<String> list = new ArrayList<String>();
+        list.add("FireShield");
+        return GeneralMethods.blockAbilities(null, list, loc, 0);
+    }
 
-	public void playFirebendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
-		if (this.getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE)) {
-			ParticleEffect.SOUL_FIRE_FLAME.display(loc, amount, xOffset, yOffset, zOffset);
-		} else {
-			ParticleEffect.FLAME.display(loc, amount, xOffset, yOffset, zOffset);
-		}
-	}
+    public static void playCombustionSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Pitch");
 
-	public static void playFirebendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Fire.FireSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Fire.FireSound.Pitch");
+            Sound sound = Sound.ENTITY_FIREWORK_ROCKET_BLAST;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.CombustionSound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.CombustionSound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-			Sound sound = Sound.BLOCK_FIRE_AMBIENT;
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Fire.FireSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Fire.FireSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
+    public static Functional.Particle fireParticles = (args) -> {
+        BendingPlayer bPlayer = (BendingPlayer) args[0];
+        Location loc = (Location) args[1];
+        int amount = (int) args[2];
+        double xOffset = (double) args[3];
+        double yOffset = (double) args[4];
+        double zOffset = (double) args[5];
+        (bPlayer.hasSubElement(Element.BLUE_FIRE) ? ParticleEffect.SOUL_FIRE_FLAME : ParticleEffect.FLAME).display(loc, amount, xOffset, yOffset, zOffset);
+    };
 
-	public static void playLightningbendingParticle(final Location loc) {
-		playLightningbendingParticle(loc, Math.random(), Math.random(), Math.random());
-	}
+    public void playFirebendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        fireParticles.play(this.getBendingPlayer(), loc, amount, xOffset, yOffset, zOffset);
+    }
 
-	public static void playLightningbendingParticle(final Location loc, final double xOffset, final double yOffset, final double zOffset) {
-		GeneralMethods.displayColoredParticle("#01E1FF", loc, 1, xOffset, yOffset, zOffset);
-	}
+    public static void playFirebendingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.FireSound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.FireSound.Pitch");
 
-	public static void playLightningbendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Fire.LightningSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningSound.Pitch");
+            Sound sound = Sound.BLOCK_FIRE_AMBIENT;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.FireSound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.FireSound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-			Sound sound = Sound.ENTITY_CREEPER_HURT;
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
 
-	public static void playLightningbendingChargingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Pitch");
+    public static Functional.Particle lightningParticles = (args) -> {
+        Location loc = (Location) args[0];
+        double xOffset = (double) args[1];
+        double yOffset = (double) args[2];
+        double zOffset = (double) args[3];
+        GeneralMethods.displayColoredParticle("#01E1FF", loc, 1, xOffset, yOffset, zOffset);
+    };
 
-			Sound sound = Sound.BLOCK_BEEHIVE_WORK;
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningCharge.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningCharge.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
-	
-	public static void playLightningbendingHitSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Fire.LightningHit.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningHit.Pitch");
+    public static void playLightningbendingParticle(final Location loc) {
+        playLightningbendingParticle(loc, Math.random(), Math.random(), Math.random());
+    }
 
-			Sound sound = Sound.ENTITY_LIGHTNING_BOLT_THUNDER;
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningHit.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningHit.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
+    public static void playLightningbendingParticle(final Location loc, final double xOffset, final double yOffset, final double zOffset) {
+        lightningParticles.play(loc, xOffset, yOffset, zOffset);
+    }
 
-	/**
-	 * Apply modifiers to this value. Applies the day factor to it
-	 * @param value The value to modify
-	 * @return The modified value
-	 */
-	@Override
-	public double applyModifiers(double value) {
-		return GeneralMethods.applyModifiers(value, getDayFactor(1.0));
-	}
+    public static void playLightningbendingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningSound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningSound.Pitch");
 
-	/**
-	 * Apply modifiers to this value. Applies the day factor to it
-	 * @param value The value to modify
-	 * @return The modified value
-	 */
-	public double applyInverseModifiers(double value) {
-		return GeneralMethods.applyInverseModifiers(value, getDayFactor(1.0));
-	}
+            Sound sound = Sound.ENTITY_CREEPER_HURT;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningSound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningSound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-	/**
-	 * Apply modifiers to this value. Applies the day factor and the blue fire factor (for damage)
-	 * @param value The value to modify
-	 * @return The modified value
-	 */
-	public double applyModifiersDamage(double value) {
-		return GeneralMethods.applyModifiers(value, getDayFactor(1.0), bPlayer.hasElement(Element.BLUE_FIRE) ? getConfig().getDouble("Properties.Fire.BlueFire.DamageFactor", 1.1) : 1);
-	}
+    public static void playLightningbendingChargingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Pitch");
 
-	/**
-	 * Apply modifiers to this value. Applies the day factor and the blue fire factor (for range)
-	 * @param value The value to modify
-	 * @return The modified value
-	 */
-	public double applyModifiersRange(double value) {
-		return GeneralMethods.applyModifiers(value, getDayFactor(1.0), bPlayer.hasElement(Element.BLUE_FIRE) ? getConfig().getDouble("Properties.Fire.BlueFire.RangeFactor", 1.2) : 1);
-	}
+            Sound sound = Sound.BLOCK_BEEHIVE_WORK;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningCharge.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningCharge.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-	/**
-	 * Apply modifiers to this value. Applies the day factor and the blue fire factor (for cooldowns)
-	 * @param value The value to modify
-	 * @return The modified value
-	 */
-	public long applyModifiersCooldown(long value) {
-		return (long) GeneralMethods.applyInverseModifiers(value, getDayFactor(1.0), bPlayer.hasElement(Element.BLUE_FIRE) ? 1 / getConfig().getDouble("Properties.Fire.BlueFire.CooldownFactor", 0.9) : 1);
-	}
+    public static void playLightningbendingHitSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningHit.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningHit.Pitch");
 
-	public static void stopBending() {
-		SOURCE_PLAYERS.clear();
-	}
+            Sound sound = Sound.ENTITY_LIGHTNING_BOLT_THUNDER;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningHit.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningHit.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-	public static Map<Block, Player> getSourcePlayers() {
-		return SOURCE_PLAYERS;
-	}
+    /**
+     * Apply modifiers to this value. Applies the day factor to it
+     *
+     * @param value The value to modify
+     * @return The modified value
+     */
+    @Override
+    public double applyModifiers(double value) {
+        return GeneralMethods.applyModifiers(value, getDayFactor(1.0));
+    }
+
+    /**
+     * Apply modifiers to this value. Applies the day factor to it
+     *
+     * @param value The value to modify
+     * @return The modified value
+     */
+    public double applyInverseModifiers(double value) {
+        return GeneralMethods.applyInverseModifiers(value, getDayFactor(1.0));
+    }
+
+    /**
+     * Apply modifiers to this value. Applies the day factor and the blue fire factor (for damage)
+     *
+     * @param value The value to modify
+     * @return The modified value
+     */
+    public double applyModifiersDamage(double value) {
+        return GeneralMethods.applyModifiers(value, getDayFactor(1.0), bPlayer.hasElement(Element.BLUE_FIRE) ? getConfig().getDouble("Properties.Fire.BlueFire.DamageFactor", 1.1) : 1);
+    }
+
+    /**
+     * Apply modifiers to this value. Applies the day factor and the blue fire factor (for range)
+     *
+     * @param value The value to modify
+     * @return The modified value
+     */
+    public double applyModifiersRange(double value) {
+        return GeneralMethods.applyModifiers(value, getDayFactor(1.0), bPlayer.hasElement(Element.BLUE_FIRE) ? getConfig().getDouble("Properties.Fire.BlueFire.RangeFactor", 1.2) : 1);
+    }
+
+    /**
+     * Apply modifiers to this value. Applies the day factor and the blue fire factor (for cooldowns)
+     *
+     * @param value The value to modify
+     * @return The modified value
+     */
+    public long applyModifiersCooldown(long value) {
+        return (long) GeneralMethods.applyInverseModifiers(value, getDayFactor(1.0), bPlayer.hasElement(Element.BLUE_FIRE) ? 1 / getConfig().getDouble("Properties.Fire.BlueFire.CooldownFactor", 0.9) : 1);
+    }
+
+    public static void stopBending() {
+        SOURCE_PLAYERS.clear();
+    }
+
+    public static Map<Block, Player> getSourcePlayers() {
+        return SOURCE_PLAYERS;
+    }
 
 }

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -9,7 +9,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.ability.functional.Functional;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -163,50 +162,26 @@ public abstract class FireAbility extends ElementalAbility {
         return fire;
     }
 
-    /**
-     * This method was used for the old collision detection system. Please see
-     * {@link Collision} for the new system.
-     * <p>
-     * Checks whether a location is within a FireShield.
-     *
-     * @param loc The location to check
-     * @return true If the location is inside a FireShield.
-     */
-    @Deprecated
-    public static boolean isWithinFireShield(final Location loc) {
-        final List<String> list = new ArrayList<String>();
-        list.add("FireShield");
-        return GeneralMethods.blockAbilities(null, list, loc, 0);
-    }
-
-    public static void playCombustionSound(final Location loc) {
-        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-            final float volume = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Volume");
-            final float pitch = (float) getConfig().getDouble("Properties.Fire.CombustionSound.Pitch");
-
-            Sound sound = Sound.ENTITY_FIREWORK_ROCKET_BLAST;
-            try {
-                sound = Sound.valueOf(getConfig().getString("Properties.Fire.CombustionSound.Sound"));
-            } catch (final IllegalArgumentException exception) {
-                ProjectKorra.log.warning("Your current value for 'Properties.Fire.CombustionSound.Sound' is not valid.");
-            } finally {
-                loc.getWorld().playSound(loc, sound, volume, pitch);
-            }
+    public static Functional.Particle fireParticles = (ability, location, amount, xOffset, yOffset, zOffset, extra, data) -> {
+        if (ability.getBendingPlayer().canUseSubElement(SubElement.BLUE_FIRE)) {
+            ParticleEffect.SOUL_FIRE_FLAME.display(location, amount, xOffset, yOffset, zOffset);
+        } else {
+            ParticleEffect.FLAME.display(location, amount, xOffset, yOffset, zOffset);
         }
-    }
-
-    public static Functional.Particle fireParticles = (args) -> {
-        BendingPlayer bPlayer = (BendingPlayer) args[0];
-        Location loc = (Location) args[1];
-        int amount = (int) args[2];
-        double xOffset = (double) args[3];
-        double yOffset = (double) args[4];
-        double zOffset = (double) args[5];
-        (bPlayer.hasSubElement(Element.BLUE_FIRE) ? ParticleEffect.SOUL_FIRE_FLAME : ParticleEffect.FLAME).display(loc, amount, xOffset, yOffset, zOffset);
     };
 
-    public void playFirebendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
-        fireParticles.play(this.getBendingPlayer(), loc, amount, xOffset, yOffset, zOffset);
+    /**
+     * Plays firebending particles in a location with given offsets.<br>
+     *
+     * @param ability The ability these particles are spawned for
+     * @param loc     The location to use
+     * @param amount  The amount of particles to use
+     * @param xOffset The xOffset to use
+     * @param yOffset The yOffset to use
+     * @param zOffset The zOffset to use
+     */
+    public static void playFirebendingParticles(CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        fireParticles.play(ability, loc, amount, xOffset, yOffset, zOffset, 0, null);
     }
 
     public static void playFirebendingSound(final Location loc) {
@@ -219,71 +194,6 @@ public abstract class FireAbility extends ElementalAbility {
                 sound = Sound.valueOf(getConfig().getString("Properties.Fire.FireSound.Sound"));
             } catch (final IllegalArgumentException exception) {
                 ProjectKorra.log.warning("Your current value for 'Properties.Fire.FireSound.Sound' is not valid.");
-            } finally {
-                loc.getWorld().playSound(loc, sound, volume, pitch);
-            }
-        }
-    }
-
-
-    public static Functional.Particle lightningParticles = (args) -> {
-        Location loc = (Location) args[0];
-        double xOffset = (double) args[1];
-        double yOffset = (double) args[2];
-        double zOffset = (double) args[3];
-        GeneralMethods.displayColoredParticle("#01E1FF", loc, 1, xOffset, yOffset, zOffset);
-    };
-
-    public static void playLightningbendingParticle(final Location loc) {
-        playLightningbendingParticle(loc, Math.random(), Math.random(), Math.random());
-    }
-
-    public static void playLightningbendingParticle(final Location loc, final double xOffset, final double yOffset, final double zOffset) {
-        lightningParticles.play(loc, xOffset, yOffset, zOffset);
-    }
-
-    public static void playLightningbendingSound(final Location loc) {
-        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningSound.Volume");
-            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningSound.Pitch");
-
-            Sound sound = Sound.ENTITY_CREEPER_HURT;
-            try {
-                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningSound.Sound"));
-            } catch (final IllegalArgumentException exception) {
-                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningSound.Sound' is not valid.");
-            } finally {
-                loc.getWorld().playSound(loc, sound, volume, pitch);
-            }
-        }
-    }
-
-    public static void playLightningbendingChargingSound(final Location loc) {
-        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Volume");
-            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Pitch");
-
-            Sound sound = Sound.BLOCK_BEEHIVE_WORK;
-            try {
-                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningCharge.Sound"));
-            } catch (final IllegalArgumentException exception) {
-                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningCharge.Sound' is not valid.");
-            } finally {
-                loc.getWorld().playSound(loc, sound, volume, pitch);
-            }
-        }
-    }
-
-    public static void playLightningbendingHitSound(final Location loc) {
-        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
-            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningHit.Volume");
-            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningHit.Pitch");
-
-            Sound sound = Sound.ENTITY_LIGHTNING_BOLT_THUNDER;
-            try {
-                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningHit.Sound"));
-            } catch (final IllegalArgumentException exception) {
-                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningHit.Sound' is not valid.");
             } finally {
                 loc.getWorld().playSound(loc, sound, volume, pitch);
             }
@@ -347,6 +257,95 @@ public abstract class FireAbility extends ElementalAbility {
 
     public static Map<Block, Player> getSourcePlayers() {
         return SOURCE_PLAYERS;
+    }
+
+    /**
+     * This method was used for the old collision detection system. Please see
+     * {@link Collision} for the new system.
+     * <p>
+     * Checks whether a location is within a FireShield.
+     *
+     * @param loc The location to check
+     * @return true If the location is inside a FireShield.
+     */
+    @Deprecated
+    public static boolean isWithinFireShield(final Location loc) {
+        final List<String> list = new ArrayList<String>();
+        list.add("FireShield");
+        return GeneralMethods.blockAbilities(null, list, loc, 0);
+    }
+
+    /**
+     * Plays firebending particles in a location with given offsets.<br>
+     *
+     * @param loc     The location to use
+     * @param amount  The amount of particles to use
+     * @param xOffset The xOffset to use
+     * @param yOffset The yOffset to use
+     * @param zOffset The zOffset to use
+     * @deprecated <b>Use {@link FireAbility#playFirebendingParticles(CoreAbility, Location, int, double, double, double)} instead.</b>
+     */
+    @Deprecated
+    public void playFirebendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        playFirebendingParticles(this, loc, amount, xOffset, yOffset, zOffset);
+    }
+
+    /**
+     * Plays a single lightning particle in a location.<br>
+     *
+     * @param loc The location to use
+     * @deprecated <b>Use {@link LightningAbility#playLightningbendingParticles(CoreAbility, Location, int)} instead.
+     */
+    @Deprecated
+    public static void playLightningbendingParticle(final Location loc) {
+        playLightningbendingParticle(loc, Math.random(), Math.random(), Math.random());
+    }
+
+    /**
+     * Plays a single lightning particle in a location with given offsets.<br>
+     *
+     * @param loc     The location to use
+     * @param xOffset The xOffset to use
+     * @param yOffset The yOffset to use
+     * @param zOffset The zOffset to use
+     * @deprecated <b>Use {@link LightningAbility#playLightningbendingParticles(CoreAbility, Location, int, double, double, double)} instead.
+     */
+    @Deprecated
+    public static void playLightningbendingParticle(final Location loc, final double xOffset, final double yOffset, final double zOffset) {
+        LightningAbility.playLightningbendingParticles(null, loc, 1, xOffset, yOffset, zOffset);
+        //GeneralMethods.displayColoredParticle("#01E1FF", loc, 1, xOffset, yOffset, zOffset);
+    }
+
+    /**
+     * @deprecated <b>Use {@link LightningAbility#playLightningbendingSound(Location)} instead.
+     */
+    @Deprecated
+    public static void playLightningbendingSound(final Location loc) {
+        LightningAbility.playLightningbendingSound(loc);
+    }
+
+    /**
+     * @deprecated <b>Use {@link LightningAbility#playLightningbendingChargingSound(Location)} instead.
+     */
+    @Deprecated
+    public static void playLightningbendingChargingSound(final Location loc) {
+        LightningAbility.playLightningbendingChargingSound(loc);
+    }
+
+    /**
+     * @deprecated <b>Use {@link LightningAbility#playLightningbendingHitSound(Location)} instead.
+     */
+    @Deprecated
+    public static void playLightningbendingHitSound(final Location loc) {
+        LightningAbility.playLightningbendingHitSound(loc);
+    }
+
+    /**
+     * @deprecated <b>Use {@link CombustionAbility#playCombustionSound(Location)} instead.
+     */
+    @Deprecated
+    public static void playCombustionSound(final Location loc) {
+        CombustionAbility.playCombustionSound(loc);
     }
 
 }

--- a/src/com/projectkorra/projectkorra/ability/IceAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/IceAbility.java
@@ -1,5 +1,8 @@
 package com.projectkorra.projectkorra.ability;
 
+import com.projectkorra.projectkorra.ProjectKorra;
+import org.bukkit.Location;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
@@ -8,6 +11,23 @@ public abstract class IceAbility extends WaterAbility implements SubAbility {
 
 	public IceAbility(final Player player) {
 		super(player);
+	}
+
+	public static void playIcebendingSound(final Location loc) {
+		if (getConfig().getBoolean("Properties.Water.PlaySound")) {
+			final float volume = (float) getConfig().getDouble("Properties.Water.IceSound.Volume");
+			final float pitch = (float) getConfig().getDouble("Properties.Water.IceSound.Pitch");
+
+			Sound sound = Sound.ITEM_FLINTANDSTEEL_USE;
+
+			try {
+				sound = Sound.valueOf(getConfig().getString("Properties.Water.IceSound.Sound"));
+			} catch (final IllegalArgumentException exception) {
+				ProjectKorra.log.warning("Your current value for 'Properties.Water.IceSound.Sound' is not valid.");
+			} finally {
+				loc.getWorld().playSound(loc, sound, volume, pitch);
+			}
+		}
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/ability/LavaAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/LavaAbility.java
@@ -1,5 +1,8 @@
 package com.projectkorra.projectkorra.ability;
 
+import com.projectkorra.projectkorra.ProjectKorra;
+import org.bukkit.Location;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
@@ -10,7 +13,24 @@ public abstract class LavaAbility extends EarthAbility implements SubAbility {
 		super(player);
 	}
 
-	@Override
+    public static void playLavabendingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Earth.LavaSound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Earth.LavaSound.Pitch");
+
+            Sound sound = Sound.BLOCK_LAVA_AMBIENT;
+
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Earth.LavaSound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Earth.LavaSound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
+
+    @Override
 	public Class<? extends Ability> getParentAbility() {
 		return EarthAbility.class;
 	}

--- a/src/com/projectkorra/projectkorra/ability/LightningAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/LightningAbility.java
@@ -1,45 +1,127 @@
 package com.projectkorra.projectkorra.ability;
 
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.functional.Functional;
+import org.bukkit.Location;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
 
 public abstract class LightningAbility extends FireAbility implements SubAbility {
 
-	public LightningAbility(final Player player) {
-		super(player);
-	}
+    public LightningAbility(final Player player) {
+        super(player);
+    }
 
-	@Override
-	public Class<? extends Ability> getParentAbility() {
-		return FireAbility.class;
-	}
+    public static void playLightningbendingHitSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningHit.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningHit.Pitch");
 
-	@Override
-	public Element getElement() {
-		return Element.LIGHTNING;
-	}
+            Sound sound = Sound.ENTITY_LIGHTNING_BOLT_THUNDER;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningHit.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningHit.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-	@Override
-	public boolean isIgniteAbility() {
-		return false;
-	}
+    public static void playLightningbendingChargingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningCharge.Pitch");
 
-	//Overriding these methods to make sure Lightning abilities don't get buffed by blue fire
-	@Override
-	public double applyModifiersDamage(double value) {
-		return GeneralMethods.applyModifiers(value, getDayFactor(1.0));
-	}
+            Sound sound = Sound.BLOCK_BEEHIVE_WORK;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningCharge.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningCharge.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-	@Override
-	public double applyModifiersRange(double value) {
-		return GeneralMethods.applyModifiers(value, getDayFactor(1.0));
-	}
+    public static void playLightningbendingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Fire.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Fire.LightningSound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Fire.LightningSound.Pitch");
 
-	@Override
-	public long applyModifiersCooldown(long value) {
-		return (long) GeneralMethods.applyInverseModifiers(value, getDayFactor(1.0));
-	}
+            Sound sound = Sound.ENTITY_CREEPER_HURT;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Fire.LightningSound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Fire.LightningSound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
+
+    public static Functional.Particle lightningParticles = (ability, location, amount, xOffset, yOffset, zOffset, extra, data) -> {
+        GeneralMethods.displayColoredParticle("#01E1FF", location, amount, xOffset, yOffset, zOffset);
+    };
+
+    /**
+     * Plays an integer amount of lightning particles in a location with a given
+     * xOffset, yOffset, and zOffset.
+     *
+     * @param ability The ability this particle is spawned for
+     * @param loc     The location to use
+     * @param amount  The amount of particles
+     * @param xOffset The xOffset to use
+     * @param yOffset The yOffset to use
+     * @param zOffset The zOffset to use
+     */
+    public static void playLightningbendingParticles(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        lightningParticles.play(ability, loc, amount, xOffset, yOffset, zOffset, 0, null);
+    }
+
+    /**
+     * Plays an integer amount of lightning particles in a location.
+     *
+     * @param ability The ability this particle is spawned for
+     * @param loc     The location to use
+     * @param amount  The amount of particles
+     */
+    public static void playLightningbendingParticles(final CoreAbility ability, final Location loc, final int amount) {
+        playLightningbendingParticles(ability, loc, amount, Math.random(), Math.random(), Math.random());
+    }
+
+    @Override
+    public Class<? extends Ability> getParentAbility() {
+        return FireAbility.class;
+    }
+
+    @Override
+    public Element getElement() {
+        return Element.LIGHTNING;
+    }
+
+    @Override
+    public boolean isIgniteAbility() {
+        return false;
+    }
+
+    //Overriding these methods to make sure Lightning abilities don't get buffed by blue fire
+    @Override
+    public double applyModifiersDamage(double value) {
+        return GeneralMethods.applyModifiers(value, getDayFactor(1.0));
+    }
+
+    @Override
+    public double applyModifiersRange(double value) {
+        return GeneralMethods.applyModifiers(value, getDayFactor(1.0));
+    }
+
+    @Override
+    public long applyModifiersCooldown(long value) {
+        return (long) GeneralMethods.applyInverseModifiers(value, getDayFactor(1.0));
+    }
 
 }

--- a/src/com/projectkorra/projectkorra/ability/MetalAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/MetalAbility.java
@@ -1,5 +1,8 @@
 package com.projectkorra.projectkorra.ability;
 
+import com.projectkorra.projectkorra.ProjectKorra;
+import org.bukkit.Location;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
@@ -10,7 +13,24 @@ public abstract class MetalAbility extends EarthAbility implements SubAbility {
 		super(player);
 	}
 
-	@Override
+    public static void playMetalbendingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Earth.MetalSound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Earth.MetalSound.Pitch");
+
+            Sound sound = Sound.ENTITY_IRON_GOLEM_HURT;
+
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Earth.MetalSound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Earth.MetalSound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
+
+    @Override
 	public Class<? extends Ability> getParentAbility() {
 		return EarthAbility.class;
 	}

--- a/src/com/projectkorra/projectkorra/ability/PlantAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/PlantAbility.java
@@ -1,41 +1,54 @@
 package com.projectkorra.projectkorra.ability;
 
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.functional.Functional;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
 
 public abstract class PlantAbility extends WaterAbility implements SubAbility {
 
-    public PlantAbility(final Player player) {
-        super(player);
-    }
+	public PlantAbility(final Player player) {
+		super(player);
+	}
+	
+	@Override
+	public Class<? extends Ability> getParentAbility() {
+		return WaterAbility.class;
+	}
 
-    @Override
-    public Class<? extends Ability> getParentAbility() {
-        return WaterAbility.class;
-    }
+	@Override
+	public Element getElement() {
+		return Element.PLANT;
+	}
 
-    @Override
-    public Element getElement() {
-        return Element.PLANT;
-    }
+	public static Functional.Particle plantParticles = (ability, location, amount, xOffset, yOffset, zOffset, extra, data) -> {
+		location.getWorld().spawnParticle(Particle.BLOCK_CRACK, location.clone().add(0.5, 0, 0.5), amount, xOffset, yOffset, zOffset, data);
+	};
+	
+	// Because Plantbending deserves particles too!
+	public static void playPlantbendingParticles(CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+		plantParticles.play(ability, loc, amount, xOffset, yOffset, zOffset, 0, Material.OAK_LEAVES.createBlockData());
+	}
 
-    public static Functional.Particle plantParticles = args -> {
-        Location loc = (Location) args[0];
-        int amount = (int) args[1];
-        double xOffset = (double) args[2];
-        double yOffset = (double) args[3];
-        double zOffset = (double) args[4];
-        loc.getWorld().spawnParticle(Particle.BLOCK_CRACK, loc.clone().add(0.5, 0, 0.5), amount, xOffset, yOffset, zOffset, Material.OAK_LEAVES.createBlockData());
-    };
+	public static void playPlantbendingSound(final Location loc) {
+		if (getConfig().getBoolean("Properties.Water.PlaySound")) {
+			final float volume = (float) getConfig().getDouble("Properties.Water.PlantSound.Volume");
+			final float pitch = (float) getConfig().getDouble("Properties.Water.PlantSound.Pitch");
 
-    // Because Plantbending deserves particles too!
-    public void playPlantbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
-        plantParticles.play(loc, amount, xOffset, yOffset, zOffset);
-    }
+			Sound sound = Sound.BLOCK_GRASS_STEP;
 
+			try {
+				sound = Sound.valueOf(getConfig().getString("Properties.Water.PlantSound.Sound"));
+			} catch (final IllegalArgumentException exception) {
+				ProjectKorra.log.warning("Your current value for 'Properties.Water.PlantSound.Sound' is not valid.");
+			} finally {
+				loc.getWorld().playSound(loc, sound, volume, pitch);
+			}
+		}
+	}
 }

--- a/src/com/projectkorra/projectkorra/ability/PlantAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/PlantAbility.java
@@ -1,5 +1,6 @@
 package com.projectkorra.projectkorra.ability;
 
+import com.projectkorra.projectkorra.ability.functional.Functional;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
@@ -9,23 +10,32 @@ import com.projectkorra.projectkorra.Element;
 
 public abstract class PlantAbility extends WaterAbility implements SubAbility {
 
-	public PlantAbility(final Player player) {
-		super(player);
-	}
+    public PlantAbility(final Player player) {
+        super(player);
+    }
 
-	@Override
-	public Class<? extends Ability> getParentAbility() {
-		return WaterAbility.class;
-	}
+    @Override
+    public Class<? extends Ability> getParentAbility() {
+        return WaterAbility.class;
+    }
 
-	@Override
-	public Element getElement() {
-		return Element.PLANT;
-	}
+    @Override
+    public Element getElement() {
+        return Element.PLANT;
+    }
 
-	// Because Plantbending deserves particles too!
-	public void playPlantbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
-		loc.getWorld().spawnParticle(Particle.BLOCK_CRACK, loc.clone().add(0.5, 0, 0.5), amount, xOffset, yOffset, zOffset, Material.OAK_LEAVES.createBlockData());
-	}
+    public static Functional.Particle plantParticles = args -> {
+        Location loc = (Location) args[0];
+        int amount = (int) args[1];
+        double xOffset = (double) args[2];
+        double yOffset = (double) args[3];
+        double zOffset = (double) args[4];
+        loc.getWorld().spawnParticle(Particle.BLOCK_CRACK, loc.clone().add(0.5, 0, 0.5), amount, xOffset, yOffset, zOffset, Material.OAK_LEAVES.createBlockData());
+    };
+
+    // Because Plantbending deserves particles too!
+    public void playPlantbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+        plantParticles.play(loc, amount, xOffset, yOffset, zOffset);
+    }
 
 }

--- a/src/com/projectkorra/projectkorra/ability/SandAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/SandAbility.java
@@ -1,6 +1,7 @@
 package com.projectkorra.projectkorra.ability;
 
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.functional.Functional;
 import com.projectkorra.projectkorra.util.ParticleEffect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -11,60 +12,60 @@ import com.projectkorra.projectkorra.Element;
 
 public abstract class SandAbility extends EarthAbility implements SubAbility {
 
-	public SandAbility(final Player player) {
-		super(player);
-	}
+    public SandAbility(final Player player) {
+        super(player);
+    }
 
-	/**
-	 * Plays an integer amount of sand particles in a location with a given
-	 * xOffset, yOffset, zOffset, speed and color.
-	 *
-	 * @param ability The ability this particle is spawned for
-	 * @param loc The location to use
-	 * @param amount The amount of particles
-	 * @param xOffset The xOffset to use
-	 * @param yOffset The yOffset to use
-	 * @param zOffset The zOffset to use
-	 * @param speed The particle animation speed
-	 * @param red Use red sand for the particle
-	 */
-	public static void displaySandParticle(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset, final double speed, final boolean red) {
-		if (amount <= 0) {
-			return;
-		}
+    public static Functional.Particle sandParticles = (ability, location, amount, xOffset, yOffset, zOffset, extra, data) -> {
+        if (amount <= 0) {
+            return;
+        }
+        ParticleEffect.BLOCK_CRACK.display(location, amount, xOffset, yOffset, zOffset, extra, data);
+        ParticleEffect.FALLING_DUST.display(location, amount, xOffset, yOffset, zOffset, extra, data);
+    };
 
-		final Material sand = red ? Material.RED_SAND : Material.SAND;
-		final Material stone = red ? Material.RED_SANDSTONE : Material.SANDSTONE;
+    /**
+     * Plays an integer amount of sand particles in a location with a given
+     * xOffset, yOffset, zOffset, speed and color.
+     *
+     * @param ability The ability this particle is spawned for
+     * @param loc     The location to use
+     * @param amount  The amount of particles
+     * @param xOffset The xOffset to use
+     * @param yOffset The yOffset to use
+     * @param zOffset The zOffset to use
+     * @param speed   The particle animation speed
+     * @param red     Use red sand for the particle
+     */
+    public static void displaySandParticle(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset, final double speed, final boolean red) {
+        sandParticles.play(ability, loc, amount, xOffset, yOffset, zOffset, speed, (red ? Material.RED_SAND : Material.SAND).createBlockData());
+    }
 
-		ParticleEffect.BLOCK_CRACK.display(loc, amount, xOffset, yOffset, zOffset, speed, sand.createBlockData());
-		ParticleEffect.BLOCK_CRACK.display(loc, amount, xOffset, yOffset, zOffset, speed, stone.createBlockData());
-	}
+    public static void playSandbendingSound(final Location loc) {
+        if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
+            final float volume = (float) getConfig().getDouble("Properties.Earth.SandSound.Volume");
+            final float pitch = (float) getConfig().getDouble("Properties.Earth.SandSound.Pitch");
 
-	public static void playSandbendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Earth.SandSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Earth.SandSound.Pitch");
+            Sound sound = Sound.BLOCK_SAND_BREAK;
 
-			Sound sound = Sound.BLOCK_SAND_BREAK;
+            try {
+                sound = Sound.valueOf(getConfig().getString("Properties.Earth.SandSound.Sound"));
+            } catch (final IllegalArgumentException exception) {
+                ProjectKorra.log.warning("Your current value for 'Properties.Earth.SandSound.Sound' is not valid.");
+            } finally {
+                loc.getWorld().playSound(loc, sound, volume, pitch);
+            }
+        }
+    }
 
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Earth.SandSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Earth.SandSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
+    @Override
+    public Class<? extends Ability> getParentAbility() {
+        return EarthAbility.class;
+    }
 
-	@Override
-	public Class<? extends Ability> getParentAbility() {
-		return EarthAbility.class;
-	}
-
-	@Override
-	public Element getElement() {
-		return Element.SAND;
-	}
+    @Override
+    public Element getElement() {
+        return Element.SAND;
+    }
 
 }

--- a/src/com/projectkorra/projectkorra/ability/SandAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/SandAbility.java
@@ -1,5 +1,10 @@
 package com.projectkorra.projectkorra.ability;
 
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.util.ParticleEffect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.Element;
@@ -8,6 +13,48 @@ public abstract class SandAbility extends EarthAbility implements SubAbility {
 
 	public SandAbility(final Player player) {
 		super(player);
+	}
+
+	/**
+	 * Plays an integer amount of sand particles in a location with a given
+	 * xOffset, yOffset, zOffset, speed and color.
+	 *
+	 * @param ability The ability this particle is spawned for
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 * @param xOffset The xOffset to use
+	 * @param yOffset The yOffset to use
+	 * @param zOffset The zOffset to use
+	 * @param speed The particle animation speed
+	 * @param red Use red sand for the particle
+	 */
+	public static void displaySandParticle(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset, final double speed, final boolean red) {
+		if (amount <= 0) {
+			return;
+		}
+
+		final Material sand = red ? Material.RED_SAND : Material.SAND;
+		final Material stone = red ? Material.RED_SANDSTONE : Material.SANDSTONE;
+
+		ParticleEffect.BLOCK_CRACK.display(loc, amount, xOffset, yOffset, zOffset, speed, sand.createBlockData());
+		ParticleEffect.BLOCK_CRACK.display(loc, amount, xOffset, yOffset, zOffset, speed, stone.createBlockData());
+	}
+
+	public static void playSandbendingSound(final Location loc) {
+		if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
+			final float volume = (float) getConfig().getDouble("Properties.Earth.SandSound.Volume");
+			final float pitch = (float) getConfig().getDouble("Properties.Earth.SandSound.Pitch");
+
+			Sound sound = Sound.BLOCK_SAND_BREAK;
+
+			try {
+				sound = Sound.valueOf(getConfig().getString("Properties.Earth.SandSound.Sound"));
+			} catch (final IllegalArgumentException exception) {
+				ProjectKorra.log.warning("Your current value for 'Properties.Earth.SandSound.Sound' is not valid.");
+			} finally {
+				loc.getWorld().playSound(loc, sound, volume, pitch);
+			}
+		}
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -293,47 +293,18 @@ public abstract class WaterAbility extends ElementalAbility {
 		return true;
 	}
 
-	public static Functional.Particle waterEffect = args -> {
-		Block block = (Block) args[0];
-		ParticleEffect.SMOKE_NORMAL.display(block.getLocation().add(0.5, 0.5, 0.5), 4);
+	public static Functional.Particle focusEffect = (ability, location, amount, xOffset, yOffset, zOffset, extra, data) -> {
+		ParticleEffect.SMOKE_NORMAL.display(location, amount);
 	};
 
-	public static void playFocusWaterEffect(final Block block) {
-		waterEffect.play(block);
-	}
-
-	public static void playIcebendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Water.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Water.IceSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Water.IceSound.Pitch");
-
-			Sound sound = Sound.ITEM_FLINTANDSTEEL_USE;
-
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Water.IceSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Water.IceSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
-	}
-
-	public static void playPlantbendingSound(final Location loc) {
-		if (getConfig().getBoolean("Properties.Water.PlaySound")) {
-			final float volume = (float) getConfig().getDouble("Properties.Water.PlantSound.Volume");
-			final float pitch = (float) getConfig().getDouble("Properties.Water.PlantSound.Pitch");
-
-			Sound sound = Sound.BLOCK_GRASS_STEP;
-
-			try {
-				sound = Sound.valueOf(getConfig().getString("Properties.Water.PlantSound.Sound"));
-			} catch (final IllegalArgumentException exception) {
-				ProjectKorra.log.warning("Your current value for 'Properties.Water.PlantSound.Sound' is not valid.");
-			} finally {
-				loc.getWorld().playSound(loc, sound, volume, pitch);
-			}
-		}
+	/**
+	 * Plays the focus water effect on a block.
+	 *
+	 * @param ability The ability this effect is spawned for
+	 * @param block The block to play it on
+	 */
+	public static void playFocusWaterEffect(final CoreAbility ability, final Block block) {
+		focusEffect.play(ability, block.getLocation().add(.5,.5,.5),4,0,0,0,0, null);
 	}
 
 	public static void playWaterbendingSound(final Location loc) {
@@ -423,5 +394,31 @@ public abstract class WaterAbility extends ElementalAbility {
 		SurgeWall.removeAllCleanup();
 		SurgeWave.removeAllCleanup();
 		WaterArms.removeAllCleanup();
+	}
+
+	/**
+	 * @deprecated <b> Use {@link IceAbility#playIcebendingSound(Location)} instead.
+	 */
+	@Deprecated
+	public static void playIcebendingSound(final Location loc) {
+		IceAbility.playIcebendingSound(loc);
+	}
+
+	/**
+	 * @deprecated <b> Use {@link PlantAbility#playPlantbendingSound(Location)} instead.
+	 */
+	@Deprecated
+	public static void playPlantbendingSound(final Location loc) {
+		PlantAbility.playPlantbendingSound(loc);
+	}
+
+	/**
+	 * Plays the focus water effect on a block.
+	 * @deprecated <b>Use {@link WaterAbility#playFocusWaterEffect(CoreAbility, Block)} instead.
+	 * @param block The block to play it on
+	 */
+	@Deprecated
+	public static void playFocusWaterEffect(final Block block) {
+		playFocusWaterEffect(null, block);
 	}
 }

--- a/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.ability;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.projectkorra.projectkorra.ability.functional.Functional;
 import com.projectkorra.projectkorra.region.RegionProtection;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -292,8 +293,13 @@ public abstract class WaterAbility extends ElementalAbility {
 		return true;
 	}
 
-	public static void playFocusWaterEffect(final Block block) {
+	public static Functional.Particle waterEffect = args -> {
+		Block block = (Block) args[0];
 		ParticleEffect.SMOKE_NORMAL.display(block.getLocation().add(0.5, 0.5, 0.5), 4);
+	};
+
+	public static void playFocusWaterEffect(final Block block) {
+		waterEffect.play(block);
 	}
 
 	public static void playIcebendingSound(final Location loc) {

--- a/src/com/projectkorra/projectkorra/ability/functional/Functional.java
+++ b/src/com/projectkorra/projectkorra/ability/functional/Functional.java
@@ -1,0 +1,13 @@
+package com.projectkorra.projectkorra.ability.functional;
+
+public class Functional {
+    @FunctionalInterface
+    public interface Particle {
+        void play(Object... args);
+    }
+
+    /*@FunctionalInterface
+    public interface Sound {
+        void play(Object... args);
+    }*/
+}

--- a/src/com/projectkorra/projectkorra/ability/functional/Functional.java
+++ b/src/com/projectkorra/projectkorra/ability/functional/Functional.java
@@ -1,13 +1,17 @@
 package com.projectkorra.projectkorra.ability.functional;
 
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import org.bukkit.Location;
+
 public class Functional {
     @FunctionalInterface
-    public interface Particle {
-        void play(Object... args);
+    public interface Particle{
+        void play(
+                CoreAbility ability,
+                Location location,
+                int amount,
+                double xOffset, double yOffset, double zOffset,
+                double extra,
+                Object data);
     }
-
-    /*@FunctionalInterface
-    public interface Sound {
-        void play(Object... args);
-    }*/
 }

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -204,7 +204,7 @@ public class AirBlast extends AirAbility {
 
 	private void advanceLocation() {
 		if (this.showParticles) {
-			playAirbendingParticles(this.location, this.particles, 0.275F, 0.275F, 0.275F);
+			playAirbendingParticles(this, this.location, this.particles, 0.275F, 0.275F, 0.275F);
 		}
 		if (this.random.nextInt(4) == 0) {
 			playAirbendingSound(this.location);

--- a/src/com/projectkorra/projectkorra/airbending/AirBurst.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBurst.java
@@ -100,7 +100,7 @@ public class AirBurst extends AirAbility {
 			}
 		} else if (this.isCharged) {
 			final Location location = this.player.getEyeLocation();
-			playAirbendingParticles(location, this.sneakParticles);
+			playAirbendingParticles(this, location, this.sneakParticles);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -238,7 +238,7 @@ public class AirScooter extends AirAbility {
 			final double y = r * Math.cos(this.phi);
 			final double z = r * Math.sin(theta) * Math.sin(this.phi);
 			origin.add(x, y, z);
-			playAirbendingParticles(origin, 1, 0F, 0F, 0F);
+			playAirbendingParticles(this, origin, 1, 0F, 0F, 0F);
 			origin.subtract(x, y, z);
 		}
 		for (double theta = 0; theta <= 2 * Math.PI; theta += Math.PI / 10) {
@@ -247,7 +247,7 @@ public class AirScooter extends AirAbility {
 			final double y = r * Math.cos(this.phi);
 			final double z = r * Math.sin(theta) * Math.sin(this.phi);
 			origin2.subtract(x, y, z);
-			playAirbendingParticles(origin2, 1, 0F, 0F, 0F);
+			playAirbendingParticles(this, origin2, 1, 0F, 0F, 0F);
 			origin2.add(x, y, z);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -189,7 +189,7 @@ public class AirShield extends AirAbility {
 
 			final Location effect = new Location(origin.getWorld(), x, y, z);
 			if (!GeneralMethods.isRegionProtectedFromBuild(this, effect)) {
-				playAirbendingParticles(effect, this.particles);
+				playAirbendingParticles(this, effect, this.particles);
 				if (this.random.nextInt(4) == 0) {
 					playAirbendingSound(effect);
 				}

--- a/src/com/projectkorra/projectkorra/airbending/AirSpout.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSpout.java
@@ -197,7 +197,7 @@ public class AirSpout extends AirAbility {
 			for (int i = 1; i <= dy; i++) {
 				index = index >= DIRECTIONS.length ? 0 : index + 1;
 				final Location effectloc2 = new Location(location.getWorld(), location.getX(), block.getY() + i, location.getZ());
-				playAirbendingParticles(effectloc2, 3, 0.4F, 0.4F, 0.4F);
+				playAirbendingParticles(this, effectloc2, 3, 0.4F, 0.4F, 0.4F);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/AirSuction.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSuction.java
@@ -100,7 +100,7 @@ public class AirSuction extends AirAbility {
 	}
 
 	private void advanceLocation() {
-		playAirbendingParticles(this.location, this.particleCount, 0.275F, 0.275F, 0.275F);
+		playAirbendingParticles(this, this.location, this.particleCount, 0.275F, 0.275F, 0.275F);
 		if (this.random.nextInt(4) == 0) {
 			playAirbendingSound(this.location);
 		}
@@ -259,7 +259,7 @@ public class AirSuction extends AirAbility {
 				return;
 			}
 
-			playAirbendingParticles(this.origin, 5, 0.5, 0.5, 0.5);
+			playAirbendingParticles(this, this.origin, 5, 0.5, 0.5, 0.5);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -162,7 +162,7 @@ public class AirSwipe extends AirAbility {
 
 				location = location.clone().add(direction.clone().multiply(this.speed));
 				this.streams.put(direction, location);
-				playAirbendingParticles(location, this.particles, 0.2F, 0.2F, 0);
+				playAirbendingParticles(this, location, this.particles, 0.2F, 0.2F, 0);
 				if (this.random.nextInt(4) == 0) {
 					playAirbendingSound(location);
 				}
@@ -314,7 +314,7 @@ public class AirSwipe extends AirAbility {
 				this.damage *= factor;
 				this.pushFactor *= factor;
 			} else if (System.currentTimeMillis() >= this.getStartTime() + this.maxChargeTime) {
-				playAirbendingParticles(this.player.getEyeLocation(), this.particles);
+				playAirbendingParticles(this, this.player.getEyeLocation(), this.particles);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/Tornado.java
+++ b/src/com/projectkorra/projectkorra/airbending/Tornado.java
@@ -190,7 +190,7 @@ public class Tornado extends AirAbility {
 
 				final Location effect = new Location(this.origin.getWorld(), x, y, z);
 				if (!GeneralMethods.isRegionProtectedFromBuild(this, effect)) {
-					playAirbendingParticles(effect, this.particleCount);
+					playAirbendingParticles(this, effect, this.particleCount);
 					if (this.random.nextInt(20) == 0) {
 						playAirbendingSound(effect);
 					}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
@@ -144,7 +144,7 @@ public class AirStream extends AirAbility implements ComboAbility {
 				public void run() {
 					for (int angle = -180; angle <= 180; angle += 45) {
 						final Vector orthog = GeneralMethods.getOrthogonalVector(this.dir.clone(), angle, 0.5);
-						playAirbendingParticles(this.loc.clone().add(orthog), 1, 0F, 0F, 0F);
+						playAirbendingParticles(AirStream.this, this.loc.clone().add(orthog), 1, 0F, 0F, 0F);
 					}
 				}
 			};

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -155,8 +155,9 @@ public class AirSweep extends AirAbility implements ComboAbility {
 				final FireComboStream fs = new FireComboStream(this.player, this, vec, hand, this.range, this.speed);
 				fs.setDensity(1);
 				fs.setSpread(0F);
-				fs.setUseNewParticles(true);
-				fs.setParticleEffect(getAirbendingParticles());
+				//fs.setUseNewParticles(true);
+				//fs.setParticleEffect(getAirbendingParticles());
+				fs.particleFunction = AirAbility.airParticles;
 				fs.setCollides(false);
 				fs.runTaskTimer(ProjectKorra.plugin, (long) (i / 2.5), 1L);
 				this.tasks.add(fs);

--- a/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
@@ -130,7 +130,7 @@ public class Twister extends AirAbility implements ComboAbility {
 				final Vector animDir = GeneralMethods.rotateXZ(new Vector(1, 0, 1), i);
 				final Location animLoc = this.currentLoc.clone().add(animDir.multiply(animRadius));
 				animLoc.add(0, y, 0);
-				playAirbendingParticles(animLoc, 1, 0, 0, 0);
+				playAirbendingParticles(this, animLoc, 1, 0, 0, 0);
 			}
 		}
 		playAirbendingSound(this.currentLoc);

--- a/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -9,7 +9,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.BlastFurnace;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.Campfire;
 import org.bukkit.block.Furnace;
 import org.bukkit.block.Smoker;
@@ -23,7 +22,6 @@ import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.ability.AirAbility;
-import com.projectkorra.projectkorra.ability.BlueFireAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -129,7 +127,7 @@ public class FireBlast extends FireAbility {
 		}
 
 		if (this.showParticles) {
-			playFirebendingParticles(this.location, 6, this.flameRadius, this.flameRadius, this.flameRadius);
+			playFirebendingParticles(this, this.location, 6, this.flameRadius, this.flameRadius, this.flameRadius);
 		}
 
 		BlockIterator blocks = new BlockIterator(this.getLocation().getWorld(), this.location.toVector(), this.direction, 0, (int) Math.ceil(this.direction.clone().multiply(speedFactor).length()));

--- a/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -247,7 +247,7 @@ public class FireBlastCharged extends FireAbility {
 
 	private void executeFireball() {
 		for (final Block block : GeneralMethods.getBlocksAroundPoint(this.location, this.collisionRadius)) {
-			playFirebendingParticles(block.getLocation(), 5, 0.5, 0.5, 0.5);
+			playFirebendingParticles(this, block.getLocation(), 5, 0.5, 0.5, 0.5);
 			if ((new Random()).nextInt(4) == 0) {
 				playFirebendingSound(this.location);
 			}
@@ -314,7 +314,7 @@ public class FireBlastCharged extends FireAbility {
 			if (!this.launched && !this.charged) {
 				return;
 			} else if (!this.launched) {
-				playFirebendingParticles(this.player.getEyeLocation().clone().add(this.player.getEyeLocation().getDirection().clone()), 3, .001, .001, .001);
+				playFirebendingParticles(this, this.player.getEyeLocation().clone().add(this.player.getEyeLocation().getDirection().clone()), 3, .001, .001, .001);
 				return;
 			}
 

--- a/src/com/projectkorra/projectkorra/firebending/FireBurst.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireBurst.java
@@ -147,7 +147,7 @@ public class FireBurst extends FireAbility {
 		} else if (this.charged) {
 			final Location location = this.player.getEyeLocation();
 			location.add(location.getDirection());
-			playFirebendingParticles(location, 1, .01, .01, .01);
+			playFirebendingParticles(this, location, 1, .01, .01, .01);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/FireJet.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireJet.java
@@ -93,7 +93,7 @@ public class FireJet extends FireAbility {
 				playFirebendingSound(this.player.getLocation());
 			}
 
-			playFirebendingParticles(this.player.getLocation(), 10, 0.3, 0.3, 0.3);
+			playFirebendingParticles(this, this.player.getLocation(), 10, 0.3, 0.3, 0.3);
 			double timefactor;
 
 			if (this.bPlayer.isAvatarState() && this.avatarStateToggled) {

--- a/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
@@ -112,7 +112,7 @@ public class FireManipulation extends FireAbility {
 					this.points.remove(point);
 					return;
 				}
-				playFirebendingParticles(point, 12, 0.25, 0.25, 0.25);
+				playFirebendingParticles(this, point, 12, 0.25, 0.25, 0.25);
 				for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(point, 1.2D)) {
 					if (entity instanceof LivingEntity && entity.getUniqueId() != this.player.getUniqueId()) {
 						DamageHandler.damageEntity(entity, this.shieldDamage, this);
@@ -142,7 +142,7 @@ public class FireManipulation extends FireAbility {
 			for (final Location point : this.points.keySet()) {
 				final Vector direction = this.focalPoint.toVector().subtract(point.toVector());
 				point.add(direction.clone().multiply(this.streamSpeed / 5));
-				playFirebendingParticles(point, this.shieldParticles, 0.25, 0.25, 0.25);
+				playFirebendingParticles(this, point, this.shieldParticles, 0.25, 0.25, 0.25);
 			}
 		} else {
 			Vector direction = this.player.getLocation().getDirection().clone();
@@ -171,7 +171,7 @@ public class FireManipulation extends FireAbility {
 				return;
 			}
 
-			playFirebendingParticles(this.shotPoint, this.streamParticles, 0.5, 0.5, 0.5);
+			playFirebendingParticles(this, this.shotPoint, this.streamParticles, 0.5, 0.5, 0.5);
 			for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.shotPoint, 2)) {
 				if (entity instanceof LivingEntity && entity.getUniqueId() != this.player.getUniqueId()) {
 					DamageHandler.damageEntity(entity, this.streamDamage, this);

--- a/src/com/projectkorra/projectkorra/firebending/FireShield.java
+++ b/src/com/projectkorra/projectkorra/firebending/FireShield.java
@@ -122,7 +122,7 @@ public class FireShield extends FireAbility {
 
 					final Location display = this.location.clone().add(this.shieldRadius / 1.5 * Math.cos(rphi) * Math.sin(rtheta), this.shieldRadius / 1.5 * Math.cos(rtheta), this.shieldRadius / 1.5 * Math.sin(rphi) * Math.sin(rtheta));
 					if (this.random.nextInt(4) == 0) {
-						playFirebendingParticles(display, 1, 0.1, 0.1, 0.1);
+						playFirebendingParticles(this, display, 1, 0.1, 0.1, 0.1);
 					}
 					if (this.random.nextInt(7) == 0) {
 						playFirebendingSound(display);
@@ -151,12 +151,12 @@ public class FireShield extends FireAbility {
 			this.location = this.player.getEyeLocation().clone();
 			final Vector direction = this.location.getDirection();
 			this.location.add(direction.multiply(this.shieldRadius));
-			playFirebendingParticles(this.location, 3, 0.2, 0.2, 0.2);
+			playFirebendingParticles(this, this.location, 3, 0.2, 0.2, 0.2);
 
 			for (double theta = 0; theta < 360; theta += 20) {
 				final Vector vector = GeneralMethods.getOrthogonalVector(direction, theta, this.discRadius / 1.5);
 				final Location display = this.location.add(vector);
-				playFirebendingParticles(display, 2, 0.3, 0.2, 0.3);
+				playFirebendingParticles(this, display, 2, 0.3, 0.2, 0.3);
 				if (this.random.nextInt(4) == 0) {
 					playFirebendingSound(display);
 				}

--- a/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -288,7 +288,7 @@ public class HeatControl extends FireAbility {
 	}
 
 	public void displayCookParticles() {
-		playFirebendingParticles(this.player.getLocation().clone().add(0, 1, 0), 3, 0.5, 0.5, 0.5);
+		playFirebendingParticles(this, this.player.getLocation().clone().add(0, 1, 0), 3, 0.5, 0.5, 0.5);
 		ParticleEffect.SMOKE_NORMAL.display(this.player.getLocation().clone().add(0, 1, 0), 2, 0.5, 0.5, 0.5);
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -161,7 +161,7 @@ public class WallOfFire extends FireAbility {
 			if (!this.isTransparent(block)) {
 				continue;
 			}
-			playFirebendingParticles(block.getLocation(), 3, 0.6, 0.6, 0.6);
+			playFirebendingParticles(this, block.getLocation(), 3, 0.6, 0.6, 0.6);
 			if (this.random.nextInt(7) == 0) {
 				playFirebendingSound(block.getLocation());
 			}

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -1,5 +1,7 @@
 package com.projectkorra.projectkorra.firebending.combo;
 
+import com.projectkorra.projectkorra.ability.FireAbility;
+import com.projectkorra.projectkorra.ability.functional.Functional;
 import com.projectkorra.projectkorra.region.RegionProtection;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -31,220 +33,222 @@ import com.projectkorra.projectkorra.util.ParticleEffect;
  * they can use this ability instead.
  */
 public class FireComboStream extends BukkitRunnable {
-	private boolean useNewParticles;
-	private boolean cancelled;
-	private boolean collides;
-	private boolean singlePoint;
-	private int density;
-	private int checkCollisionDelay;
-	private int checkCollisionCounter;
-	private float spread;
-	private double collisionRadius;
-	private final double speed;
-	private final double distance;
-	private double damage;
-	private double fireTicks;
-	private double knockback;
-	ParticleEffect particleEffect;
-	private final Player player;
-	private final BendingPlayer bPlayer;
-	private final CoreAbility coreAbility;
-	private final Vector direction;
-	private final Location initialLocation;
-	private final Location location;
+    public Functional.Particle particleFunction;
+    private boolean useNewParticles;
+    private boolean cancelled;
+    private boolean collides;
+    private boolean singlePoint;
+    private int density;
+    private int checkCollisionDelay;
+    private int checkCollisionCounter;
+    private float spread;
+    private double collisionRadius;
+    private final double speed;
+    private final double distance;
+    private double damage;
+    private double fireTicks;
+    private double knockback;
+    private ParticleEffect particleEffect;
+    private final Player player;
+    private final BendingPlayer bPlayer;
+    private final CoreAbility coreAbility;
+    private final Vector direction;
+    private final Location initialLocation;
+    private final Location location;
 
-	public FireComboStream(final Player player, final CoreAbility coreAbility, final Vector direction, final Location location, final double distance, final double speed) {
-		this.useNewParticles = false;
-		this.cancelled = false;
-		this.collides = true;
-		this.singlePoint = false;
-		this.density = 1;
-		this.checkCollisionDelay = 1;
-		this.checkCollisionCounter = 0;
-		this.spread = 0;
-		this.collisionRadius = 2;
-		this.player = player;
-		this.bPlayer = BendingPlayer.getBendingPlayer(player);
-		this.particleEffect = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? ParticleEffect.SOUL_FIRE_FLAME : ParticleEffect.FLAME;
-		this.coreAbility = coreAbility;
-		this.direction = direction;
-		this.speed = speed;
-		this.initialLocation = location.clone();
-		this.location = location.clone();
-		this.distance = distance;
-	}
+    public FireComboStream(final Player player, final CoreAbility coreAbility, final Vector direction, final Location location, final double distance, final double speed) {
+        this.useNewParticles = false;
+        this.cancelled = false;
+        this.collides = true;
+        this.singlePoint = false;
+        this.density = 1;
+        this.checkCollisionDelay = 1;
+        this.checkCollisionCounter = 0;
+        this.spread = 0;
+        this.collisionRadius = 2;
+        this.player = player;
+        this.bPlayer = BendingPlayer.getBendingPlayer(player);
+        this.particleFunction = FireAbility.fireParticles;
+        this.particleEffect = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? ParticleEffect.SOUL_FIRE_FLAME : ParticleEffect.FLAME;
+        this.coreAbility = coreAbility;
+        this.direction = direction;
+        this.speed = speed;
+        this.initialLocation = location.clone();
+        this.location = location.clone();
+        this.distance = distance;
+    }
 
-	@Override
-	public void run() {
-		final Block block = this.location.getBlock();
+    @Override
+    public void run() {
+        final Block block = this.location.getBlock();
 
-		if (RegionProtection.isRegionProtected(this.player, this.location, coreAbility)) {
-			this.remove();
-			return;
-		}
+        if (RegionProtection.isRegionProtected(this.player, this.location, coreAbility)) {
+            this.remove();
+            return;
+        }
 
-		if (!ElementalAbility.isAir(block.getRelative(BlockFace.UP).getType()) && !ElementalAbility.isPlant(block)) {
-			this.remove();
-			return;
-		}
-		for (int i = 0; i < this.density; i++) {
-			if (this.useNewParticles) {
-				this.particleEffect.display(this.location, 1, this.spread, this.spread, this.spread);
-			} else {
-				this.location.getWorld().playEffect(this.location, Effect.MOBSPAWNER_FLAMES, 0, 15);
-			}
-		}
+        if (!ElementalAbility.isAir(block.getRelative(BlockFace.UP).getType()) && !ElementalAbility.isPlant(block)) {
+            this.remove();
+            return;
+        }
+        for (int i = 0; i < this.density; i++) {
+            if (this.useNewParticles) {
+                this.particleEffect.display(this.location, 1, this.spread, this.spread, this.spread);
+            } else {
+                particleFunction.play(coreAbility, this.location, 1, this.spread, this.spread, this.spread, 0, null);
+            }
+        }
 
-		if (GeneralMethods.checkDiagonalWall(this.location, this.direction)) {
-			this.remove();
-			return;
-		}
+        if (GeneralMethods.checkDiagonalWall(this.location, this.direction)) {
+            this.remove();
+            return;
+        }
 
-		this.location.add(this.direction.normalize().multiply(this.speed));
-		
-		try {
-			this.location.checkFinite();
-		} catch (IllegalArgumentException e) {
-			this.remove();
-			return;
-		}
-		
-		if (this.initialLocation.distanceSquared(this.location) > this.distance * this.distance || !Double.isFinite(this.collisionRadius)) {
-			this.remove();
-			return;
-		} else if (this.collides && this.checkCollisionCounter % this.checkCollisionDelay == 0) {
-			for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, this.collisionRadius)) {
-				if (entity instanceof LivingEntity && !entity.equals(this.coreAbility.getPlayer()) && !entity.isDead()) {
-					this.collision((LivingEntity) entity, this.direction, this.coreAbility);
-				}
-			}
-		}
+        this.location.add(this.direction.normalize().multiply(this.speed));
 
-		this.checkCollisionCounter++;
-		if (this.singlePoint) {
-			this.remove();
-		}
-	}
+        try {
+            this.location.checkFinite();
+        } catch (IllegalArgumentException e) {
+            this.remove();
+            return;
+        }
 
-	public void collision(final LivingEntity entity, final Vector direction, final CoreAbility coreAbility) {
-		entity.getLocation().getWorld().playSound(entity.getLocation(), Sound.ENTITY_VILLAGER_HURT, 0.3f, 0.3f);
+        if (this.initialLocation.distanceSquared(this.location) > this.distance * this.distance || !Double.isFinite(this.collisionRadius)) {
+            this.remove();
+            return;
+        } else if (this.collides && this.checkCollisionCounter % this.checkCollisionDelay == 0) {
+            for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, this.collisionRadius)) {
+                if (entity instanceof LivingEntity && !entity.equals(this.coreAbility.getPlayer()) && !entity.isDead()) {
+                    this.collision((LivingEntity) entity, this.direction, this.coreAbility);
+                }
+            }
+        }
 
-		if (coreAbility.getName().equalsIgnoreCase("FireKick")) {
-			final FireKick fireKick = CoreAbility.getAbility(this.player, FireKick.class);
+        this.checkCollisionCounter++;
+        if (this.singlePoint) {
+            this.remove();
+        }
+    }
 
-			if (!fireKick.getAffectedEntities().contains(entity)) {
-				fireKick.getAffectedEntities().add(entity);
-				DamageHandler.damageEntity(entity, this.damage, coreAbility);
-			}
-		} else if (coreAbility.getName().equalsIgnoreCase("FireSpin")) {
-			final FireSpin fireSpin = CoreAbility.getAbility(this.player, FireSpin.class);
+    public void collision(final LivingEntity entity, final Vector direction, final CoreAbility coreAbility) {
+        entity.getLocation().getWorld().playSound(entity.getLocation(), Sound.ENTITY_VILLAGER_HURT, 0.3f, 0.3f);
 
-			if (entity instanceof Player) {
-				if (Commands.invincible.contains(((Player) entity).getName())) {
-					return;
-				}
-			}
-			if (!fireSpin.getAffectedEntities().contains(entity)) {
-				fireSpin.getAffectedEntities().add(entity);
-				final double newKnockback = this.bPlayer.isAvatarState() ? this.knockback + 0.5 : this.knockback;
-				DamageHandler.damageEntity(entity, this.damage, coreAbility);
-				GeneralMethods.setVelocity(coreAbility, entity, direction.normalize().multiply(newKnockback));
-			}
-		} else if (coreAbility.getName().equalsIgnoreCase("JetBlaze")) {
-			final JetBlaze jetBlaze = CoreAbility.getAbility(this.player, JetBlaze.class);
+        if (coreAbility.getName().equalsIgnoreCase("FireKick")) {
+            final FireKick fireKick = CoreAbility.getAbility(this.player, FireKick.class);
 
-			if (!jetBlaze.getAffectedEntities().contains(entity)) {
-				jetBlaze.getAffectedEntities().add(entity);
-				DamageHandler.damageEntity(entity, this.damage, coreAbility);
-				entity.setFireTicks((int) (this.fireTicks * 20));
-				new FireDamageTimer(entity, this.player, coreAbility);
-			}
-		} else if (coreAbility.getName().equalsIgnoreCase("FireWheel")) {
-			final FireWheel fireWheel = CoreAbility.getAbility(this.player, FireWheel.class);
+            if (!fireKick.getAffectedEntities().contains(entity)) {
+                fireKick.getAffectedEntities().add(entity);
+                DamageHandler.damageEntity(entity, this.damage, coreAbility);
+            }
+        } else if (coreAbility.getName().equalsIgnoreCase("FireSpin")) {
+            final FireSpin fireSpin = CoreAbility.getAbility(this.player, FireSpin.class);
 
-			if (!fireWheel.getAffectedEntities().contains(entity)) {
-				fireWheel.getAffectedEntities().add(entity);
-				DamageHandler.damageEntity(entity, this.damage, coreAbility);
-				entity.setFireTicks((int) (this.fireTicks * 20));
-				new FireDamageTimer(entity, this.player, coreAbility);
-				this.remove();
-			}
-		}
-	}
+            if (entity instanceof Player) {
+                if (Commands.invincible.contains(((Player) entity).getName())) {
+                    return;
+                }
+            }
+            if (!fireSpin.getAffectedEntities().contains(entity)) {
+                fireSpin.getAffectedEntities().add(entity);
+                final double newKnockback = this.bPlayer.isAvatarState() ? this.knockback + 0.5 : this.knockback;
+                DamageHandler.damageEntity(entity, this.damage, coreAbility);
+                GeneralMethods.setVelocity(coreAbility, entity, direction.normalize().multiply(newKnockback));
+            }
+        } else if (coreAbility.getName().equalsIgnoreCase("JetBlaze")) {
+            final JetBlaze jetBlaze = CoreAbility.getAbility(this.player, JetBlaze.class);
 
-	@Override
-	public void cancel() {
-		this.remove();
-	}
+            if (!jetBlaze.getAffectedEntities().contains(entity)) {
+                jetBlaze.getAffectedEntities().add(entity);
+                DamageHandler.damageEntity(entity, this.damage, coreAbility);
+                entity.setFireTicks((int) (this.fireTicks * 20));
+                new FireDamageTimer(entity, this.player, coreAbility);
+            }
+        } else if (coreAbility.getName().equalsIgnoreCase("FireWheel")) {
+            final FireWheel fireWheel = CoreAbility.getAbility(this.player, FireWheel.class);
 
-	public Vector getDirection() {
-		return this.direction.clone();
-	}
+            if (!fireWheel.getAffectedEntities().contains(entity)) {
+                fireWheel.getAffectedEntities().add(entity);
+                DamageHandler.damageEntity(entity, this.damage, coreAbility);
+                entity.setFireTicks((int) (this.fireTicks * 20));
+                new FireDamageTimer(entity, this.player, coreAbility);
+                this.remove();
+            }
+        }
+    }
 
-	public Location getLocation() {
-		return this.location;
-	}
+    @Override
+    public void cancel() {
+        this.remove();
+    }
 
-	@Override
-	public boolean isCancelled() {
-		return this.cancelled;
-	}
+    public Vector getDirection() {
+        return this.direction.clone();
+    }
 
-	public void remove() {
-		super.cancel();
-		this.cancelled = true;
-	}
+    public Location getLocation() {
+        return this.location;
+    }
 
-	public CoreAbility getAbility() {
-		return this.coreAbility;
-	}
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
 
-	public void setCheckCollisionDelay(final int delay) {
-		this.checkCollisionDelay = delay;
-	}
+    public void remove() {
+        super.cancel();
+        this.cancelled = true;
+    }
 
-	public void setCollides(final boolean b) {
-		this.collides = b;
-	}
+    public CoreAbility getAbility() {
+        return this.coreAbility;
+    }
 
-	public void setCollisionRadius(final double radius) {
-		this.collisionRadius = radius;
-	}
+    public void setCheckCollisionDelay(final int delay) {
+        this.checkCollisionDelay = delay;
+    }
 
-	public void setDensity(final int density) {
-		this.density = density;
-	}
+    public void setCollides(final boolean b) {
+        this.collides = b;
+    }
 
-	public void setDamage(final double damage) {
-		this.damage = damage;
-	}
+    public void setCollisionRadius(final double radius) {
+        this.collisionRadius = radius;
+    }
 
-	public void setKnockback(final double knockback) {
-		this.knockback = knockback;
-	}
+    public void setDensity(final int density) {
+        this.density = density;
+    }
 
-	public void setFireTicks(final double fireTicks) {
-		this.fireTicks = fireTicks;
-	}
+    public void setDamage(final double damage) {
+        this.damage = damage;
+    }
 
-	public void setParticleEffect(final ParticleEffect effect) {
-		this.particleEffect = effect;
-	}
+    public void setKnockback(final double knockback) {
+        this.knockback = knockback;
+    }
 
-	public void setSinglePoint(final boolean b) {
-		this.singlePoint = b;
-	}
+    public void setFireTicks(final double fireTicks) {
+        this.fireTicks = fireTicks;
+    }
 
-	public void setSpread(final float spread) {
-		this.spread = spread;
-	}
+    public void setParticleEffect(final ParticleEffect effect) {
+        this.particleEffect = effect;
+    }
 
-	public void setUseNewParticles(final boolean b) {
-		this.useNewParticles = b;
-	}
+    public void setSinglePoint(final boolean b) {
+        this.singlePoint = b;
+    }
 
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
-	}
+    public void setSpread(final float spread) {
+        this.spread = spread;
+    }
+
+    public void setUseNewParticles(final boolean b) {
+        this.useNewParticles = b;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
+    }
 }

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireKick.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireKick.java
@@ -106,7 +106,7 @@ public class FireKick extends FireAbility implements ComboAbility {
 				final FireComboStream fs = new FireComboStream(this.player, this, vec, this.player.getLocation(), this.range, this.speed);
 				fs.setSpread(0.2F);
 				fs.setDensity(5);
-				fs.setUseNewParticles(true);
+				//fs.setUseNewParticles(true);
 				fs.setDamage(this.damage);
 				if (this.tasks.size() % 3 != 0) {
 					fs.setCollides(false);

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireSpin.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireSpin.java
@@ -102,7 +102,7 @@ public class FireSpin extends FireAbility implements ComboAbility {
 				final FireComboStream fs = new FireComboStream(this.player, this, vec, this.player.getLocation().clone().add(0, 1, 0), this.range, this.speed);
 				fs.setSpread(0.0F);
 				fs.setDensity(1);
-				fs.setUseNewParticles(true);
+				//fs.setUseNewParticles(true);
 				fs.setDamage(this.damage);
 				fs.setKnockback(this.knockback);
 				if (this.tasks.size() % 10 != 0) {

--- a/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
@@ -21,7 +21,6 @@ import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
-import com.projectkorra.projectkorra.util.ClickType;
 import com.projectkorra.projectkorra.util.DamageHandler;
 
 public class FireWheel extends FireAbility implements ComboAbility {
@@ -135,7 +134,7 @@ public class FireWheel extends FireAbility implements ComboAbility {
 			final Vector newDir = this.direction.clone().multiply(this.radius * Math.cos(Math.toRadians(i)));
 			tempLoc.add(newDir);
 			tempLoc.setY(tempLoc.getY() + (this.radius * Math.sin(Math.toRadians(i))));
-			playFirebendingParticles(tempLoc, 0, 0, 0, 0);
+			playFirebendingParticles(this, tempLoc, 0, 0, 0, 0);
 		}
 
 		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, this.radius + 0.5)) {

--- a/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
@@ -86,7 +86,7 @@ public class JetBlast extends FireAbility implements ComboAbility {
 
 			fs.setDensity(1);
 			fs.setSpread(0.9F);
-			fs.setUseNewParticles(true);
+			//fs.setUseNewParticles(true);
 			fs.setCollides(false);
 			fs.runTaskTimer(ProjectKorra.plugin, 0, 1L);
 			this.tasks.add(fs);

--- a/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
+++ b/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
@@ -96,8 +96,8 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 			fs.setDensity(8);
 			fs.setSpread(1.0F);
 			fs.setUseNewParticles(true);
-			fs.setCollisionRadius(2);
 			fs.setParticleEffect(ParticleEffect.SMOKE_LARGE);
+			fs.setCollisionRadius(2);
 			fs.setDamage(this.damage);
 			fs.setFireTicks(this.fireTicks);
 			fs.runTaskTimer(ProjectKorra.plugin, 0, 1L);

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -204,7 +204,7 @@ public class Lightning extends LightningAbility {
 				if (this.player.isSneaking()) {
 					final Location loc = this.player.getEyeLocation().add(this.player.getEyeLocation().getDirection().normalize().multiply(1.2));
 					loc.add(0, 0.3, 0);
-					playLightningbendingParticle(loc, 0.2F, 0.2F, 0.2F);
+					playLightningbendingParticles(this, loc, 1, 0.2F, 0.2F, 0.2F);
 					if (ThreadLocalRandom.current().nextDouble() < .2) {
 						playLightningbendingChargingSound(loc);
 					}
@@ -238,7 +238,7 @@ public class Lightning extends LightningAbility {
 				final double d8 = localLocation1.getZ() + d4 * Math.sin(d5);
 				final double newY = (localLocation1.getY() + 1.0D + d4 * Math.cos(d6));
 				final Location localLocation2 = new Location(this.player.getWorld(), d7, newY, d8);
-				playLightningbendingParticle(localLocation2);
+				playLightningbendingParticles(this, localLocation2, 1);
 				this.particleRotation += 1.0D / d3;
 				if (ThreadLocalRandom.current().nextDouble() < .2) {
 					playLightningbendingChargingSound(this.player.getLocation());
@@ -502,7 +502,7 @@ public class Lightning extends LightningAbility {
 		 */
 		@Override
 		public void run() {
-			playLightningbendingParticle(this.location, 0F, 0F, 0F);
+			playLightningbendingParticles(Lightning.this, this.location, 1, 0F, 0F, 0F);
 			this.count++;
 			if (this.count > 5) {
 				this.cancel();

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -246,7 +246,7 @@ public class OctopusForm extends WaterAbility {
 			final Location location = this.player.getLocation();
 
 			if (this.sourceSelected) {
-				playFocusWaterEffect(this.sourceBlock);
+				playFocusWaterEffect(this, this.sourceBlock);
 			} else if (this.settingUp) {
 				if (this.sourceBlock.getY() < location.getBlockY()) {
 					this.source.revertBlock();

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.ability.IceAbility;
 import com.projectkorra.projectkorra.region.RegionProtection;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -34,669 +35,669 @@ import com.projectkorra.projectkorra.waterbending.util.WaterReturn;
 
 public class SurgeWall extends WaterAbility {
 
-	private static final Map<Block, Block> AFFECTED_BLOCKS = new ConcurrentHashMap<>();
-	private static final Map<Block, Player> WALL_BLOCKS = new ConcurrentHashMap<>();
-	public static final List<TempBlock> SOURCE_BLOCKS = new ArrayList<>();
-
-	private boolean progressing;
-	private boolean settingUp;
-	private boolean forming;
-	private boolean frozen;
-	private boolean solidifyLava;
-	private long time;
-	private long interval;
-	@Attribute(Attribute.COOLDOWN)
-	private long cooldown;
-	@Attribute(Attribute.DURATION)
-	private long duration;
-	private long obsidianDuration;
-	@Attribute(Attribute.RADIUS)
-	private double radius;
-	@Attribute(Attribute.RANGE)
-	private double range;
-	private Block sourceBlock;
-	private Location location;
-	private Location firstDestination;
-	private Location targetDestination;
-	private ArrayList<Location> locations;
-	private Vector firstDirection;
-	private Vector targetDirection;
-	private Map<Block, Material> oldTemps;
-
-	public SurgeWall(final Player player) {
-		super(player);
-
-		this.interval = getConfig().getLong("Abilities.Water.Surge.Wall.Interval");
-		this.cooldown = applyInverseModifiers(getConfig().getLong("Abilities.Water.Surge.Wall.Cooldown"));
-		this.duration = applyModifiers(getConfig().getLong("Abilities.Water.Surge.Wall.Duration"));
-		this.range = applyModifiers(getConfig().getDouble("Abilities.Water.Surge.Wall.Range"));
-		this.radius = applyModifiers(getConfig().getDouble("Abilities.Water.Surge.Wall.Radius"));
-		this.solidifyLava = getConfig().getBoolean("Abilities.Water.Surge.Wall.SolidifyLava.Enabled");
-		this.obsidianDuration = getConfig().getLong("Abilities.Water.Surge.Wall.SolidifyLava.Duration");
-		this.locations = new ArrayList<>();
-		this.oldTemps = new HashMap<>();
-
-		SurgeWave wave = getAbility(player, SurgeWave.class);
-		if (wave != null && !wave.isProgressing() && !this.bPlayer.isOnCooldown("SurgeWave")) {
-			wave.moveWater();
-			return;
-		}
-
-		if (this.bPlayer.isAvatarState()) {
-			this.radius = getConfig().getDouble("Abilities.Avatar.AvatarState.Water.Surge.Wall.Radius");
-		}
-
-		final SurgeWall wall = getAbility(player, SurgeWall.class);
-		if (wall != null) {
-			if (wall.progressing) {
-				wall.freezeThaw();
-				return;
-			} else if (this.prepare()) {
-				wall.remove();
-				this.start();
-				this.time = System.currentTimeMillis();
-			}
-		} else if (!this.bPlayer.isOnCooldown("SurgeWall") && this.prepare()) {
-			this.start();
-			this.time = System.currentTimeMillis();
-			return;
-		}
-
-		if (this.bPlayer.isOnCooldown("SurgeWave") || player.isSneaking()) {
-			return;
-		} else if (wall == null && WaterReturn.hasWaterBottle(player)) {
-			final Location eyeLoc = player.getEyeLocation();
-			final Block block = eyeLoc.add(eyeLoc.getDirection().normalize()).getBlock();
-
-			if (isTransparent(player, block) && isTransparent(player, eyeLoc.getBlock())) {
-				final TempBlock tempBlock = new TempBlock(block, Material.WATER);
-				SOURCE_BLOCKS.add(tempBlock);
-
-				wave = new SurgeWave(player);
-				wave.setCanHitSelf(false);
-				wave.moveWater();
-
-				if (!wave.isProgressing()) {
-					wave.remove();
-				} else {
-					WaterReturn.emptyWaterBottle(player);
-				}
-
-				SOURCE_BLOCKS.remove(tempBlock);
-				tempBlock.revertBlock();
-			}
-		}
-	}
-
-	private void freezeThaw() {
-		if (!this.bPlayer.canIcebend()) {
-			return;
-		} else if (this.frozen) {
-			this.thaw();
-		} else {
-			this.freeze();
-		}
-	}
-
-	private void freeze() {
-		this.frozen = true;
-		for (final Block block : WALL_BLOCKS.keySet()) {
-			if (WALL_BLOCKS.get(block) == this.player) {
-				new TempBlock(block, Material.ICE);
-				playIcebendingSound(block.getLocation());
-			}
-		}
-	}
-
-	private void thaw() {
-		this.frozen = false;
-		for (final Block block : WALL_BLOCKS.keySet()) {
-			if (WALL_BLOCKS.get(block) == this.player) {
-				new TempBlock(block, Material.WATER);
-			}
-		}
-	}
-
-	public boolean prepare() {
-		this.cancelPrevious();
-		final Block block = BlockSource.getWaterSourceBlock(this.player, this.range, ClickType.LEFT_CLICK, true, true, this.bPlayer.canPlantbend());
-
-		if (block != null && !RegionProtection.isRegionProtected(this, block.getLocation())) {
-			this.sourceBlock = block;
-			this.focusBlock();
-			return true;
-		}
-		return false;
-	}
-
-	private void cancelPrevious() {
-		final SurgeWall oldWave = getAbility(this.player, SurgeWall.class);
-		if (oldWave != null) {
-			if (oldWave.progressing) {
-				oldWave.removeWater(oldWave.sourceBlock);
-			} else {
-				oldWave.remove();
-			}
-		}
-	}
-
-	private void focusBlock() {
-		this.location = this.sourceBlock.getLocation();
-	}
-
-	public void moveWater() {
-		if (this.sourceBlock != null) {
-			this.targetDestination = this.player.getTargetBlock(getTransparentMaterialSet(), (int) this.range).getLocation();
-
-			if (this.targetDestination.distanceSquared(this.location) <= 1) {
-				this.progressing = false;
-				this.targetDestination = null;
-			} else {
-				this.bPlayer.addCooldown("SurgeWall", this.cooldown);
-				this.progressing = true;
-				this.settingUp = true;
-				this.firstDestination = this.getToEyeLevel();
-				this.firstDirection = this.getDirection(this.sourceBlock.getLocation(), this.firstDestination);
-				this.targetDirection = this.getDirection(this.firstDestination, this.targetDestination);
-
-				if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
-					new PlantRegrowth(this.player, this.sourceBlock);
-					this.sourceBlock.setType(Material.AIR, false);
-				}
-				this.addWater(this.sourceBlock);
-			}
-
-		}
-	}
-
-	private Location getToEyeLevel() {
-		final Location loc = this.sourceBlock.getLocation().clone();
-		loc.setY(this.targetDestination.getY());
-		return loc;
-	}
-
-	private Vector getDirection(final Location location, final Location destination) {
-		double x1, y1, z1;
-		double x0, y0, z0;
-
-		x1 = destination.getX();
-		y1 = destination.getY();
-		z1 = destination.getZ();
-
-		x0 = location.getX();
-		y0 = location.getY();
-		z0 = location.getZ();
-
-		return new Vector(x1 - x0, y1 - y0, z1 - z0);
-	}
-
-	@Override
-	public void progress() {
-		if (!this.bPlayer.canBendIgnoreBindsCooldowns(this)) {
-			this.remove();
-			return;
-		} else if (this.duration != 0 && System.currentTimeMillis() > this.getStartTime() + this.duration) {
-			this.bPlayer.addCooldown(this);
-			this.remove();
-			return;
-		} else if (!isWaterbendable(this.sourceBlock) && !this.settingUp && !this.forming && !this.progressing) {
-			remove();
-			return;
-		}
-
-		this.locations.clear();
-
-		if (System.currentTimeMillis() - this.time >= this.interval) {
-			this.time = System.currentTimeMillis();
-			final boolean matchesName = this.bPlayer.getBoundAbilityName().equals(this.getName());
-
-			if (!this.progressing && !matchesName) {
-				this.remove();
-				return;
-			} else if (this.progressing && (!this.player.isSneaking() || !matchesName)) {
-				this.remove();
-				return;
-			} else if (!this.progressing) {
-				ParticleEffect.SMOKE_NORMAL.display(this.sourceBlock.getLocation().add(0.5, 0.5, 0.5), 1);
-				return;
-			}
-
-			if (this.forming) {
-				if ((new Random()).nextInt(7) == 0) {
-					playWaterbendingSound(this.location);
-				}
-
-				final ArrayList<Block> blocks = new ArrayList<Block>();
-				final Location targetLoc = GeneralMethods.getTargetedLocation(this.player, (int) this.range, false, false, Material.WATER, Material.ICE);
-				this.location = targetLoc.clone();
-				final Vector eyeDir = this.player.getEyeLocation().getDirection();
-				Vector vector;
-				Block block;
-				for (double i = 0; i <= this.getNightFactor(this.radius); i += 0.5) {
-					for (double angle = 0; angle < 360; angle += 10) {
-						vector = GeneralMethods.getOrthogonalVector(eyeDir.clone(), angle, i);
-						block = targetLoc.clone().add(vector).getBlock();
-
-						if (RegionProtection.isRegionProtected(this, block.getLocation())) {
-							continue;
-						} else if (WALL_BLOCKS.containsKey(block)) {
-							blocks.add(block);
-						} else if (!blocks.contains(block) && (ElementalAbility.isAir(block.getType()) || FireAbility.isFire(block.getType()) || this.isWaterbendable(block)) && this.isTransparent(block)) {
-							WALL_BLOCKS.put(block, this.player);
-							this.addWallBlock(block);
-							blocks.add(block);
-							this.locations.add(block.getLocation());
-							FireBlast.removeFireBlastsAroundPoint(block.getLocation(), 2);
-						}
-					}
-				}
-
-				for (final Block blocki : WALL_BLOCKS.keySet()) {
-					if (WALL_BLOCKS.get(blocki) == this.player && !blocks.contains(blocki)) {
-						this.finalRemoveWater(blocki);
-					}
-
-					if (solidifyLava) {
-						for (BlockFace relative : BlockFace.values()) {
-							Block blockRelative = blocki.getRelative(relative);
-							if (blockRelative.getType() == Material.LAVA) {
-								Levelled levelled = (Levelled)blockRelative.getBlockData();
-								TempBlock tempBlock;
-
-								if (levelled.getLevel() == 0)
-									tempBlock = new TempBlock(blockRelative, Material.OBSIDIAN);
-								else
-									tempBlock = new TempBlock(blockRelative, Material.COBBLESTONE);
-
-								tempBlock.setRevertTime(obsidianDuration);
-								tempBlock.getBlock().getWorld().playSound(tempBlock.getLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 0.2F, 1);
-							}
-						}
-					}
-				}
-
-				return;
-			}
-
-			if (this.sourceBlock.getLocation().distanceSquared(this.firstDestination) < 0.5 * 0.5 && this.settingUp) {
-				this.settingUp = false;
-			}
-
-			Vector direction;
-			if (this.settingUp) {
-				direction = this.firstDirection;
-			} else {
-				direction = this.targetDirection;
-			}
-
-			this.location = this.location.clone().add(direction);
-
-			Block block = this.location.getBlock();
-			if (block.getLocation().equals(this.sourceBlock.getLocation())) {
-				this.location = this.location.clone().add(direction);
-				block = this.location.getBlock();
-			}
-
-			if (!ElementalAbility.isAir(block.getType())) {
-				this.remove();
-				return;
-			} else if (!this.progressing) {
-				this.remove();
-				return;
-			}
-
-			this.addWater(block);
-			this.removeWater(this.sourceBlock);
-			this.sourceBlock = block;
-
-			if (this.location.distanceSquared(this.targetDestination) < 1) {
-				this.removeWater(this.sourceBlock);
-				this.forming = true;
-			}
-		}
-	}
-
-	private void addWallBlock(final Block block) {
-		if (TempBlock.isTempBlock(block)) {
-			this.oldTemps.put(block, block.getType());
-		}
-
-		if (this.frozen) {
-			new TempBlock(block, Material.ICE);
-		} else {
-			new TempBlock(block, Material.WATER);
-		}
-	}
-
-	@Override
-	public void remove() {
-		super.remove();
-		this.returnWater();
-		this.finalRemoveWater(this.sourceBlock);
-
-		for (final Block block : WALL_BLOCKS.keySet()) {
-			if (WALL_BLOCKS.get(block) == this.player) {
-				this.finalRemoveWater(block);
-			}
-		}
-
-	}
-
-	private void removeWater(final Block block) {
-		if (block != null) {
-			if (AFFECTED_BLOCKS.containsKey(block)) {
-				if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block)) {
-					if (this.oldTemps.containsKey(block)) {
-						final TempBlock tb = TempBlock.get(block);
-						if (tb != null) {
-							tb.setType(this.oldTemps.get(block));
-						}
-					} else {
-						TempBlock.revertBlock(block, Material.AIR);
-					}
-				}
-				AFFECTED_BLOCKS.remove(block);
-			}
-		}
-	}
-
-	private void finalRemoveWater(final Block block) {
-		if (block != null) {
-			if (AFFECTED_BLOCKS.containsKey(block)) {
-				if (this.oldTemps.containsKey(block)) {
-					final TempBlock tb = TempBlock.get(block);
-					if (tb != null) {
-						tb.setType(this.oldTemps.get(block));
-					}
-				} else {
-					TempBlock.revertBlock(block, Material.AIR);
-				}
-				AFFECTED_BLOCKS.remove(block);
-			}
-			if (WALL_BLOCKS.containsKey(block)) {
-				if (this.oldTemps.containsKey(block)) {
-					final TempBlock tb = TempBlock.get(block);
-					if (tb != null) {
-						tb.setType(this.oldTemps.get(block));
-					}
-				} else {
-					TempBlock.revertBlock(block, Material.AIR);
-				}
-				WALL_BLOCKS.remove(block);
-			}
-		}
-	}
-
-	private void addWater(final Block block) {
-		if (RegionProtection.isRegionProtected(this, block.getLocation())) {
-			return;
-		} else if (!TempBlock.isTempBlock(block)) {
-			new TempBlock(block, Material.WATER);
-			AFFECTED_BLOCKS.put(block, block);
-		}
-	}
-
-	@Override
-	public boolean allowBreakPlants() {
-		return false;
-	}
-
-	public static void form(final Player player) {
-		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-		if (bPlayer == null) {
-			return;
-		}
-
-		final double range = WaterAbility.getNightFactor(player.getWorld()) * getConfig().getDouble("Abilities.Water.Surge.Wall.Range");
-		SurgeWall wall = getAbility(player, SurgeWall.class);
-		SurgeWave wave = getAbility(player, SurgeWave.class);
-
-		if (wave != null) {
-			if (wave.isProgressing() && !wave.isFreezing()) {
-				// Freeze the wave.
-				new SurgeWave(player);
-			} else if (wave.isActivateFreeze()) {
-				wave.remove();
-				return;
-			}
-		}
-
-		if (wall == null) {
-			final Block source = BlockSource.getWaterSourceBlock(player, range, ClickType.SHIFT_DOWN, true, true, bPlayer.canPlantbend());
-
-			if (wave == null && source == null && WaterReturn.hasWaterBottle(player)) {
-				if (bPlayer.isOnCooldown("SurgeWall")) {
-					return;
-				}
-
-				final Location eyeLoc = player.getEyeLocation();
-				final Block block = eyeLoc.add(eyeLoc.getDirection().normalize()).getBlock();
-
-				if (isTransparent(player, block) && isTransparent(player, eyeLoc.getBlock())) {
-					final TempBlock tempBlock = new TempBlock(block, Material.WATER);
-					SOURCE_BLOCKS.add(tempBlock);
-
-					wall = new SurgeWall(player);
-					wall.moveWater();
-
-					if (!wall.progressing) {
-						SOURCE_BLOCKS.remove(tempBlock);
-						tempBlock.revertBlock();
-						wall.remove();
-					} else {
-						WaterReturn.emptyWaterBottle(player);
-					}
-
-					SOURCE_BLOCKS.remove(tempBlock);
-					tempBlock.revertBlock();
-					return;
-				}
-			}
-
-			// If SurgeWall isn't being created, then try to source SurgeWave.
-			if (!bPlayer.isOnCooldown("SurgeWave")) {
-				wave = new SurgeWave(player);
-			}
-			return;
-		} else {
-			if (isWaterbendable(player, null, player.getTargetBlock((HashSet<Material>) null, Math.min(1, (int)range)))) {
-				wave = new SurgeWave(player);
-				return;
-			}
-		}
-
-		if (wall != null) {
-			wall.moveWater();
-		}
-	}
-
-	public static void removeAllCleanup() {
-		for (final Block block : AFFECTED_BLOCKS.keySet()) {
-			TempBlock.revertBlock(block, Material.AIR);
-			AFFECTED_BLOCKS.remove(block);
-			WALL_BLOCKS.remove(block);
-		}
-		for (final Block block : WALL_BLOCKS.keySet()) {
-			TempBlock.revertBlock(block, Material.AIR);
-			AFFECTED_BLOCKS.remove(block);
-			WALL_BLOCKS.remove(block);
-		}
-	}
-
-	public static boolean wasBrokenFor(final Player player, final Block block) {
-		final SurgeWall wall = getAbility(player, SurgeWall.class);
-		if (wall != null) {
-			if (wall.sourceBlock == null) {
-				return false;
-			} else if (wall.sourceBlock.equals(block)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private void returnWater() {
-		if (this.location != null) {
-			if (this.frozen) {
-				this.thaw();
-			}
-			new WaterReturn(this.player, this.location.getBlock());
-		}
-	}
-
-	@Override
-	public String getName() {
-		return "Surge";
-	}
-
-	@Override
-	public Location getLocation() {
-		if (this.location != null) {
-			return this.location;
-		} else if (this.sourceBlock != null) {
-			return this.sourceBlock.getLocation();
-		}
-		return this.player != null ? this.player.getLocation() : null;
-	}
-
-	@Override
-	public long getCooldown() {
-		return this.cooldown;
-	}
-
-	@Override
-	public boolean isSneakAbility() {
-		return true;
-	}
-
-	@Override
-	public boolean isHarmlessAbility() {
-		return false;
-	}
-
-	@Override
-	public List<Location> getLocations() {
-		return this.locations;
-	}
-
-	public boolean isProgressing() {
-		return this.progressing;
-	}
-
-	public void setProgressing(final boolean progressing) {
-		this.progressing = progressing;
-	}
-
-	public boolean isSettingUp() {
-		return this.settingUp;
-	}
-
-	public void setSettingUp(final boolean settingUp) {
-		this.settingUp = settingUp;
-	}
-
-	public boolean isForming() {
-		return this.forming;
-	}
-
-	public void setForming(final boolean forming) {
-		this.forming = forming;
-	}
-
-	public boolean isFrozen() {
-		return this.frozen;
-	}
-
-	public void setFrozen(final boolean frozen) {
-		this.frozen = frozen;
-	}
-
-	public long getTime() {
-		return this.time;
-	}
-
-	public void setTime(final long time) {
-		this.time = time;
-	}
-
-	public long getInterval() {
-		return this.interval;
-	}
-
-	public void setInterval(final long interval) {
-		this.interval = interval;
-	}
-
-	public double getRadius() {
-		return this.radius;
-	}
-
-	public void setRadius(final double radius) {
-		this.radius = radius;
-	}
-
-	public double getRange() {
-		return this.range;
-	}
-
-	public void setRange(final double range) {
-		this.range = range;
-	}
-
-	public Block getSourceBlock() {
-		return this.sourceBlock;
-	}
-
-	public void setSourceBlock(final Block sourceBlock) {
-		this.sourceBlock = sourceBlock;
-	}
-
-	public Location getFirstDestination() {
-		return this.firstDestination;
-	}
-
-	public void setFirstDestination(final Location firstDestination) {
-		this.firstDestination = firstDestination;
-	}
-
-	public Location getTargetDestination() {
-		return this.targetDestination;
-	}
-
-	public void setTargetDestination(final Location targetDestination) {
-		this.targetDestination = targetDestination;
-	}
-
-	public Vector getFirstDirection() {
-		return this.firstDirection;
-	}
-
-	public void setFirstDirection(final Vector firstDirection) {
-		this.firstDirection = firstDirection;
-	}
-
-	public Vector getTargetDirection() {
-		return this.targetDirection;
-	}
-
-	public void setTargetDirection(final Vector targetDirection) {
-		this.targetDirection = targetDirection;
-	}
-
-	public static Map<Block, Block> getAffectedBlocks() {
-		return AFFECTED_BLOCKS;
-	}
-
-	public static Map<Block, Player> getWallBlocks() {
-		return WALL_BLOCKS;
-	}
-
-	public void setCooldown(final long cooldown) {
-		this.cooldown = cooldown;
-	}
-
-	public void setLocation(final Location location) {
-		this.location = location;
-	}
+    private static final Map<Block, Block> AFFECTED_BLOCKS = new ConcurrentHashMap<>();
+    private static final Map<Block, Player> WALL_BLOCKS = new ConcurrentHashMap<>();
+    public static final List<TempBlock> SOURCE_BLOCKS = new ArrayList<>();
+
+    private boolean progressing;
+    private boolean settingUp;
+    private boolean forming;
+    private boolean frozen;
+    private boolean solidifyLava;
+    private long time;
+    private long interval;
+    @Attribute(Attribute.COOLDOWN)
+    private long cooldown;
+    @Attribute(Attribute.DURATION)
+    private long duration;
+    private long obsidianDuration;
+    @Attribute(Attribute.RADIUS)
+    private double radius;
+    @Attribute(Attribute.RANGE)
+    private double range;
+    private Block sourceBlock;
+    private Location location;
+    private Location firstDestination;
+    private Location targetDestination;
+    private ArrayList<Location> locations;
+    private Vector firstDirection;
+    private Vector targetDirection;
+    private Map<Block, Material> oldTemps;
+
+    public SurgeWall(final Player player) {
+        super(player);
+
+        this.interval = getConfig().getLong("Abilities.Water.Surge.Wall.Interval");
+        this.cooldown = applyInverseModifiers(getConfig().getLong("Abilities.Water.Surge.Wall.Cooldown"));
+        this.duration = applyModifiers(getConfig().getLong("Abilities.Water.Surge.Wall.Duration"));
+        this.range = applyModifiers(getConfig().getDouble("Abilities.Water.Surge.Wall.Range"));
+        this.radius = applyModifiers(getConfig().getDouble("Abilities.Water.Surge.Wall.Radius"));
+        this.solidifyLava = getConfig().getBoolean("Abilities.Water.Surge.Wall.SolidifyLava.Enabled");
+        this.obsidianDuration = getConfig().getLong("Abilities.Water.Surge.Wall.SolidifyLava.Duration");
+        this.locations = new ArrayList<>();
+        this.oldTemps = new HashMap<>();
+
+        SurgeWave wave = getAbility(player, SurgeWave.class);
+        if (wave != null && !wave.isProgressing() && !this.bPlayer.isOnCooldown("SurgeWave")) {
+            wave.moveWater();
+            return;
+        }
+
+        if (this.bPlayer.isAvatarState()) {
+            this.radius = getConfig().getDouble("Abilities.Avatar.AvatarState.Water.Surge.Wall.Radius");
+        }
+
+        final SurgeWall wall = getAbility(player, SurgeWall.class);
+        if (wall != null) {
+            if (wall.progressing) {
+                wall.freezeThaw();
+                return;
+            } else if (this.prepare()) {
+                wall.remove();
+                this.start();
+                this.time = System.currentTimeMillis();
+            }
+        } else if (!this.bPlayer.isOnCooldown("SurgeWall") && this.prepare()) {
+            this.start();
+            this.time = System.currentTimeMillis();
+            return;
+        }
+
+        if (this.bPlayer.isOnCooldown("SurgeWave") || player.isSneaking()) {
+            return;
+        } else if (wall == null && WaterReturn.hasWaterBottle(player)) {
+            final Location eyeLoc = player.getEyeLocation();
+            final Block block = eyeLoc.add(eyeLoc.getDirection().normalize()).getBlock();
+
+            if (isTransparent(player, block) && isTransparent(player, eyeLoc.getBlock())) {
+                final TempBlock tempBlock = new TempBlock(block, Material.WATER);
+                SOURCE_BLOCKS.add(tempBlock);
+
+                wave = new SurgeWave(player);
+                wave.setCanHitSelf(false);
+                wave.moveWater();
+
+                if (!wave.isProgressing()) {
+                    wave.remove();
+                } else {
+                    WaterReturn.emptyWaterBottle(player);
+                }
+
+                SOURCE_BLOCKS.remove(tempBlock);
+                tempBlock.revertBlock();
+            }
+        }
+    }
+
+    private void freezeThaw() {
+        if (!this.bPlayer.canIcebend()) {
+            return;
+        } else if (this.frozen) {
+            this.thaw();
+        } else {
+            this.freeze();
+        }
+    }
+
+    private void freeze() {
+        this.frozen = true;
+        for (final Block block : WALL_BLOCKS.keySet()) {
+            if (WALL_BLOCKS.get(block) == this.player) {
+                new TempBlock(block, Material.ICE);
+                IceAbility.playIcebendingSound(block.getLocation());
+            }
+        }
+    }
+
+    private void thaw() {
+        this.frozen = false;
+        for (final Block block : WALL_BLOCKS.keySet()) {
+            if (WALL_BLOCKS.get(block) == this.player) {
+                new TempBlock(block, Material.WATER);
+            }
+        }
+    }
+
+    public boolean prepare() {
+        this.cancelPrevious();
+        final Block block = BlockSource.getWaterSourceBlock(this.player, this.range, ClickType.LEFT_CLICK, true, true, this.bPlayer.canPlantbend());
+
+        if (block != null && !RegionProtection.isRegionProtected(this, block.getLocation())) {
+            this.sourceBlock = block;
+            this.focusBlock();
+            return true;
+        }
+        return false;
+    }
+
+    private void cancelPrevious() {
+        final SurgeWall oldWave = getAbility(this.player, SurgeWall.class);
+        if (oldWave != null) {
+            if (oldWave.progressing) {
+                oldWave.removeWater(oldWave.sourceBlock);
+            } else {
+                oldWave.remove();
+            }
+        }
+    }
+
+    private void focusBlock() {
+        this.location = this.sourceBlock.getLocation();
+    }
+
+    public void moveWater() {
+        if (this.sourceBlock != null) {
+            this.targetDestination = this.player.getTargetBlock(getTransparentMaterialSet(), (int) this.range).getLocation();
+
+            if (this.targetDestination.distanceSquared(this.location) <= 1) {
+                this.progressing = false;
+                this.targetDestination = null;
+            } else {
+                this.bPlayer.addCooldown("SurgeWall", this.cooldown);
+                this.progressing = true;
+                this.settingUp = true;
+                this.firstDestination = this.getToEyeLevel();
+                this.firstDirection = this.getDirection(this.sourceBlock.getLocation(), this.firstDestination);
+                this.targetDirection = this.getDirection(this.firstDestination, this.targetDestination);
+
+                if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
+                    new PlantRegrowth(this.player, this.sourceBlock);
+                    this.sourceBlock.setType(Material.AIR, false);
+                }
+                this.addWater(this.sourceBlock);
+            }
+
+        }
+    }
+
+    private Location getToEyeLevel() {
+        final Location loc = this.sourceBlock.getLocation().clone();
+        loc.setY(this.targetDestination.getY());
+        return loc;
+    }
+
+    private Vector getDirection(final Location location, final Location destination) {
+        double x1, y1, z1;
+        double x0, y0, z0;
+
+        x1 = destination.getX();
+        y1 = destination.getY();
+        z1 = destination.getZ();
+
+        x0 = location.getX();
+        y0 = location.getY();
+        z0 = location.getZ();
+
+        return new Vector(x1 - x0, y1 - y0, z1 - z0);
+    }
+
+    @Override
+    public void progress() {
+        if (!this.bPlayer.canBendIgnoreBindsCooldowns(this)) {
+            this.remove();
+            return;
+        } else if (this.duration != 0 && System.currentTimeMillis() > this.getStartTime() + this.duration) {
+            this.bPlayer.addCooldown(this);
+            this.remove();
+            return;
+        } else if (!isWaterbendable(this.sourceBlock) && !this.settingUp && !this.forming && !this.progressing) {
+            remove();
+            return;
+        }
+
+        this.locations.clear();
+
+        if (System.currentTimeMillis() - this.time >= this.interval) {
+            this.time = System.currentTimeMillis();
+            final boolean matchesName = this.bPlayer.getBoundAbilityName().equals(this.getName());
+
+            if (!this.progressing && !matchesName) {
+                this.remove();
+                return;
+            } else if (this.progressing && (!this.player.isSneaking() || !matchesName)) {
+                this.remove();
+                return;
+            } else if (!this.progressing) {
+                WaterAbility.playFocusWaterEffect(this, this.sourceBlock);
+                return;
+            }
+
+            if (this.forming) {
+                if ((new Random()).nextInt(7) == 0) {
+                    playWaterbendingSound(this.location);
+                }
+
+                final ArrayList<Block> blocks = new ArrayList<Block>();
+                final Location targetLoc = GeneralMethods.getTargetedLocation(this.player, (int) this.range, false, false, Material.WATER, Material.ICE);
+                this.location = targetLoc.clone();
+                final Vector eyeDir = this.player.getEyeLocation().getDirection();
+                Vector vector;
+                Block block;
+                for (double i = 0; i <= this.getNightFactor(this.radius); i += 0.5) {
+                    for (double angle = 0; angle < 360; angle += 10) {
+                        vector = GeneralMethods.getOrthogonalVector(eyeDir.clone(), angle, i);
+                        block = targetLoc.clone().add(vector).getBlock();
+
+                        if (RegionProtection.isRegionProtected(this, block.getLocation())) {
+                            continue;
+                        } else if (WALL_BLOCKS.containsKey(block)) {
+                            blocks.add(block);
+                        } else if (!blocks.contains(block) && (ElementalAbility.isAir(block.getType()) || FireAbility.isFire(block.getType()) || this.isWaterbendable(block)) && this.isTransparent(block)) {
+                            WALL_BLOCKS.put(block, this.player);
+                            this.addWallBlock(block);
+                            blocks.add(block);
+                            this.locations.add(block.getLocation());
+                            FireBlast.removeFireBlastsAroundPoint(block.getLocation(), 2);
+                        }
+                    }
+                }
+
+                for (final Block blocki : WALL_BLOCKS.keySet()) {
+                    if (WALL_BLOCKS.get(blocki) == this.player && !blocks.contains(blocki)) {
+                        this.finalRemoveWater(blocki);
+                    }
+
+                    if (solidifyLava) {
+                        for (BlockFace relative : BlockFace.values()) {
+                            Block blockRelative = blocki.getRelative(relative);
+                            if (blockRelative.getType() == Material.LAVA) {
+                                Levelled levelled = (Levelled) blockRelative.getBlockData();
+                                TempBlock tempBlock;
+
+                                if (levelled.getLevel() == 0)
+                                    tempBlock = new TempBlock(blockRelative, Material.OBSIDIAN);
+                                else
+                                    tempBlock = new TempBlock(blockRelative, Material.COBBLESTONE);
+
+                                tempBlock.setRevertTime(obsidianDuration);
+                                tempBlock.getBlock().getWorld().playSound(tempBlock.getLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 0.2F, 1);
+                            }
+                        }
+                    }
+                }
+
+                return;
+            }
+
+            if (this.sourceBlock.getLocation().distanceSquared(this.firstDestination) < 0.5 * 0.5 && this.settingUp) {
+                this.settingUp = false;
+            }
+
+            Vector direction;
+            if (this.settingUp) {
+                direction = this.firstDirection;
+            } else {
+                direction = this.targetDirection;
+            }
+
+            this.location = this.location.clone().add(direction);
+
+            Block block = this.location.getBlock();
+            if (block.getLocation().equals(this.sourceBlock.getLocation())) {
+                this.location = this.location.clone().add(direction);
+                block = this.location.getBlock();
+            }
+
+            if (!ElementalAbility.isAir(block.getType())) {
+                this.remove();
+                return;
+            } else if (!this.progressing) {
+                this.remove();
+                return;
+            }
+
+            this.addWater(block);
+            this.removeWater(this.sourceBlock);
+            this.sourceBlock = block;
+
+            if (this.location.distanceSquared(this.targetDestination) < 1) {
+                this.removeWater(this.sourceBlock);
+                this.forming = true;
+            }
+        }
+    }
+
+    private void addWallBlock(final Block block) {
+        if (TempBlock.isTempBlock(block)) {
+            this.oldTemps.put(block, block.getType());
+        }
+
+        if (this.frozen) {
+            new TempBlock(block, Material.ICE);
+        } else {
+            new TempBlock(block, Material.WATER);
+        }
+    }
+
+    @Override
+    public void remove() {
+        super.remove();
+        this.returnWater();
+        this.finalRemoveWater(this.sourceBlock);
+
+        for (final Block block : WALL_BLOCKS.keySet()) {
+            if (WALL_BLOCKS.get(block) == this.player) {
+                this.finalRemoveWater(block);
+            }
+        }
+
+    }
+
+    private void removeWater(final Block block) {
+        if (block != null) {
+            if (AFFECTED_BLOCKS.containsKey(block)) {
+                if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block)) {
+                    if (this.oldTemps.containsKey(block)) {
+                        final TempBlock tb = TempBlock.get(block);
+                        if (tb != null) {
+                            tb.setType(this.oldTemps.get(block));
+                        }
+                    } else {
+                        TempBlock.revertBlock(block, Material.AIR);
+                    }
+                }
+                AFFECTED_BLOCKS.remove(block);
+            }
+        }
+    }
+
+    private void finalRemoveWater(final Block block) {
+        if (block != null) {
+            if (AFFECTED_BLOCKS.containsKey(block)) {
+                if (this.oldTemps.containsKey(block)) {
+                    final TempBlock tb = TempBlock.get(block);
+                    if (tb != null) {
+                        tb.setType(this.oldTemps.get(block));
+                    }
+                } else {
+                    TempBlock.revertBlock(block, Material.AIR);
+                }
+                AFFECTED_BLOCKS.remove(block);
+            }
+            if (WALL_BLOCKS.containsKey(block)) {
+                if (this.oldTemps.containsKey(block)) {
+                    final TempBlock tb = TempBlock.get(block);
+                    if (tb != null) {
+                        tb.setType(this.oldTemps.get(block));
+                    }
+                } else {
+                    TempBlock.revertBlock(block, Material.AIR);
+                }
+                WALL_BLOCKS.remove(block);
+            }
+        }
+    }
+
+    private void addWater(final Block block) {
+        if (RegionProtection.isRegionProtected(this, block.getLocation())) {
+            return;
+        } else if (!TempBlock.isTempBlock(block)) {
+            new TempBlock(block, Material.WATER);
+            AFFECTED_BLOCKS.put(block, block);
+        }
+    }
+
+    @Override
+    public boolean allowBreakPlants() {
+        return false;
+    }
+
+    public static void form(final Player player) {
+        final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+        if (bPlayer == null) {
+            return;
+        }
+
+        final double range = WaterAbility.getNightFactor(player.getWorld()) * getConfig().getDouble("Abilities.Water.Surge.Wall.Range");
+        SurgeWall wall = getAbility(player, SurgeWall.class);
+        SurgeWave wave = getAbility(player, SurgeWave.class);
+
+        if (wave != null) {
+            if (wave.isProgressing() && !wave.isFreezing()) {
+                // Freeze the wave.
+                new SurgeWave(player);
+            } else if (wave.isActivateFreeze()) {
+                wave.remove();
+                return;
+            }
+        }
+
+        if (wall == null) {
+            final Block source = BlockSource.getWaterSourceBlock(player, range, ClickType.SHIFT_DOWN, true, true, bPlayer.canPlantbend());
+
+            if (wave == null && source == null && WaterReturn.hasWaterBottle(player)) {
+                if (bPlayer.isOnCooldown("SurgeWall")) {
+                    return;
+                }
+
+                final Location eyeLoc = player.getEyeLocation();
+                final Block block = eyeLoc.add(eyeLoc.getDirection().normalize()).getBlock();
+
+                if (isTransparent(player, block) && isTransparent(player, eyeLoc.getBlock())) {
+                    final TempBlock tempBlock = new TempBlock(block, Material.WATER);
+                    SOURCE_BLOCKS.add(tempBlock);
+
+                    wall = new SurgeWall(player);
+                    wall.moveWater();
+
+                    if (!wall.progressing) {
+                        SOURCE_BLOCKS.remove(tempBlock);
+                        tempBlock.revertBlock();
+                        wall.remove();
+                    } else {
+                        WaterReturn.emptyWaterBottle(player);
+                    }
+
+                    SOURCE_BLOCKS.remove(tempBlock);
+                    tempBlock.revertBlock();
+                    return;
+                }
+            }
+
+            // If SurgeWall isn't being created, then try to source SurgeWave.
+            if (!bPlayer.isOnCooldown("SurgeWave")) {
+                wave = new SurgeWave(player);
+            }
+            return;
+        } else {
+            if (isWaterbendable(player, null, player.getTargetBlock((HashSet<Material>) null, Math.min(1, (int) range)))) {
+                wave = new SurgeWave(player);
+                return;
+            }
+        }
+
+        if (wall != null) {
+            wall.moveWater();
+        }
+    }
+
+    public static void removeAllCleanup() {
+        for (final Block block : AFFECTED_BLOCKS.keySet()) {
+            TempBlock.revertBlock(block, Material.AIR);
+            AFFECTED_BLOCKS.remove(block);
+            WALL_BLOCKS.remove(block);
+        }
+        for (final Block block : WALL_BLOCKS.keySet()) {
+            TempBlock.revertBlock(block, Material.AIR);
+            AFFECTED_BLOCKS.remove(block);
+            WALL_BLOCKS.remove(block);
+        }
+    }
+
+    public static boolean wasBrokenFor(final Player player, final Block block) {
+        final SurgeWall wall = getAbility(player, SurgeWall.class);
+        if (wall != null) {
+            if (wall.sourceBlock == null) {
+                return false;
+            } else if (wall.sourceBlock.equals(block)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void returnWater() {
+        if (this.location != null) {
+            if (this.frozen) {
+                this.thaw();
+            }
+            new WaterReturn(this.player, this.location.getBlock());
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "Surge";
+    }
+
+    @Override
+    public Location getLocation() {
+        if (this.location != null) {
+            return this.location;
+        } else if (this.sourceBlock != null) {
+            return this.sourceBlock.getLocation();
+        }
+        return this.player != null ? this.player.getLocation() : null;
+    }
+
+    @Override
+    public long getCooldown() {
+        return this.cooldown;
+    }
+
+    @Override
+    public boolean isSneakAbility() {
+        return true;
+    }
+
+    @Override
+    public boolean isHarmlessAbility() {
+        return false;
+    }
+
+    @Override
+    public List<Location> getLocations() {
+        return this.locations;
+    }
+
+    public boolean isProgressing() {
+        return this.progressing;
+    }
+
+    public void setProgressing(final boolean progressing) {
+        this.progressing = progressing;
+    }
+
+    public boolean isSettingUp() {
+        return this.settingUp;
+    }
+
+    public void setSettingUp(final boolean settingUp) {
+        this.settingUp = settingUp;
+    }
+
+    public boolean isForming() {
+        return this.forming;
+    }
+
+    public void setForming(final boolean forming) {
+        this.forming = forming;
+    }
+
+    public boolean isFrozen() {
+        return this.frozen;
+    }
+
+    public void setFrozen(final boolean frozen) {
+        this.frozen = frozen;
+    }
+
+    public long getTime() {
+        return this.time;
+    }
+
+    public void setTime(final long time) {
+        this.time = time;
+    }
+
+    public long getInterval() {
+        return this.interval;
+    }
+
+    public void setInterval(final long interval) {
+        this.interval = interval;
+    }
+
+    public double getRadius() {
+        return this.radius;
+    }
+
+    public void setRadius(final double radius) {
+        this.radius = radius;
+    }
+
+    public double getRange() {
+        return this.range;
+    }
+
+    public void setRange(final double range) {
+        this.range = range;
+    }
+
+    public Block getSourceBlock() {
+        return this.sourceBlock;
+    }
+
+    public void setSourceBlock(final Block sourceBlock) {
+        this.sourceBlock = sourceBlock;
+    }
+
+    public Location getFirstDestination() {
+        return this.firstDestination;
+    }
+
+    public void setFirstDestination(final Location firstDestination) {
+        this.firstDestination = firstDestination;
+    }
+
+    public Location getTargetDestination() {
+        return this.targetDestination;
+    }
+
+    public void setTargetDestination(final Location targetDestination) {
+        this.targetDestination = targetDestination;
+    }
+
+    public Vector getFirstDirection() {
+        return this.firstDirection;
+    }
+
+    public void setFirstDirection(final Vector firstDirection) {
+        this.firstDirection = firstDirection;
+    }
+
+    public Vector getTargetDirection() {
+        return this.targetDirection;
+    }
+
+    public void setTargetDirection(final Vector targetDirection) {
+        this.targetDirection = targetDirection;
+    }
+
+    public static Map<Block, Block> getAffectedBlocks() {
+        return AFFECTED_BLOCKS;
+    }
+
+    public static Map<Block, Player> getWallBlocks() {
+        return WALL_BLOCKS;
+    }
+
+    public void setCooldown(final long cooldown) {
+        this.cooldown = cooldown;
+    }
+
+    public void setLocation(final Location location) {
+        this.location = location;
+    }
 
 }

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -285,7 +285,7 @@ public class SurgeWave extends WaterAbility {
 				this.remove();
 				return;
 			} else if (!this.progressing) {
-				ParticleEffect.SMOKE_NORMAL.display(this.sourceBlock.getLocation().add(0.5, 0.5, 0.5), 4);
+				WaterAbility.playFocusWaterEffect(this, this.sourceBlock);
 				return;
 			}
 

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.ability.IceAbility;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.bukkit.Location;
@@ -161,7 +162,7 @@ public class Torrent extends WaterAbility {
 				if (this.revert) {
 					tblock.setRevertTime(this.revertTime + (new Random().nextInt((500 + 500) + 1) - 500));
 				}
-				playIcebendingSound(block.getLocation());
+				IceAbility.playIcebendingSound(block.getLocation());
 			}
 		}
 	}
@@ -210,7 +211,7 @@ public class Torrent extends WaterAbility {
 					this.source = new TempBlock(this.sourceBlock, Material.WATER);
 					this.location = this.sourceBlock.getLocation();
 				} else {
-					playFocusWaterEffect(this.sourceBlock);
+					playFocusWaterEffect(this, this.sourceBlock);
 					return;
 				}
 			}

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -205,7 +205,7 @@ public class WaterManipulation extends WaterAbility {
 						this.remove();
 						return;
 					}
-					ParticleEffect.SMOKE_NORMAL.display(this.sourceBlock.getLocation().clone().add(0.5, 0.5, 0.5), 4, 0, 0, 0);
+					playFocusWaterEffect(this, this.sourceBlock);
 					return;
 				}
 

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -193,7 +193,7 @@ public class WaterSpoutWave extends WaterAbility {
 				this.setType(AbilityType.SHIFT);
 				return;
 			}
-			playFocusWaterEffect(this.origin.getBlock());
+			playFocusWaterEffect(this, this.origin.getBlock());
 		} else if (this.type == AbilityType.SHIFT) {
 			if (this.direction == null) {
 				this.direction = this.player.getEyeLocation().getDirection();

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
@@ -322,7 +322,7 @@ public class IceBlast extends IceAbility {
 			}
 			this.location = this.location.add(direction.clone());
 		} else if (this.prepared) {
-			playFocusWaterEffect(this.sourceBlock);
+			playFocusWaterEffect(this, this.sourceBlock);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -222,7 +222,7 @@ public class IceSpikeBlast extends IceAbility {
 			this.source.setRevertTime(130);
 		} else if (this.prepared) {
 			if (this.sourceBlock != null) {
-				playFocusWaterEffect(this.sourceBlock);
+				playFocusWaterEffect(this, this.sourceBlock);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.projectkorra.projectkorra.ability.LightningAbility;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -16,7 +17,6 @@ import org.bukkit.entity.Player;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
-import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.ability.util.MultiAbilityManager;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -396,7 +396,7 @@ public class WaterArms extends WaterAbility {
 					for (final Location loc : arc.getPoints()) {
 						if (arm.getLocation().getWorld().equals(loc.getWorld()) && loc.distance(arm.getLocation()) <= 2.5) {
 							for (final Location l1 : getOffsetLocations(4, arm.getLocation(), 1.25)) {
-								FireAbility.playLightningbendingParticle(l1);
+								LightningAbility.playLightningbendingParticles(this, l1, 1);
 							}
 							if (this.lightningKill) {
 								DamageHandler.damageEntity(this.player, 60D, lightning);

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.ability.IceAbility;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -194,7 +195,7 @@ public class WaterArmsSpear extends WaterAbility {
 			if (i >= 0) {
 				final Block block = this.spearLocations.get(i).getBlock();
 				if (this.canPlaceBlock(block)) {
-					playIcebendingSound(block.getLocation());
+					IceAbility.playIcebendingSound(block.getLocation());
 					if (getIceBlocks().containsKey(block)) {
 						getIceBlocks().remove(block);
 					}
@@ -246,7 +247,7 @@ public class WaterArmsSpear extends WaterAbility {
 						}
 					}
 				}
-				playIcebendingSound(block.getLocation());
+				IceAbility.playIcebendingSound(block.getLocation());
 				new TempBlock(block, Material.ICE);
 				getIceBlocks().put(block, System.currentTimeMillis() + this.spearDuration + (long) (Math.random() * 500));
 			}

--- a/src/com/projectkorra/projectkorra/waterbending/plant/PlantTether.java
+++ b/src/com/projectkorra/projectkorra/waterbending/plant/PlantTether.java
@@ -72,7 +72,7 @@ public class PlantTether extends PlantAbility {
 				}
 				break;
 			case ENTITYPULL:
-				this.playPlantbendingParticles(this.target.getLocation().clone().add(-0.5, 0, -0.5), 4, 0.2, 0.5, 0.2);
+				playPlantbendingParticles(this, this.target.getLocation().clone().add(-0.5, 0, -0.5), 4, 0.2, 0.5, 0.2);
 
 				if ((this.timeOut > 15000) || (this.target.getLocation().distance(this.originLoc) < 0.5)) {
 					this.bPlayer.addCooldown("PlantTether", this.getCooldown());
@@ -89,7 +89,7 @@ public class PlantTether extends PlantAbility {
 		}
 
 
-		this.playPlantbendingParticles(this.originLoc, 3, 0.2, 0.5, 0.2);
+		playPlantbendingParticles(this, this.originLoc, 3, 0.2, 0.5, 0.2);
 		this.timeOut += 1;
 	}
 


### PR DESCRIPTION
### This changes were tested on my server! Working great, supporting existing addons.
I made example addon, that adds ColorfulFire subelement, changes particles of airbending and adds my WaterSource particles.
**This PR's jar file:** https://github.com/Dreig-PSD/ProjectKorra/releases/tag/v1.10.2-FunctionalParticles
**Example addon:** https://github.com/Dreig-PSD/CustomBendingParticles/releases/tag/Updated1

## Additions
* Adds Functional.Particle FunctionalInterface, path: com.projectkorra.projectkorra.ability.functional
* A public variable of type Functional.Particle is used in classes FireAbility, AirAbility, WaterAbility ... XAbility as a default way to display particles of a certain element.
This variable is used in the XAbility#playXbendingParticles methods.
In addition, this variable is now also used in the FireComboStream class.

## Fixes
* SurgeWave and SurgeWall code did not use the WaterAbility#playFocusWaterEffect method, fixed.

## Removals
* Nothing is removed, some methods are marked as Deprecated with references in javadoc.

## Misc. Changes
* Methods like playXbendingSound, playXbendingParticles were moved to it's classes.
For example, FireAbility#playLightningbendingParticles was moved to LightningAbility, but FireAbility still have playLightningParticles method, but now it's depracated and just calls method from LightningAbility class.
* Deprecated methods were moved to the bottoms of the classes XAbility.
