### PR TITLE
Fix Blaze Fire placement

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -131,8 +131,8 @@ public abstract class FireAbility extends ElementalAbility {
 	 * @return True if fire can be placed here
 	 */
 	public static boolean isIgnitable(final Block block) {
-		return (block.getRelative(BlockFace.DOWN).getType().isSolid() && !block.getType().isSolid())
-				|| (GeneralMethods.isTransparent(block) && IGNITE_FACES.stream().map(face -> block.getRelative(face).getType()).anyMatch(FireAbility::isIgnitable));
+		return (!block.isLiquid() && GeneralMethods.isTransparent(block)) && ((block.getRelative(BlockFace.DOWN).getType().isSolid())
+				|| (IGNITE_FACES.stream().map(face -> block.getRelative(face).getType()).anyMatch(FireAbility::isIgnitable)));
 	}
 
 	public static boolean isIgnitable(final Material material) {
@@ -146,11 +146,10 @@ public abstract class FireAbility extends ElementalAbility {
 	 * @return The fire blockstate
 	 */
 	public static BlockData createFireState(Block position, boolean blue) {
-		if (blue) return Material.SOUL_FIRE.createBlockData();
-
 		Fire fire = (Fire) Material.FIRE.createBlockData();
+		
 		if (position.getRelative(BlockFace.DOWN).getType().isSolid())
-			return fire; //Default fire for when there is a solid block bellow
+			return (blue) ? Material.SOUL_FIRE.createBlockData() : fire; //Default fire for when there is a solid block bellow
 		for (BlockFace face : IGNITE_FACES) {
 			if (isIgnitable(position.getRelative(face).getType())) {
 				fire.setFace(face, true);

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -90,7 +90,7 @@ public abstract class FireAbility extends ElementalAbility {
 
 	public void createTempFire(final Location loc, final long time) {
 		if(isIgnitable(loc.getBlock())) {
-			new TempBlock(loc.getBlock(), createFireState(loc.getBlock(), getFireType().equals(Material.valueOf("SOUL_FIRE"))), time);
+			new TempBlock(loc.getBlock(), createFireState(loc.getBlock(), getFireType() == Material.SOUL_FIRE), time);
 			SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
 		}
 	}

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -16,7 +16,9 @@ import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Fire;
 import org.bukkit.entity.Player;
 
@@ -131,7 +133,7 @@ public abstract class FireAbility extends ElementalAbility {
 	 * @return True if fire can be placed here
 	 */
 	public static boolean isIgnitable(final Block block) {
-		return (!block.isLiquid() && GeneralMethods.isTransparent(block)) && ((block.getRelative(BlockFace.DOWN).getType().isSolid())
+		return (!isWater(block) && !block.isLiquid() && GeneralMethods.isTransparent(block)) && ((block.getRelative(BlockFace.DOWN).getType().isSolid())
 				|| (IGNITE_FACES.stream().map(face -> block.getRelative(face).getType()).anyMatch(FireAbility::isIgnitable)));
 	}
 

--- a/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -21,6 +21,8 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Fire;
 import org.bukkit.entity.Player;
+import org.bukkit.util.BoundingBox;
+import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -88,7 +90,7 @@ public abstract class FireAbility extends ElementalAbility {
 
 	public void createTempFire(final Location loc, final long time) {
 		if(isIgnitable(loc.getBlock())) {
-			new TempBlock(loc.getBlock(), getFireType().createBlockData(), time);
+			new TempBlock(loc.getBlock(), createFireState(loc.getBlock(), getFireType().equals(Material.valueOf("SOUL_FIRE"))), time);
 			SOURCE_PLAYERS.put(loc.getBlock(), this.getPlayer());
 		}
 	}
@@ -133,7 +135,10 @@ public abstract class FireAbility extends ElementalAbility {
 	 * @return True if fire can be placed here
 	 */
 	public static boolean isIgnitable(final Block block) {
-		return (!isWater(block) && !block.isLiquid() && GeneralMethods.isTransparent(block)) && ((block.getRelative(BlockFace.DOWN).getType().isSolid())
+		Block support = block.getRelative(BlockFace.DOWN);
+		Location loc = support.getLocation();
+		boolean supported = support.getBoundingBox().overlaps(loc.add(0, 0.8, 0).toVector(), loc.add(1, 1, 1).toVector());
+		return (!isWater(block) && !block.isLiquid() && GeneralMethods.isTransparent(block)) && ((supported && support.getType().isSolid())
 				|| (IGNITE_FACES.stream().map(face -> block.getRelative(face).getType()).anyMatch(FireAbility::isIgnitable)));
 	}
 
@@ -150,13 +155,16 @@ public abstract class FireAbility extends ElementalAbility {
 	public static BlockData createFireState(Block position, boolean blue) {
 		Fire fire = (Fire) Material.FIRE.createBlockData();
 		
-		if (position.getRelative(BlockFace.DOWN).getType().isSolid())
+		if (isIgnitable(position) && position.getRelative(BlockFace.DOWN).getType().isSolid())
 			return (blue) ? Material.SOUL_FIRE.createBlockData() : fire; //Default fire for when there is a solid block bellow
+
 		for (BlockFace face : IGNITE_FACES) {
-			if (isIgnitable(position.getRelative(face).getType())) {
+			fire.setFace(face, false);
+			if (isIgnitable(position.getRelative(face))) {
 				fire.setFace(face, true);
 			}
 		}
+
 		return fire;
 	}
 

--- a/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
+++ b/src/com/projectkorra/projectkorra/firebending/BlazeArc.java
@@ -100,7 +100,7 @@ public class BlazeArc extends FireAbility {
 		Block[] blockArr = { block.getRelative(BlockFace.UP), block, block.getRelative(BlockFace.DOWN) };
 
 		for (int i = 0; i < 3; i++) {
-			if (isFire(blockArr[i].getType()) || isIgnitable(blockArr[i])) {
+			if (isFire(blockArr[i].getType()) || (isIgnitable(blockArr[i]) && blockArr[i].getRelative(BlockFace.DOWN).getType().isSolid())) {
 				return blockArr[i];
 			}
 		}


### PR DESCRIPTION
## Fixes
* Fixes Blaze placing Fire blocks in water and potentially other places it should not.
  * Resolves issue with `FireAbility#isIgnitable(Block)` where it was not respecting liquids.

## Misc. Changes
* Changes `FireAbility#createFireState(Block, boolean)` to avoid placing floating Soul Fire.
  * Now, regular fire side blocks will be placed where a full Soul Fire block cannot be supported from below.
