### PR TITLE
Fix WaterArmsSpear Ice not reverting

### DIFF
--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
@@ -199,8 +199,7 @@ public class WaterArmsSpear extends WaterAbility {
 						getIceBlocks().remove(block);
 					}
 
-					final TempBlock tempBlock = new TempBlock(block, Material.AIR);
-					tempBlock.setType(Material.ICE);
+					new TempBlock(block, Material.ICE);
 
 					getIceBlocks().put(block, System.currentTimeMillis() + this.spearDuration + (long) (Math.random() * 500));
 				}


### PR DESCRIPTION
## Fixes
* Fixes WaterArmsSpear spear ice not reverting when the ability ends or the plugin reloads.