### PR TITLE
Fix TremorSense makes mining faster

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -253,6 +253,17 @@ public class PKListener implements Listener {
 			}
 		}
 
+		if (bPlayer.isElementToggled(Element.EARTH) && bPlayer.isPassiveToggled(Element.EARTH)) {
+			Tremorsense tremorsense = CoreAbility.getAbility(player, Tremorsense.class);
+			if (tremorsense != null) {
+				if (block.equals(tremorsense.getBlock())) {
+					event.setCancelled(true);
+					// Has to be a scheduler to make the Glowstone block re-appear
+					Bukkit.getScheduler().runTask(plugin, tremorsense::showGlowBlock);
+				}
+			}
+		}
+
 		if (bPlayer.isElementToggled(Element.WATER) && bPlayer.isToggled()) {
 			if (abil != null && abil.equalsIgnoreCase("Surge")) {
 				ability = CoreAbility.getAbility(SurgeWall.class);

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -257,9 +257,10 @@ public class PKListener implements Listener {
 			Tremorsense tremorsense = CoreAbility.getAbility(player, Tremorsense.class);
 			if (tremorsense != null) {
 				if (block.equals(tremorsense.getBlock())) {
-					event.setCancelled(true);
-					// Has to be a scheduler to make the Glowstone block re-appear
-					Bukkit.getScheduler().runTask(plugin, tremorsense::showGlowBlock);
+					if (!tremorsense.canBreak()) {
+						tremorsense.setUpBreaking();
+						event.setCancelled(true);
+					}
 				}
 			}
 		}

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -102,11 +102,11 @@ public class Tremorsense extends EarthAbility {
 		
 		if (isBendable && this.block == null) {
 			this.block = standBlock;
-			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE.createBlockData());
+			showGlowBlock();
 		} else if (isBendable && !this.block.equals(standBlock)) {
 			this.revertGlowBlock();
 			this.block = standBlock;
-			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE.createBlockData());
+			showGlowBlock();
 		} else if (this.block == null) {
 			return;
 		} else if (!this.player.getWorld().equals(this.block.getWorld())) {
@@ -128,6 +128,12 @@ public class Tremorsense extends EarthAbility {
 	public void revertGlowBlock() {
 		if (this.block != null) {
 			this.player.sendBlockChange(this.block.getLocation(), this.block.getBlockData());
+		}
+	}
+
+	public void showGlowBlock() {
+		if (this.block != null) {
+			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE.createBlockData());
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -125,6 +125,19 @@ public class Tremorsense extends EarthAbility {
 		}
 	}
 
+	private boolean canBreak = false;
+	private Block breakBlock;
+
+	public boolean canBreak() {
+		return canBreak;
+	}
+
+	public void setUpBreaking() {
+		this.canBreak = true;
+		this.breakBlock = this.block;
+		revertGlowBlock();
+	}
+
 	public void revertGlowBlock() {
 		if (this.block != null) {
 			this.player.sendBlockChange(this.block.getLocation(), this.block.getBlockData());
@@ -133,6 +146,10 @@ public class Tremorsense extends EarthAbility {
 
 	public void showGlowBlock() {
 		if (this.block != null) {
+			if (this.canBreak && this.block.getX() == this.breakBlock.getX() && this.block.getZ() == this.breakBlock.getZ()) {
+				return;
+			}
+			this.canBreak = false;
 			this.player.sendBlockChange(this.block.getLocation(), Material.GLOWSTONE.createBlockData());
 		}
 	}


### PR DESCRIPTION
## Fixes
- Fixed issue #1010 
  - Player breaks the Glowstone, that gets cancelled and the correct block shows up.
  - Player breaks the block again, and this time the block get properly broken.
  - As an addition, if the player stays within the same X and Z coords, the glowstone doesn't show up. This enables digging straight down without breaking the Glowstone again and again.