### PR TITLE
FireDamageTimer can be applied to lava tempblocks

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -557,10 +557,22 @@ public class PKListener implements Listener {
 		if (event.getCause() == DamageCause.FIRE && FireAbility.getSourcePlayers().containsKey(entity.getLocation().getBlock())) {
 			new FireDamageTimer(entity, FireAbility.getSourcePlayers().get(entity.getLocation().getBlock()));
 		}
-
-		if (FireDamageTimer.isEnflamed(entity) && event.getCause() == DamageCause.FIRE_TICK) {
+		
+		if (event.getCause() == DamageCause.LAVA && entity instanceof Player) {
+			for (int i = 0; i < 3; i++) {
+				Block lava = entity.getLocation().clone().add(0, i, 0).getBlock();
+				if (EarthAbility.isLava(lava)) {
+					if (TempBlock.get(lava) != null) {
+						TempBlock.get(lava).getAbility().ifPresent(ability -> new FireDamageTimer(entity, ability.getPlayer(), ability));
+					}
+				}
+			}
+		}
+		
+		if ((FireDamageTimer.isEnflamed(entity) && event.getCause() == DamageCause.FIRE_TICK) || (event.getCause() == DamageCause.LAVA && TempBlock.get(entity.getLocation().getBlock()) != null && EarthAbility.isLava(entity.getLocation().getBlock()))) {
 			event.setCancelled(true);
-			FireDamageTimer.dealFlameDamage(entity);
+			FireDamageTimer.dealFlameDamage(entity, event.getCause());
+			entity.setVelocity(new Vector(0, 0, 0));
 		}
 
 		if (entity instanceof Player) {

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -547,6 +547,10 @@ public class PKListener implements Listener {
 		if (TempBlock.isTempBlock(block)) {
 			if (EarthAbility.isEarthbendable(block.getType(), true, true, true) && GeneralMethods.isSolid(block)) {
 				event.setCancelled(true);
+			} else if (event.getCause() == DamageCause.LAVA && EarthAbility.isLava(block)) {
+				TempBlock.get(block).getAbility().ifPresent(ability -> new FireDamageTimer(event.getEntity(), ability.getPlayer(), ability, true));
+				event.setCancelled(true);
+				FireDamageTimer.dealFlameDamage(event.getEntity(), event.getDamage());
 			}
 		}
 	}
@@ -560,15 +564,7 @@ public class PKListener implements Listener {
 			new FireDamageTimer(entity, FireAbility.getSourcePlayers().get(entity.getLocation().getBlock()), null, true);
 		}
 		
-		if (event.getCause() == DamageCause.LAVA && entity instanceof Player) {
-			for (Block lava : GeneralMethods.getBlocksAroundPoint(entity.getLocation().clone().add(0, 1, 0), 1.375)) {
-				if (EarthAbility.isLava(lava) && TempBlock.get(lava) != null) {
-					TempBlock.get(lava).getAbility().ifPresent(ability -> new FireDamageTimer(entity, ability.getPlayer(), ability, true));
-				}
-			}
-		}
-		
-		if ((FireDamageTimer.isEnflamed(entity) && event.getCause() == DamageCause.FIRE_TICK) || (event.getCause() == DamageCause.LAVA && TempBlock.get(entity.getLocation().getBlock()) != null && EarthAbility.isLava(entity.getLocation().getBlock()))) {
+		if (FireDamageTimer.isEnflamed(entity) && event.getCause() == DamageCause.FIRE_TICK) {
 			event.setCancelled(true);
 			FireDamageTimer.dealFlameDamage(entity, damage);
 		}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -561,8 +561,7 @@ public class PKListener implements Listener {
 		}
 		
 		if (event.getCause() == DamageCause.LAVA && entity instanceof Player) {
-			for (int i = 0; i < 3; i++) {
-				Block lava = entity.getLocation().clone().add(0, i, 0).getBlock();
+			for (Block lava : GeneralMethods.getBlocksAroundPoint(entity.getLocation().clone().add(0, 1, 0), 1.375)) {
 				if (EarthAbility.isLava(lava) && TempBlock.get(lava) != null) {
 					TempBlock.get(lava).getAbility().ifPresent(ability -> new FireDamageTimer(entity, ability.getPlayer(), ability, true));
 				}

--- a/src/com/projectkorra/projectkorra/earthbending/lava/LavaFlow.java
+++ b/src/com/projectkorra/projectkorra/earthbending/lava/LavaFlow.java
@@ -415,7 +415,7 @@ public class LavaFlow extends LavaAbility {
 				block.setType(Material.LAVA);
 				block.setBlockData(GeneralMethods.getLavaData(0));
 			} else {
-				tblock = new TempBlock(block, Material.LAVA);
+				tblock = new TempBlock(block, Material.LAVA.createBlockData(), this);
 			}
 
 			if (tblock != null) {

--- a/src/com/projectkorra/projectkorra/firebending/util/FireDamageTimer.java
+++ b/src/com/projectkorra/projectkorra/firebending/util/FireDamageTimer.java
@@ -12,7 +12,6 @@ import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.firebending.HeatControl;
 import com.projectkorra.projectkorra.util.DamageHandler;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 public class FireDamageTimer {
 
@@ -31,11 +30,15 @@ public class FireDamageTimer {
 	 */
 	@Deprecated
 	public FireDamageTimer(final Entity entity, final Player source) {
-		this(entity, source, null);
+		this(entity, source, null, false);
+	}
+	
+	public FireDamageTimer(final Entity entity, final Player source, Ability abil) {
+		this(entity, source, abil, false);
 	}
 
-	public FireDamageTimer(final Entity entity, final Player source, Ability abil) {
-		if (entity.getEntityId() == source.getEntityId()) {
+	public FireDamageTimer(final Entity entity, final Player source, Ability abil, final boolean affectSelf) {
+		if (entity.getEntityId() == source.getEntityId() && !affectSelf) {
 			return;
 		}
 
@@ -58,7 +61,7 @@ public class FireDamageTimer {
 		}
 	}
 	
-	public static void dealFlameDamage(final Entity entity, final DamageCause cause) {
+	public static void dealFlameDamage(final Entity entity, final double damage) {
 		if (INSTANCES.containsKey(entity) && entity instanceof LivingEntity) {
 			if (entity instanceof Player) {
 				if (!HeatControl.canBurn((Player) entity)) {
@@ -68,15 +71,11 @@ public class FireDamageTimer {
 			final LivingEntity Lentity = (LivingEntity) entity;
 			final Player source = INSTANCES.get(entity);
 			
-			double damage = DAMAGE;
-			if (cause == DamageCause.LAVA) {
-				damage = 4;
-			}
 			// damages the entity.
 			if (ability == null) {
-				DamageHandler.damageEntity(Lentity, source, damage, CoreAbility.getAbilitiesByElement(Element.FIRE).get(0));
+				DamageHandler.damageEntity(Lentity, source, damage, CoreAbility.getAbilitiesByElement(Element.FIRE).get(0), false, true);
 			} else {
-				DamageHandler.damageEntity(Lentity, source, damage, ability);
+				DamageHandler.damageEntity(Lentity, source, damage, ability, false, true);
 			}
 			
 			if (entity.getFireTicks() > MAX_TICKS) {
@@ -86,7 +85,7 @@ public class FireDamageTimer {
 	}
 
 	public static void dealFlameDamage(final Entity entity) {
-		dealFlameDamage(entity, DamageCause.FIRE_TICK);
+		dealFlameDamage(entity, DAMAGE);
 	}
 
 	public static void handleFlames() {

--- a/src/com/projectkorra/projectkorra/firebending/util/FireDamageTimer.java
+++ b/src/com/projectkorra/projectkorra/firebending/util/FireDamageTimer.java
@@ -12,12 +12,13 @@ import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.firebending.HeatControl;
 import com.projectkorra.projectkorra.util.DamageHandler;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 public class FireDamageTimer {
 
 	private static final int MAX_TICKS = 90;
 	private static Ability ability = null;
-	private static final int DAMAGE = 1;
+	private static final double DAMAGE = 1;
 	private static final long BUFFER = 30;
 	private static final Map<Entity, Player> INSTANCES = new ConcurrentHashMap<>();
 	private static final Map<Entity, Long> TIMES = new ConcurrentHashMap<>();
@@ -56,8 +57,8 @@ public class FireDamageTimer {
 			return false;
 		}
 	}
-
-	public static void dealFlameDamage(final Entity entity) {
+	
+	public static void dealFlameDamage(final Entity entity, final DamageCause cause) {
 		if (INSTANCES.containsKey(entity) && entity instanceof LivingEntity) {
 			if (entity instanceof Player) {
 				if (!HeatControl.canBurn((Player) entity)) {
@@ -66,18 +67,26 @@ public class FireDamageTimer {
 			}
 			final LivingEntity Lentity = (LivingEntity) entity;
 			final Player source = INSTANCES.get(entity);
-
+			
+			double damage = DAMAGE;
+			if (cause == DamageCause.LAVA) {
+				damage = 4;
+			}
 			// damages the entity.
 			if (ability == null) {
-				DamageHandler.damageEntity(Lentity, source, DAMAGE, CoreAbility.getAbilitiesByElement(Element.FIRE).get(0));
+				DamageHandler.damageEntity(Lentity, source, damage, CoreAbility.getAbilitiesByElement(Element.FIRE).get(0));
 			} else {
-				DamageHandler.damageEntity(Lentity, source, DAMAGE, ability);
+				DamageHandler.damageEntity(Lentity, source, damage, ability);
 			}
-
+			
 			if (entity.getFireTicks() > MAX_TICKS) {
 				entity.setFireTicks(MAX_TICKS);
 			}
 		}
+	}
+
+	public static void dealFlameDamage(final Entity entity) {
+		dealFlameDamage(entity, DamageCause.FIRE_TICK);
 	}
 
 	public static void handleFlames() {

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -131,7 +131,7 @@ public class DamageHandler {
 	 * @param entity The entity that is receiving the damage
 	 * @param damage The amount of damage to deal
 	 */
-	public static void damageEntity(final Entity entity, Player source, double damage, final Ability ability, boolean ignoreArmor, boolean sourcelessDamage) {
+	public static void damageEntity(final Entity entity, Player source, double damage, final Ability ability, boolean ignoreArmor, boolean doSourcelessDamage) {
 		if (ability == null) {
 			return;
 		}
@@ -193,7 +193,7 @@ public class DamageHandler {
 
 			final EntityDamageByEntityEvent finalEvent = new EntityDamageByEntityEvent(source, entity, DamageCause.CUSTOM, damage);
 			final double prevHealth = lent.getHealth();
-			if (sourcelessDamage) {
+			if (doSourcelessDamage) {
 				lent.damage(damage);
 			} else {
 				lent.damage(damage, source);
@@ -218,6 +218,14 @@ public class DamageHandler {
 			}
 		}
 
+	}
+	
+	public static void damageEntity(final Entity entity, final Player source, final double damage, final Ability ability, final boolean ignoreArmor) {
+		damageEntity(entity, source, damage, ability, ignoreArmor);
+	}
+	
+	public static void damageEntity(final Entity entity, final double damage, final Ability ability, final boolean ignoreArmor) {
+		damageEntity(entity, ability.getPlayer(), damage, ability, ignoreArmor, false);
 	}
 
 	public static void damageEntity(final Entity entity, final Player source, final double damage, final Ability ability) {

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -131,7 +131,7 @@ public class DamageHandler {
 	 * @param entity The entity that is receiving the damage
 	 * @param damage The amount of damage to deal
 	 */
-	public static void damageEntity(final Entity entity, Player source, double damage, final Ability ability, boolean ignoreArmor) {
+	public static void damageEntity(final Entity entity, Player source, double damage, final Ability ability, boolean ignoreArmor, boolean sourcelessDamage) {
 		if (ability == null) {
 			return;
 		}
@@ -193,7 +193,11 @@ public class DamageHandler {
 
 			final EntityDamageByEntityEvent finalEvent = new EntityDamageByEntityEvent(source, entity, DamageCause.CUSTOM, damage);
 			final double prevHealth = lent.getHealth();
-			lent.damage(damage, source);
+			if (sourcelessDamage) {
+				lent.damage(damage);
+			} else {
+				lent.damage(damage, source);
+			}
 			final double nextHealth = lent.getHealth();
 			entity.setLastDamageCause(finalEvent);
 
@@ -217,7 +221,7 @@ public class DamageHandler {
 	}
 
 	public static void damageEntity(final Entity entity, final Player source, final double damage, final Ability ability) {
-		damageEntity(entity, source, damage, ability, false);
+		damageEntity(entity, source, damage, ability, false, false);
 	}
 
 	public static void damageEntity(final Entity entity, final double damage, final Ability ability) {

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -3,10 +3,12 @@ package com.projectkorra.projectkorra.util;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -42,6 +44,7 @@ public class TempBlock {
 	private boolean inRevertQueue;
 	private boolean reverted;
 	private RevertTask revertTask = null;
+	private Optional<Ability> ability = Optional.empty(); // If we want this TempBlock to have an assigned ability created from it
 
 	public TempBlock(final Block block, final Material newtype) {
 		this(block, newtype.createBlockData(), 0);
@@ -57,6 +60,15 @@ public class TempBlock {
 	
 	public TempBlock(final Block block, final BlockData newData) {
 		this(block, newData, 0);
+	}
+	
+	public TempBlock(final Block block, final BlockData newData, final long revertTime, final Ability ability) {
+		this(block, newData, revertTime);
+		this.ability = Optional.of(ability);
+	}
+	
+	public TempBlock(final Block block, final BlockData newData, final Ability ability) {
+		this(block, newData, 0, ability);
 	}
 
 	public TempBlock(final Block block, BlockData newData, final long revertTime) {
@@ -176,6 +188,10 @@ public class TempBlock {
 
 	public BlockState getState() {
 		return this.state;
+	}
+	
+	public Optional<Ability> getAbility() {
+		return this.ability;
 	}
 
 	public RevertTask getRevertTask() {


### PR DESCRIPTION
## Additions
* When dealt fire damage (or lava damage) from TempBlocks that are lava blocks, a FireDamageTimer instance will be created. To do this, you will need to assign an ability whenever you create a new TempBlock (see 3rd point). See LavaFlow changes.
* Proper death message from death by lava from an ability.
* TempBlocks can now have an Ability attached to them (Optional) if needed. Available parameter during object instantiation to add the ability to the TempBlock. Can be accessed through TempBlock#getAbility (this returns an Optional<Ability>, as some TempBlocks may not have an attached ability). Can be useful for developers.
* FireDamageTimer damage no longer does unnecessary knockback.
* DamageHandler now supports sourceless LivingEntity#damage calls. This lets abilities provide damage without knockback, among other differences.

## Changes
* BENDING_PLAYER_DEATH in PKListener now stores Pair<String, Player> as its value, representing the ability name (left) and killer (right). The key still represents the victim.
* PlayerDeathEvent no longer checks for a killer via entity.getKiller(), because now, we have the option to inflict sourceless damage. Thus, we now check for a killer using BENDING_PLAYER_DEATH.