### PR TITLE
Add Lightning + Copper and Entity interactions

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1616,6 +1616,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.Lightning.MaxChainArcs", 2);
 			config.addDefault("Abilities.Fire.Lightning.WaterArcs", 4);
 			config.addDefault("Abilities.Fire.Lightning.WaterArcRange", 20.0);
+			config.addDefault("Abilities.Fire.Lightning.MaxCopperArcs", 8);
 			config.addDefault("Abilities.Fire.Lightning.SelfHitWater", true);
 			config.addDefault("Abilities.Fire.Lightning.SelfHitClose", false);
 			config.addDefault("Abilities.Fire.Lightning.ArcOnIce", false);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1616,6 +1616,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.Lightning.MaxChainArcs", 2);
 			config.addDefault("Abilities.Fire.Lightning.WaterArcs", 4);
 			config.addDefault("Abilities.Fire.Lightning.WaterArcRange", 20.0);
+			config.addDefault("Abilities.Fire.Lightning.ConductivityRange", 5.0);
 			config.addDefault("Abilities.Fire.Lightning.MaxCopperArcs", 8);
 			config.addDefault("Abilities.Fire.Lightning.SelfHitWater", true);
 			config.addDefault("Abilities.Fire.Lightning.SelfHitClose", false);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1619,7 +1619,11 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.Lightning.SelfHitWater", true);
 			config.addDefault("Abilities.Fire.Lightning.SelfHitClose", false);
 			config.addDefault("Abilities.Fire.Lightning.ArcOnIce", false);
+			config.addDefault("Abilities.Fire.Lightning.ArcOnCopper", true);
 			config.addDefault("Abilities.Fire.Lightning.AllowOnFireJet", true);
+			config.addDefault("Abilities.Fire.Lightning.TransformMobs", true);
+			config.addDefault("Abilities.Fire.Lightning.ChargeCreeper", true);
+			config.addDefault("Abilities.Fire.Lightning.ChainLightningRods", true);
 
 			config.addDefault("Abilities.Fire.WallOfFire.Enabled", true);
 			config.addDefault("Abilities.Fire.WallOfFire.Range", 3);

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -330,9 +330,6 @@ public class Lightning extends LightningAbility {
 				this.copperChainVertex++;
 				this.currentCopperChainArc = null;
 			}
-		} else if (this.copperChainVertex + 1 >= chargedCopperBlocks.length) {
-			this.arcs.clear();
-			this.removeWithTasks();
 		}
 	}
 	
@@ -742,10 +739,8 @@ public class Lightning extends LightningAbility {
 					} else if (isCopper(block) && !block.hasMetadata("chargedcopper")) {
 						Lightning.this.hitCopper = true;
 						
-						if (Lightning.this.chargedCopperBlocks[0] == null) {
-							setupCopperGraph(block);
-							Lightning.this.startChaining = true;
-						}
+						setupCopperGraph(block);
+						Lightning.this.startChaining = true;
 					}
 					powerLightningRods(block);
 				}

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -828,6 +828,30 @@ public class Lightning extends LightningAbility {
 	public void setHitCopper(final boolean hitCopper) {
 		this.hitCopper = hitCopper;
 	}
+	
+	public boolean isTransformMobs() {
+		return this.transformMobs;
+	}
+	
+	public void setTransformMobs(final boolean transformMobs) {
+		this.transformMobs = transformMobs;
+	}
+	
+	public boolean isChargeCreeper() {
+		return this.chargeCreeper;
+	}
+	
+	public void setChargeCreeper(final boolean chargeCreeper) {
+		this.chargeCreeper = chargeCreeper;
+	}
+	
+	public boolean isChainLightningRods() {
+		return this.chainLightningRods;
+	}
+	
+	public void setChainLightningRods(final boolean chainLightningRods) {
+		this.chainLightningRods = chainLightningRods;
+	}
 
 	public boolean isSelfHitWater() {
 		return this.selfHitWater;

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -116,9 +116,6 @@ public class Lightning extends LightningAbility {
 			if (!getAbility(player, Lightning.class).isCharged()) {
 				return;
 			}
-			if (getAbility(player, Lightning.class).state == State.CHAIN) {
-				getAbility(player, Lightning.class).remove();
-			}
 		}
 
 		this.charged = false;

--- a/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
+++ b/src/com/projectkorra/projectkorra/firebending/lightning/Lightning.java
@@ -207,7 +207,9 @@ public class Lightning extends LightningAbility {
 		} else if (this.transformMobs && LIGHTNING_AFFECTED.contains(entity.getType())) {
 			switch (entity.getType()) {
 				case CREEPER:
-					((Creeper) entity).setPowered(true);
+					if (this.chargeCreeper) {
+						((Creeper) entity).setPowered(true);
+					}
 					break;
 				case VILLAGER:
 					entity.getWorld().spawnEntity(entity.getLocation(), EntityType.WITCH);
@@ -228,8 +230,8 @@ public class Lightning extends LightningAbility {
 				default:
 					break;
 			}
-			return;
 		}
+		return;
 	}
 	
 	/**


### PR DESCRIPTION
## Additions
* Lightning affects entities the same way vanilla lightning affects entities.
    * Adds new configurable options to transform all entities (`Abilities.Fire.Lightning.TransformMobs`) and charge creepers (`Abilities.Fire.Lightning.ChargeCreeper`) separately. If TransformMobs is false, but ChargeCreeper is true, only creepers are affected. If TransformMobs is true, but ChargeCreepers is false, only transformable mobs (in addition to turtles) are affected. If both are false, entities are not affected.
    * Creepers become charged, villagers turn into witches, pigs turn into zombified piglins, mushroom cows change color variants, and turtles die in one hit and drop bowls

* Lightning conducts copper blocks within a radius specified by the new `Abilities.Fire.Lightning.ConductivityRange` config option.
    * Lightning rods can attract lightning **if you aim at them**. Additionally, you can chain power lightning rods if stacked atop one another; this is configurable using the new `Abilities.Fire.Lightning.ChainLightningRods` config option.
    * Copper blocks can chain and conduct lightning if struct by the ability. This is configurable using the new `Abilities.Fire.Lightning.ArcOnCopper` and `Abilities.Fire.Lightning.MaxCopperArcs` config option.