### PR TITLE
Deprecated playAirbendingParticles.

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/AirAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/AirAbility.java
@@ -106,17 +106,33 @@ public abstract class AirAbility extends ElementalAbility {
 
 	/**
 	 * Plays an integer amount of air particles in a location.
+	 * Deprecated. Use {@link AirAbility#playAirbendingParticles(CoreAbility, Location, int)} instead
 	 *
 	 * @param loc The location to use
 	 * @param amount The amount of particles
 	 */
+	@Deprecated
 	public static void playAirbendingParticles(final Location loc, final int amount) {
 		playAirbendingParticles(loc, amount, Math.random(), Math.random(), Math.random());
 	}
 
+
+	/**
+	 * Plays an integer amount of air particles in a location.
+	 *
+	 * @param ability The ability this particle is spawned for
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 */
+	public static void playAirbendingParticles(final CoreAbility ability, final Location loc, final int amount) {
+		playAirbendingParticles(ability, loc, amount, Math.random(), Math.random(), Math.random());
+	}
+
+
 	/**
 	 * Plays an integer amount of air particles in a location with a given
 	 * xOffset, yOffset, and zOffset.
+	 * Deprecated. Use {@link AirAbility#playAirbendingParticles(CoreAbility, Location, int, double, double, double)} instead
 	 *
 	 * @param loc The location to use
 	 * @param amount The amount of particles
@@ -124,9 +140,26 @@ public abstract class AirAbility extends ElementalAbility {
 	 * @param yOffset The yOffset to use
 	 * @param zOffset The zOffset to use
 	 */
+	@Deprecated
 	public static void playAirbendingParticles(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
 		getAirbendingParticles().display(loc, amount, xOffset, yOffset, zOffset);
 	}
+
+	/**
+	 * Plays an integer amount of air particles in a location with a given
+	 * xOffset, yOffset, and zOffset.
+	 *
+	 * @param ability The ability this particle is spawned for
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 * @param xOffset The xOffset to use
+	 * @param yOffset The yOffset to use
+	 * @param zOffset The zOffset to use
+	 */
+	public static void playAirbendingParticles(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+		getAirbendingParticles().display(loc, amount, xOffset, yOffset, zOffset);
+	}
+
 
 	/**
 	 * Plays the Airbending Sound at a location if enabled in the config.

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -283,7 +283,45 @@ public abstract class EarthAbility extends ElementalAbility {
 		TEMP_AIR_LOCATIONS.put(info.getID(), info);
 	}
 
+	/**
+	 * Plays an integer amount of sand particles in a location with a given
+	 * xOffset, yOffset, zOffset, speed and color.
+	 * Deprecated. Use {@link EarthAbility#displaySandParticle(CoreAbility, Location, int, double, double, double, double, boolean)} instead
+	 *
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 * @param xOffset The xOffset to use
+	 * @param yOffset The yOffset to use
+	 * @param zOffset The zOffset to use
+	 * @param speed The particle animation speed
+	 * @param red Use red sand for the particle
+	 */
 	public static void displaySandParticle(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset, final double speed, final boolean red) {
+		if (amount <= 0) {
+			return;
+		}
+
+		final Material sand = red ? Material.RED_SAND : Material.SAND;
+		final Material stone = red ? Material.RED_SANDSTONE : Material.SANDSTONE;
+
+		ParticleEffect.BLOCK_CRACK.display(loc, amount, xOffset, yOffset, zOffset, speed, sand.createBlockData());
+		ParticleEffect.BLOCK_CRACK.display(loc, amount, xOffset, yOffset, zOffset, speed, stone.createBlockData());
+	}
+
+	/**
+	 * Plays an integer amount of sand particles in a location with a given
+	 * xOffset, yOffset, zOffset, speed and color.
+	 *
+	 * @param ability The ability this particle is spawned for
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 * @param xOffset The xOffset to use
+	 * @param yOffset The yOffset to use
+	 * @param zOffset The zOffset to use
+	 * @param speed The particle animation speed
+	 * @param red Use red sand for the particle
+	 */
+	public static void displaySandParticle(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset, final double speed, final boolean red) {
 		if (amount <= 0) {
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -296,6 +296,7 @@ public abstract class EarthAbility extends ElementalAbility {
 	 * @param speed The particle animation speed
 	 * @param red Use red sand for the particle
 	 */
+	@Deprecated
 	public static void displaySandParticle(final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset, final double speed, final boolean red) {
 		if (amount <= 0) {
 			return;

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -215,12 +215,56 @@ public abstract class FireAbility extends ElementalAbility {
 		}
 	}
 
+	/**
+	 * Plays a single lightning particle in a location.
+	 * Deprecated. Use {@link FireAbility#playLightningbendingParticle(CoreAbility, Location, int)} instead
+	 *
+	 * @param loc The location to use
+	 */
+	@Deprecated
 	public static void playLightningbendingParticle(final Location loc) {
 		playLightningbendingParticle(loc, Math.random(), Math.random(), Math.random());
 	}
 
+	/**
+	 * Plays a single lightning particle in a location with a given
+	 * xOffset, yOffset, and zOffset.
+	 * Deprecated. Use {@link FireAbility#playLightningbendingParticle(CoreAbility, Location, int, double, double, double)} instead
+	 *
+	 * @param loc The location to use
+	 * @param xOffset The xOffset to use
+	 * @param yOffset The yOffset to use
+	 * @param zOffset The zOffset to use
+	 */
+	@Deprecated
 	public static void playLightningbendingParticle(final Location loc, final double xOffset, final double yOffset, final double zOffset) {
 		GeneralMethods.displayColoredParticle("#01E1FF", loc, 1, xOffset, yOffset, zOffset);
+	}
+
+	/**
+	 * Plays an integer amount of lightning particles in a location.
+	 *
+	 * @param ability The ability this particle is spawned for
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 */
+	public static void playLightningbendingParticle(final CoreAbility ability, final Location loc, final int amount) {
+		playLightningbendingParticle(ability, loc, amount, Math.random(), Math.random(), Math.random());
+	}
+
+	/**
+	 * Plays an integer amount of lightning particles in a location with a given
+	 * xOffset, yOffset, and zOffset.
+	 *
+	 * @param ability The ability this particle is spawned for
+	 * @param loc The location to use
+	 * @param amount The amount of particles
+	 * @param xOffset The xOffset to use
+	 * @param yOffset The yOffset to use
+	 * @param zOffset The zOffset to use
+	 */
+	public static void playLightningbendingParticle(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+		GeneralMethods.displayColoredParticle("#01E1FF", loc, amount, xOffset, yOffset, zOffset);
 	}
 
 	public static void playLightningbendingSound(final Location loc) {

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -217,7 +217,7 @@ public abstract class FireAbility extends ElementalAbility {
 
 	/**
 	 * Plays a single lightning particle in a location.
-	 * Deprecated. Use {@link FireAbility#playLightningbendingParticle(CoreAbility, Location, int)} instead
+	 * Deprecated. Use {@link FireAbility#playLightningbendingParticles(CoreAbility, Location, int)} instead
 	 *
 	 * @param loc The location to use
 	 */
@@ -229,7 +229,7 @@ public abstract class FireAbility extends ElementalAbility {
 	/**
 	 * Plays a single lightning particle in a location with a given
 	 * xOffset, yOffset, and zOffset.
-	 * Deprecated. Use {@link FireAbility#playLightningbendingParticle(CoreAbility, Location, int, double, double, double)} instead
+	 * Deprecated. Use {@link FireAbility#playLightningbendingParticles(CoreAbility, Location, int, double, double, double)} instead
 	 *
 	 * @param loc The location to use
 	 * @param xOffset The xOffset to use
@@ -248,8 +248,8 @@ public abstract class FireAbility extends ElementalAbility {
 	 * @param loc The location to use
 	 * @param amount The amount of particles
 	 */
-	public static void playLightningbendingParticle(final CoreAbility ability, final Location loc, final int amount) {
-		playLightningbendingParticle(ability, loc, amount, Math.random(), Math.random(), Math.random());
+	public static void playLightningbendingParticles(final CoreAbility ability, final Location loc, final int amount) {
+		playLightningbendingParticles(ability, loc, amount, Math.random(), Math.random(), Math.random());
 	}
 
 	/**
@@ -263,7 +263,7 @@ public abstract class FireAbility extends ElementalAbility {
 	 * @param yOffset The yOffset to use
 	 * @param zOffset The zOffset to use
 	 */
-	public static void playLightningbendingParticle(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
+	public static void playLightningbendingParticles(final CoreAbility ability, final Location loc, final int amount, final double xOffset, final double yOffset, final double zOffset) {
 		GeneralMethods.displayColoredParticle("#01E1FF", loc, amount, xOffset, yOffset, zOffset);
 	}
 

--- a/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -292,9 +292,27 @@ public abstract class WaterAbility extends ElementalAbility {
 		return true;
 	}
 
+
+	/**
+	 * Plays the focus water effect on a block.
+	 * Deprecated. Use {@link WaterAbility#playFocusWaterEffect(CoreAbility, Block)} instead
+	 *
+	 * @param block The block to play it on
+	 */
 	public static void playFocusWaterEffect(final Block block) {
 		ParticleEffect.SMOKE_NORMAL.display(block.getLocation().add(0.5, 0.5, 0.5), 4);
 	}
+
+	/**
+	 * Plays the focus water effect on a block.
+	 *
+	 * @param ability The ability this effect is spawned for
+	 * @param block The block to play it on
+	 */
+	public static void playFocusWaterEffect(final CoreAbility ability, final Block block) {
+		ParticleEffect.SMOKE_NORMAL.display(block.getLocation().add(0.5, 0.5, 0.5), 4);
+	}
+
 
 	public static void playIcebendingSound(final Location loc) {
 		if (getConfig().getBoolean("Properties.Water.PlaySound")) {

--- a/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -299,6 +299,7 @@ public abstract class WaterAbility extends ElementalAbility {
 	 *
 	 * @param block The block to play it on
 	 */
+	@Deprecated
 	public static void playFocusWaterEffect(final Block block) {
 		ParticleEffect.SMOKE_NORMAL.display(block.getLocation().add(0.5, 0.5, 0.5), 4);
 	}

--- a/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -204,7 +204,7 @@ public class AirBlast extends AirAbility {
 
 	private void advanceLocation() {
 		if (this.showParticles) {
-			playAirbendingParticles(this.location, this.particles, 0.275F, 0.275F, 0.275F);
+			playAirbendingParticles(this, this.location, this.particles, 0.275F, 0.275F, 0.275F);
 		}
 		if (this.random.nextInt(4) == 0) {
 			playAirbendingSound(this.location);

--- a/src/com/projectkorra/projectkorra/airbending/AirBurst.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirBurst.java
@@ -100,7 +100,7 @@ public class AirBurst extends AirAbility {
 			}
 		} else if (this.isCharged) {
 			final Location location = this.player.getEyeLocation();
-			playAirbendingParticles(location, this.sneakParticles);
+			playAirbendingParticles(this, location, this.sneakParticles);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/airbending/AirScooter.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirScooter.java
@@ -238,7 +238,7 @@ public class AirScooter extends AirAbility {
 			final double y = r * Math.cos(this.phi);
 			final double z = r * Math.sin(theta) * Math.sin(this.phi);
 			origin.add(x, y, z);
-			playAirbendingParticles(origin, 1, 0F, 0F, 0F);
+			playAirbendingParticles(this, origin, 1, 0F, 0F, 0F);
 			origin.subtract(x, y, z);
 		}
 		for (double theta = 0; theta <= 2 * Math.PI; theta += Math.PI / 10) {
@@ -247,7 +247,7 @@ public class AirScooter extends AirAbility {
 			final double y = r * Math.cos(this.phi);
 			final double z = r * Math.sin(theta) * Math.sin(this.phi);
 			origin2.subtract(x, y, z);
-			playAirbendingParticles(origin2, 1, 0F, 0F, 0F);
+			playAirbendingParticles(this, origin2, 1, 0F, 0F, 0F);
 			origin2.add(x, y, z);
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -189,7 +189,7 @@ public class AirShield extends AirAbility {
 
 			final Location effect = new Location(origin.getWorld(), x, y, z);
 			if (!GeneralMethods.isRegionProtectedFromBuild(this, effect)) {
-				playAirbendingParticles(effect, this.particles);
+				playAirbendingParticles(this, effect, this.particles);
 				if (this.random.nextInt(4) == 0) {
 					playAirbendingSound(effect);
 				}

--- a/src/com/projectkorra/projectkorra/airbending/AirSpout.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSpout.java
@@ -197,7 +197,7 @@ public class AirSpout extends AirAbility {
 			for (int i = 1; i <= dy; i++) {
 				index = index >= DIRECTIONS.length ? 0 : index + 1;
 				final Location effectloc2 = new Location(location.getWorld(), location.getX(), block.getY() + i, location.getZ());
-				playAirbendingParticles(effectloc2, 3, 0.4F, 0.4F, 0.4F);
+				playAirbendingParticles(this, effectloc2, 3, 0.4F, 0.4F, 0.4F);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/AirSuction.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSuction.java
@@ -100,7 +100,7 @@ public class AirSuction extends AirAbility {
 	}
 
 	private void advanceLocation() {
-		playAirbendingParticles(this.location, this.particleCount, 0.275F, 0.275F, 0.275F);
+		playAirbendingParticles(this, this.location, this.particleCount, 0.275F, 0.275F, 0.275F);
 		if (this.random.nextInt(4) == 0) {
 			playAirbendingSound(this.location);
 		}
@@ -259,7 +259,7 @@ public class AirSuction extends AirAbility {
 				return;
 			}
 
-			playAirbendingParticles(this.origin, 5, 0.5, 0.5, 0.5);
+			playAirbendingParticles(this, this.origin, 5, 0.5, 0.5, 0.5);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -162,7 +162,7 @@ public class AirSwipe extends AirAbility {
 
 				location = location.clone().add(direction.clone().multiply(this.speed));
 				this.streams.put(direction, location);
-				playAirbendingParticles(location, this.particles, 0.2F, 0.2F, 0);
+				playAirbendingParticles(this, location, this.particles, 0.2F, 0.2F, 0);
 				if (this.random.nextInt(4) == 0) {
 					playAirbendingSound(location);
 				}
@@ -314,7 +314,7 @@ public class AirSwipe extends AirAbility {
 				this.damage *= factor;
 				this.pushFactor *= factor;
 			} else if (System.currentTimeMillis() >= this.getStartTime() + this.maxChargeTime) {
-				playAirbendingParticles(this.player.getEyeLocation(), this.particles);
+				playAirbendingParticles(this, this.player.getEyeLocation(), this.particles);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/airbending/Tornado.java
+++ b/src/com/projectkorra/projectkorra/airbending/Tornado.java
@@ -190,7 +190,7 @@ public class Tornado extends AirAbility {
 
 				final Location effect = new Location(this.origin.getWorld(), x, y, z);
 				if (!GeneralMethods.isRegionProtectedFromBuild(this, effect)) {
-					playAirbendingParticles(effect, this.particleCount);
+					playAirbendingParticles(this, effect, this.particleCount);
 					if (this.random.nextInt(20) == 0) {
 						playAirbendingSound(effect);
 					}

--- a/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
@@ -144,7 +144,7 @@ public class AirStream extends AirAbility implements ComboAbility {
 				public void run() {
 					for (int angle = -180; angle <= 180; angle += 45) {
 						final Vector orthog = GeneralMethods.getOrthogonalVector(this.dir.clone(), angle, 0.5);
-						playAirbendingParticles(this.loc.clone().add(orthog), 1, 0F, 0F, 0F);
+						playAirbendingParticles(AirStream.this, this.loc.clone().add(orthog), 1, 0F, 0F, 0F);
 					}
 				}
 			};

--- a/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
+++ b/src/com/projectkorra/projectkorra/airbending/combo/Twister.java
@@ -130,7 +130,7 @@ public class Twister extends AirAbility implements ComboAbility {
 				final Vector animDir = GeneralMethods.rotateXZ(new Vector(1, 0, 1), i);
 				final Location animLoc = this.currentLoc.clone().add(animDir.multiply(animRadius));
 				animLoc.add(0, y, 0);
-				playAirbendingParticles(animLoc, 1, 0, 0, 0);
+				playAirbendingParticles(this, animLoc, 1, 0, 0, 0);
 			}
 		}
 		playAirbendingSound(this.currentLoc);

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -204,7 +204,7 @@ public class Lightning extends LightningAbility {
 				if (this.player.isSneaking()) {
 					final Location loc = this.player.getEyeLocation().add(this.player.getEyeLocation().getDirection().normalize().multiply(1.2));
 					loc.add(0, 0.3, 0);
-					playLightningbendingParticle(loc, 0.2F, 0.2F, 0.2F);
+					playLightningbendingParticle(this, loc, 1, 0.2F, 0.2F, 0.2F);
 					if (ThreadLocalRandom.current().nextDouble() < .2) {
 						playLightningbendingChargingSound(loc);
 					}
@@ -238,7 +238,7 @@ public class Lightning extends LightningAbility {
 				final double d8 = localLocation1.getZ() + d4 * Math.sin(d5);
 				final double newY = (localLocation1.getY() + 1.0D + d4 * Math.cos(d6));
 				final Location localLocation2 = new Location(this.player.getWorld(), d7, newY, d8);
-				playLightningbendingParticle(localLocation2);
+				playLightningbendingParticle(this, localLocation2, 1);
 				this.particleRotation += 1.0D / d3;
 				if (ThreadLocalRandom.current().nextDouble() < .2) {
 					playLightningbendingChargingSound(this.player.getLocation());
@@ -502,7 +502,7 @@ public class Lightning extends LightningAbility {
 		 */
 		@Override
 		public void run() {
-			playLightningbendingParticle(this.location, 0F, 0F, 0F);
+			playLightningbendingParticle(Lightning.this, this.location, 1, 0F, 0F, 0F);
 			this.count++;
 			if (this.count > 5) {
 				this.cancel();

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -204,7 +204,7 @@ public class Lightning extends LightningAbility {
 				if (this.player.isSneaking()) {
 					final Location loc = this.player.getEyeLocation().add(this.player.getEyeLocation().getDirection().normalize().multiply(1.2));
 					loc.add(0, 0.3, 0);
-					playLightningbendingParticle(this, loc, 1, 0.2F, 0.2F, 0.2F);
+					playLightningbendingParticles(this, loc, 1, 0.2F, 0.2F, 0.2F);
 					if (ThreadLocalRandom.current().nextDouble() < .2) {
 						playLightningbendingChargingSound(loc);
 					}
@@ -238,7 +238,7 @@ public class Lightning extends LightningAbility {
 				final double d8 = localLocation1.getZ() + d4 * Math.sin(d5);
 				final double newY = (localLocation1.getY() + 1.0D + d4 * Math.cos(d6));
 				final Location localLocation2 = new Location(this.player.getWorld(), d7, newY, d8);
-				playLightningbendingParticle(this, localLocation2, 1);
+				playLightningbendingParticles(this, localLocation2, 1);
 				this.particleRotation += 1.0D / d3;
 				if (ThreadLocalRandom.current().nextDouble() < .2) {
 					playLightningbendingChargingSound(this.player.getLocation());
@@ -502,7 +502,7 @@ public class Lightning extends LightningAbility {
 		 */
 		@Override
 		public void run() {
-			playLightningbendingParticle(Lightning.this, this.location, 1, 0F, 0F, 0F);
+			playLightningbendingParticles(Lightning.this, this.location, 1, 0F, 0F, 0F);
 			this.count++;
 			if (this.count > 5) {
 				this.cancel();

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -246,7 +246,7 @@ public class OctopusForm extends WaterAbility {
 			final Location location = this.player.getLocation();
 
 			if (this.sourceSelected) {
-				playFocusWaterEffect(this.sourceBlock);
+				playFocusWaterEffect(this, this.sourceBlock);
 			} else if (this.settingUp) {
 				if (this.sourceBlock.getY() < location.getBlockY()) {
 					this.source.revertBlock();

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -210,7 +210,7 @@ public class Torrent extends WaterAbility {
 					this.source = new TempBlock(this.sourceBlock, Material.WATER);
 					this.location = this.sourceBlock.getLocation();
 				} else {
-					playFocusWaterEffect(this.sourceBlock);
+					playFocusWaterEffect(this, this.sourceBlock);
 					return;
 				}
 			}

--- a/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -205,7 +205,7 @@ public class WaterManipulation extends WaterAbility {
 						this.remove();
 						return;
 					}
-					ParticleEffect.SMOKE_NORMAL.display(this.sourceBlock.getLocation().clone().add(0.5, 0.5, 0.5), 4, 0, 0, 0);
+					playFocusWaterEffect(this, this.sourceBlock);
 					return;
 				}
 

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -193,7 +193,7 @@ public class WaterSpoutWave extends WaterAbility {
 				this.setType(AbilityType.SHIFT);
 				return;
 			}
-			playFocusWaterEffect(this.origin.getBlock());
+			playFocusWaterEffect(this, this.origin.getBlock());
 		} else if (this.type == AbilityType.SHIFT) {
 			if (this.direction == null) {
 				this.direction = this.player.getEyeLocation().getDirection();

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
@@ -322,7 +322,7 @@ public class IceBlast extends IceAbility {
 			}
 			this.location = this.location.add(direction.clone());
 		} else if (this.prepared) {
-			playFocusWaterEffect(this.sourceBlock);
+			playFocusWaterEffect(this, this.sourceBlock);
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -222,7 +222,7 @@ public class IceSpikeBlast extends IceAbility {
 			this.source.setRevertTime(130);
 		} else if (this.prepared) {
 			if (this.sourceBlock != null) {
-				playFocusWaterEffect(this.sourceBlock);
+				playFocusWaterEffect(this, this.sourceBlock);
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -396,7 +396,7 @@ public class WaterArms extends WaterAbility {
 					for (final Location loc : arc.getPoints()) {
 						if (arm.getLocation().getWorld().equals(loc.getWorld()) && loc.distance(arm.getLocation()) <= 2.5) {
 							for (final Location l1 : getOffsetLocations(4, arm.getLocation(), 1.25)) {
-								FireAbility.playLightningbendingParticle(l1);
+								FireAbility.playLightningbendingParticle(this, l1, 1);
 							}
 							if (this.lightningKill) {
 								DamageHandler.damageEntity(this.player, 60D, lightning);

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -396,7 +396,7 @@ public class WaterArms extends WaterAbility {
 					for (final Location loc : arc.getPoints()) {
 						if (arm.getLocation().getWorld().equals(loc.getWorld()) && loc.distance(arm.getLocation()) <= 2.5) {
 							for (final Location l1 : getOffsetLocations(4, arm.getLocation(), 1.25)) {
-								FireAbility.playLightningbendingParticle(this, l1, 1);
+								FireAbility.playLightningbendingParticles(this, l1, 1);
 							}
 							if (this.lightningKill) {
 								DamageHandler.damageEntity(this.player, 60D, lightning);


### PR DESCRIPTION
I chose to recreate the function, with an added on CoreAbility argument, instead of a method, cause it would have to have its name changed, therefore breaking the playXbendingParticles scheme. The faster this is done, the better for all of us particle maniacs.

## Misc. Changes
    > Deprecated playAirbendingParticles, playSandbendingParticle, playFocusWaterEffect, and playLightningbendingParticles.
    > Updated all of these function calls to reflect the change
    > Added JavaDocs there where they were absent.