### PR TITLE
Rewrite Display Command

### DIFF
--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -216,20 +216,20 @@ public class DisplayCommand extends PKCommand {
 		this.iterateAbilities(sender, abilities);
 
 		//Display the number of Passives and Combos
-		if (!allCombos.isEmpty()) {
+		if (!combos.isEmpty()) {
 			sender.sendMessage("");
-			final ComponentBuilder messageBuilder = new ComponentBuilder().appendLegacy(subColor + "Combos (#)".replace("#", String.valueOf(allCombos.size())));
+			final ComponentBuilder messageBuilder = new ComponentBuilder().appendLegacy(subColor + "Combos (#)".replace("#", String.valueOf(combos.size())));
 			messageBuilder.event(hoverEvent(mainColor + this.color(this.hoverType.replace("{type}", subColor + elementName + "Combos"))));
 			messageBuilder.event(clickEvent("/bending display " + elementName + "Combos"));
 			sender.spigot().sendMessage(messageBuilder.create());
 		}
 		
-		if (!allPassives.isEmpty()) {
-			if (allCombos.isEmpty()) {
+		if (!passives.isEmpty()) {
+			if (combos.isEmpty()) {
 				sender.sendMessage("");
 			}
 			
-			final ComponentBuilder messageBuilder = new ComponentBuilder().appendLegacy(subColor + "Passives (#)".replace("#", String.valueOf(allPassives.size())));
+			final ComponentBuilder messageBuilder = new ComponentBuilder().appendLegacy(subColor + "Passives (#)".replace("#", String.valueOf(passives.size())));
 			messageBuilder.event(hoverEvent(mainColor + this.color(this.hoverType.replace("{type}", subColor + elementName + "Passives"))));
 			messageBuilder.event(clickEvent("/bending display " + elementName + "Passives"));
 			sender.spigot().sendMessage(messageBuilder.create());
@@ -237,10 +237,10 @@ public class DisplayCommand extends PKCommand {
 
 		// Display the subelements and the number of their abilities
 		if (Element.getSubElements(element).length > 0) {
-			sender.sendMessage("");
 			final ComponentBuilder message = new ComponentBuilder();
 			for (final SubElement sub : Element.getSubElements(element)) {
-				if (sender.hasPermission("bending." + elementName.toLowerCase() + "." + sub.getName().toLowerCase())) {
+				final int count = this.filterAbilities(sender, this.getAbilities(sub)).size() + this.filterAbilities(sender, this.getCombos(sub)).size() + this.filterAbilities(sender, PassiveManager.getPassivesForElement(sub)).size();
+				if (sender.hasPermission("bending." + elementName.toLowerCase() + "." + sub.getName().toLowerCase()) && count > 0) {
 					final ChatColor color = sub.getColor();
 					final String name = sub.getName();
 					
@@ -248,12 +248,15 @@ public class DisplayCommand extends PKCommand {
 						message.appendLegacy(this.color(this.separator));
 					}
 					
-					message.appendLegacy(color + name + " (#)".replace("#", String.valueOf(this.getAbilities(sub).size() + this.getCombos(sub).size() + PassiveManager.getPassivesForElement(sub).size())));
+					message.appendLegacy(color + name + " (#)".replace("#", String.valueOf(count)));
 					message.event(hoverEvent(color + this.color(this.hoverType.replace("{type}", color + name))));
 					message.event(clickEvent("/bending display " + name));
 				}
 			}
-			sender.spigot().sendMessage(message.create());
+			if (!message.getParts().isEmpty()) {
+				sender.sendMessage("");
+				sender.spigot().sendMessage(message.create());
+			}
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -213,14 +213,14 @@ public class DisplayCommand extends PKCommand {
 			}
 			
 			if (!messageBuilder.getParts().isEmpty()) {
-				messageBuilder.appendLegacy(this.color(this.separator));
+				messageBuilder.appendLegacy(ChatUtil.color(this.separator));
 			}
 
 			final ChatColor color = coreAbil.getElement().getColor();
 			final ChatColor subColor = coreAbil.getElement() instanceof SubElement ? color : coreAbil.getElement().getSubColor();
 			
-			messageBuilder.appendLegacy(this.color(this.format.replace("{ability}", color + abilityName)));
-			messageBuilder.event(this.hoverEvent(color + this.color(this.hoverAbility.replace("{ability}", subColor + abilityName))));
+			messageBuilder.appendLegacy(ChatUtil.color(this.format.replace("{ability}", color + abilityName)));
+			messageBuilder.event(this.hoverEvent(color + ChatUtil.color(this.hoverAbility.replace("{ability}", subColor + abilityName))));
 			messageBuilder.event(this.clickEvent("/bending help " + coreAbil.getName()));
 		}
 		sender.spigot().sendMessage(messageBuilder.create());
@@ -257,7 +257,7 @@ public class DisplayCommand extends PKCommand {
 		if (!combos.isEmpty()) {
 			sender.sendMessage("");
 			final ComponentBuilder messageBuilder = new ComponentBuilder().appendLegacy(subColor + "Combos (#)".replace("#", String.valueOf(combos.size())));
-			messageBuilder.event(this.hoverEvent(mainColor + this.color(this.hoverType.replace("{type}", subColor + elementName + "Combos"))));
+			messageBuilder.event(this.hoverEvent(mainColor + ChatUtil.color(this.hoverType.replace("{type}", subColor + elementName + "Combos"))));
 			messageBuilder.event(this.clickEvent("/bending display " + elementName + "Combos"));
 			sender.spigot().sendMessage(messageBuilder.create());
 		}
@@ -268,7 +268,7 @@ public class DisplayCommand extends PKCommand {
 			}
 			
 			final ComponentBuilder messageBuilder = new ComponentBuilder().appendLegacy(subColor + "Passives (#)".replace("#", String.valueOf(passives.size())));
-			messageBuilder.event(this.hoverEvent(mainColor + this.color(this.hoverType.replace("{type}", subColor + elementName + "Passives"))));
+			messageBuilder.event(this.hoverEvent(mainColor + ChatUtil.color(this.hoverType.replace("{type}", subColor + elementName + "Passives"))));
 			messageBuilder.event(this.clickEvent("/bending display " + elementName + "Passives"));
 			sender.spigot().sendMessage(messageBuilder.create());
 		}
@@ -283,11 +283,11 @@ public class DisplayCommand extends PKCommand {
 					final String name = sub.getName();
 					
 					if (!message.getParts().isEmpty()) {
-						message.appendLegacy(this.color(this.separator));
+						message.appendLegacy(ChatUtil.color(this.separator));
 					}
 					
 					message.appendLegacy(color + name + " (#)".replace("#", String.valueOf(count)));
-					message.event(this.hoverEvent(color + this.color(this.hoverType.replace("{type}", color + name))));
+					message.event(this.hoverEvent(color + ChatUtil.color(this.hoverType.replace("{type}", color + name))));
 					message.event(this.clickEvent("/bending display " + name));
 				}
 			}
@@ -405,6 +405,10 @@ public class DisplayCommand extends PKCommand {
 		abbreviations.put("wp", "waterpassive");
 	}
 	
+	public void addAbbreviation(String abbreviated, String unAbbreviated) {
+		abbreviations.put(abbreviated, unAbbreviated);
+	}
+	
 	private HoverEvent hoverEvent(String string) {
 		return new HoverEvent(HoverEvent.Action.SHOW_TEXT, text(string));
 	}
@@ -414,10 +418,6 @@ public class DisplayCommand extends PKCommand {
 	}
 	
 	private Text text(String string) {
-		return new Text(new ComponentBuilder().appendLegacy(color(string)).create());
-	}
-	
-	private String color(String string) {
-		return ChatColor.translateAlternateColorCodes('&', string);
+		return new Text(new ComponentBuilder().appendLegacy(ChatUtil.color(string)).create());
 	}
 }

--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -195,13 +195,13 @@ public class DisplayCommand extends PKCommand {
 			final ChatColor subColor = coreAbil.getElement() instanceof SubElement ? color : coreAbil.getElement().getSubColor();
 			
 			fullMessage.appendLegacy(this.format.replace("{ability}", color + abilityName).replace("{bind}", ""));
-			fullMessage.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(new ComponentBuilder().appendLegacy(color + this.hoverAbility.replace("{ability}", subColor + abilityName)).create())));
-			fullMessage.event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/bending help " + coreAbil.getName()));
+			fullMessage.event(hoverEvent(color + this.hoverAbility.replace("{ability}", subColor + abilityName)));
+			fullMessage.event(clickRun("/bending help " + coreAbil.getName()));
 			
-			if (! this.bindButton.equals("")) {
+			if (! this.bindButton.equals("") && !(coreAbil instanceof PassiveAbility) && !(coreAbil instanceof ComboAbility)) {
 				fullMessage.appendLegacy(subColor + this.bindButton);
-				fullMessage.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(new ComponentBuilder().appendLegacy(color + this.hoverBindButton.replace("{ability}", subColor + abilityName)).create())));
-				fullMessage.event(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/bending bind " + coreAbil.getName()));
+				fullMessage.event(hoverEvent(color + this.hoverBindButton.replace("{ability}", subColor + abilityName)));
+				fullMessage.event(clickSuggest("/bending bind " + coreAbil.getName()));
 			}
 		}
 		sender.spigot().sendMessage(fullMessage.create());
@@ -241,15 +241,15 @@ public class DisplayCommand extends PKCommand {
 		//Display the number of Passives and Combos
 		if (!correctCombos(element).isEmpty()) {
 			final ComponentBuilder combos = new ComponentBuilder().appendLegacy(subColor + "Combos (#)".replace("#", String.valueOf(correctCombos(element).size())));
-			combos.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(new ComponentBuilder().appendLegacy(mainColor + this.hoverType.replace("{type}", subColor + elementName + "Combos")).create())));
-			combos.event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/bending display " + elementName + "Combos"));
+			combos.event(hoverEvent(mainColor + this.hoverType.replace("{type}", subColor + elementName + "Combos")));
+			combos.event(clickRun("/bending display " + elementName + "Combos"));
 			sender.spigot().sendMessage(combos.create());
 		}
 		
 		if (!filterNames(sender, PassiveManager.getPassivesForElement(element)).isEmpty()) {
 			final ComponentBuilder passives = new ComponentBuilder().appendLegacy(subColor + "Passives (#)".replace("#", String.valueOf(filterNames(sender, PassiveManager.getPassivesForElement(element)).size())));
-			passives.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(new ComponentBuilder().appendLegacy(mainColor + this.hoverType.replace("{type}", subColor + elementName + "Passives")).create())));
-			passives.event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/bending display " + elementName + "Passives"));
+			passives.event(hoverEvent(mainColor + this.hoverType.replace("{type}", subColor + elementName + "Passives")));
+			passives.event(clickRun("/bending display " + elementName + "Passives"));
 			sender.spigot().sendMessage(passives.create());
 		}
 
@@ -259,14 +259,15 @@ public class DisplayCommand extends PKCommand {
 			for (final SubElement sub : Element.getSubElements(element)) {
 				if (sender.hasPermission("bending." + elementName.toLowerCase() + "." + sub.getName().toLowerCase())) {
 					final ChatColor color = sub.getColor();
+					final String name = sub.getName();
 					
 					if (!message.getParts().isEmpty()) {
 						message.appendLegacy(this.separator);
 					}
 					
-					message.appendLegacy(color + sub.getName() + " (#)".replace("#", String.valueOf(filterAbilities(sender, CoreAbility.getAbilitiesByElement(sub)).size())));
-					message.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(new ComponentBuilder().appendLegacy(color + this.hoverType.replace("{type}", color + sub.getName())).create())));
-					message.event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/bending display " + sub.getName()));
+					message.appendLegacy(color + name + " (#)".replace("#", String.valueOf(filterAbilities(sender, CoreAbility.getAbilitiesByElement(sub)).size())));
+					message.event(hoverEvent(color + this.hoverType.replace("{type}", color + name)));
+					message.event(clickRun("/bending display " + name));
 				}
 			}
 			sender.spigot().sendMessage(message.create());
@@ -384,5 +385,21 @@ public class DisplayCommand extends PKCommand {
 		list.add("ChiPassives");
 
 		return list;
+	}
+	
+	private HoverEvent hoverEvent(String string) {
+		return new HoverEvent(HoverEvent.Action.SHOW_TEXT, text(string));
+	}
+	
+	private ClickEvent clickSuggest(String string) {
+		return new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, string);
+	}
+	
+	private ClickEvent clickRun(String string) {
+		return new ClickEvent(ClickEvent.Action.RUN_COMMAND, string);
+	}
+	
+	private Text text(String string) {
+		return new Text(new ComponentBuilder().appendLegacy(string).create());
 	}
 }

--- a/src/com/projectkorra/projectkorra/command/DisplayCommand.java
+++ b/src/com/projectkorra/projectkorra/command/DisplayCommand.java
@@ -166,14 +166,14 @@ public class DisplayCommand extends PKCommand {
 			}
 			
 			if (!fullMessage.getParts().isEmpty()) {
-				fullMessage.appendLegacy(this.separator);
+				fullMessage.appendLegacy(this.color(this.separator));
 			}
 
 			final ChatColor color = coreAbil.getElement().getColor();
 			final ChatColor subColor = coreAbil.getElement() instanceof SubElement ? color : coreAbil.getElement().getSubColor();
 			
-			fullMessage.appendLegacy(this.format.replace("{ability}", color + abilityName));
-			fullMessage.event(hoverEvent(color + this.hoverAbility.replace("{ability}", subColor + abilityName)));
+			fullMessage.appendLegacy(this.color(this.format.replace("{ability}", color + abilityName)));
+			fullMessage.event(hoverEvent(color + this.color(this.hoverAbility.replace("{ability}", subColor + abilityName))));
 			fullMessage.event(clickEvent("/bending help " + coreAbil.getName()));
 		}
 		sender.spigot().sendMessage(fullMessage.create());
@@ -215,7 +215,7 @@ public class DisplayCommand extends PKCommand {
 		if (!comboList.isEmpty()) {
 			sender.sendMessage("");
 			final ComponentBuilder combos = new ComponentBuilder().appendLegacy(subColor + "Combos (#)".replace("#", String.valueOf(comboList.size())));
-			combos.event(hoverEvent(mainColor + this.hoverType.replace("{type}", subColor + elementName + "Combos")));
+			combos.event(hoverEvent(mainColor + this.color(this.hoverType.replace("{type}", subColor + elementName + "Combos"))));
 			combos.event(clickEvent("/bending display " + elementName + "Combos"));
 			sender.spigot().sendMessage(combos.create());
 		}
@@ -227,7 +227,7 @@ public class DisplayCommand extends PKCommand {
 			}
 			
 			final ComponentBuilder passives = new ComponentBuilder().appendLegacy(subColor + "Passives (#)".replace("#", String.valueOf(passiveList.size())));
-			passives.event(hoverEvent(mainColor + this.hoverType.replace("{type}", subColor + elementName + "Passives")));
+			passives.event(hoverEvent(mainColor + this.color(this.hoverType.replace("{type}", subColor + elementName + "Passives"))));
 			passives.event(clickEvent("/bending display " + elementName + "Passives"));
 			sender.spigot().sendMessage(passives.create());
 		}
@@ -242,11 +242,11 @@ public class DisplayCommand extends PKCommand {
 					final String name = sub.getName();
 					
 					if (!message.getParts().isEmpty()) {
-						message.appendLegacy(this.separator);
+						message.appendLegacy(this.color(this.separator));
 					}
 					
 					message.appendLegacy(color + name + " (#)".replace("#", String.valueOf(filterAbilities(sender, CoreAbility.getAbilitiesByElement(sub)).size())));
-					message.event(hoverEvent(color + this.hoverType.replace("{type}", color + name)));
+					message.event(hoverEvent(color + this.color(this.hoverType.replace("{type}", color + name))));
 					message.event(clickEvent("/bending display " + name));
 				}
 			}
@@ -390,6 +390,10 @@ public class DisplayCommand extends PKCommand {
 	}
 	
 	private Text text(String string) {
-		return new Text(new ComponentBuilder().appendLegacy(string).create());
+		return new Text(new ComponentBuilder().appendLegacy(color(string)).create());
+	}
+	
+	private String color(String string) {
+		return ChatColor.translateAlternateColorCodes('&', string);
 	}
 }

--- a/src/com/projectkorra/projectkorra/command/HelpCommand.java
+++ b/src/com/projectkorra/projectkorra/command/HelpCommand.java
@@ -132,7 +132,7 @@ public class HelpCommand extends PKCommand {
 				sender.sendMessage(ChatColor.WHITE + this.usage + ability.getInstructions());
 			}
 			
-			if (!isPassiveAbility && (!(sender instanceof Player) || sender.hasPermission("bending.ability." + arg))) {
+			if (!isPassiveAbility && sender instanceof Player && sender.hasPermission("bending.ability." + arg)) {
 				final ComponentBuilder bindShortcut = new ComponentBuilder();
 				for (int i = 1; i <= 9; i++) {
 					if (!bindShortcut.getParts().isEmpty()) {

--- a/src/com/projectkorra/projectkorra/command/HelpCommand.java
+++ b/src/com/projectkorra/projectkorra/command/HelpCommand.java
@@ -132,7 +132,7 @@ public class HelpCommand extends PKCommand {
 				sender.sendMessage(ChatColor.WHITE + this.usage + ability.getInstructions());
 			}
 			
-			if (!isPassiveAbility) {
+			if (!isPassiveAbility && (!(sender instanceof Player) || sender.hasPermission("bending.ability." + arg))) {
 				final ComponentBuilder bindShortcut = new ComponentBuilder();
 				for (int i = 1; i <= 9; i++) {
 					if (!bindShortcut.getParts().isEmpty()) {

--- a/src/com/projectkorra/projectkorra/command/HelpCommand.java
+++ b/src/com/projectkorra/projectkorra/command/HelpCommand.java
@@ -1,15 +1,5 @@
 package com.projectkorra.projectkorra.command;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import com.projectkorra.projectkorra.util.ChatUtil;
-import net.md_5.bungee.api.ChatColor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.ability.AddonAbility;
 import com.projectkorra.projectkorra.ability.ComboAbility;
@@ -17,6 +7,15 @@ import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.PassiveAbility;
 import com.projectkorra.projectkorra.ability.util.ComboManager;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
+import com.projectkorra.projectkorra.util.ChatUtil;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Executor for /bending help. Extends {@link PKCommand}.
@@ -59,8 +58,8 @@ public class HelpCommand extends PKCommand {
 
 		if (!this.hasPermission(sender) || !this.correctLength(sender, args.size(), 0, 1)) {
 			return;
-		} else if (args.size() == 0) {
-			final List<String> strings = new ArrayList<String>();
+		} else if (args.isEmpty()) {
+			final List<String> strings = new ArrayList<>();
 			for (final PKCommand command : instances.values()) {
 				if (!command.getName().equalsIgnoreCase("help") && sender.hasPermission("bending.command." + command.getName())) {
 					strings.add(command.getProperUse());
@@ -86,7 +85,7 @@ public class HelpCommand extends PKCommand {
 		final String arg = args.get(0).toLowerCase();
 
 		if (this.isNumeric(arg)) {
-			final List<String> strings = new ArrayList<String>();
+			final List<String> strings = new ArrayList<>();
 			for (final PKCommand command : instances.values()) {
 				strings.add(command.getProperUse());
 			}

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1,16 +1,15 @@
 package com.projectkorra.projectkorra.configuration;
 
+import com.projectkorra.projectkorra.GeneralMethods;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.EntityType;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import com.projectkorra.projectkorra.GeneralMethods;
-import org.bukkit.Material;
-import org.bukkit.configuration.file.FileConfiguration;
-
-import net.md_5.bungee.api.ChatColor;
-import org.bukkit.entity.EntityType;
 
 public class ConfigManager {
 
@@ -225,6 +224,8 @@ public class ConfigManager {
 			config.addDefault("Commands.Display.InvalidArgument", "Not a valid argument.");
 			config.addDefault("Commands.Display.PlayersOnly", "This command is only usable by players.");
 			config.addDefault("Commands.Display.NoBinds", "You do not have any abilities bound.\nIf you would like to see a list of available abilities, please use the /bending display [Element] command. Use /bending help for more information.");
+			config.addDefault("Commands.Display.HoverType", "Click to display {type}.");
+			config.addDefault("Commands.Display.HoverAbility", "Click to view how to use {ability}.");
 
 			config.addDefault("Commands.Debug.Description", "Outputs information on the current ProjectKorra installation to /plugins/ProjectKorra/debug.txt");
 			config.addDefault("Commands.Debug.SuccessfullyExported", "Debug File Created as debug.txt in the ProjectKorra plugin folder.\nPut contents on pastie.org and create a bug report  on the ProjectKorra forum if you need to.");

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -217,15 +217,18 @@ public class ConfigManager {
 			config.addDefault("Commands.Help.Usage", "Usage: ");
 
 			config.addDefault("Commands.Display.Description", "This command will show you all of the elements you have bound if you do not specify an element. If you do specify an element (Air, Water, Earth, Fire, or Chi), it will show you all of the available abilities of that element installed on the server.");
-
 			config.addDefault("Commands.Display.NoCombosAvailable", "There are no {element} combos available.");
 			config.addDefault("Commands.Display.NoPassivesAvailable", "There are no {element} passives available.");
 			config.addDefault("Commands.Display.NoAbilitiesAvailable", "There are no {element} abilities on this server.");
 			config.addDefault("Commands.Display.InvalidArgument", "Not a valid argument.");
 			config.addDefault("Commands.Display.PlayersOnly", "This command is only usable by players.");
 			config.addDefault("Commands.Display.NoBinds", "You do not have any abilities bound.\nIf you would like to see a list of available abilities, please use the /bending display [Element] command. Use /bending help for more information.");
+			config.addDefault("Commands.Display.Format", "{ability} {bind}");
+			config.addDefault("Commands.Display.Separator", "\n");
 			config.addDefault("Commands.Display.HoverType", "Click to display {type}.");
 			config.addDefault("Commands.Display.HoverAbility", "Click to view how to use {ability}.");
+			config.addDefault("Commands.Display.HoverBindButton", "Click to bind {ability}.");
+			config.addDefault("Commands.Display.BindButton", "[+]");
 
 			config.addDefault("Commands.Debug.Description", "Outputs information on the current ProjectKorra installation to /plugins/ProjectKorra/debug.txt");
 			config.addDefault("Commands.Debug.SuccessfullyExported", "Debug File Created as debug.txt in the ProjectKorra plugin folder.\nPut contents on pastie.org and create a bug report  on the ProjectKorra forum if you need to.");

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -228,6 +228,7 @@ public class ConfigManager {
 			config.addDefault("Commands.Display.NoCombosAccess", "You do not have access to any available {element} combos.");
 			config.addDefault("Commands.Display.NoPassivesAccess", "You do not have access to any available {element} passives.");
 			config.addDefault("Commands.Display.NoAbilitiesAccess", "You do not have access to any available {element} abilities.");
+			config.addDefault("Commands.Display.NoElementsAccess", "You do not have access to any available elements.");
 			config.addDefault("Commands.Display.InvalidArgument", "Not a valid argument.");
 			config.addDefault("Commands.Display.PlayersOnly", "This command is only usable by players.");
 			config.addDefault("Commands.Display.NoBinds", "You do not have any abilities bound.\nIf you would like to see a list of available abilities, please use the /bending display [Element] command. Use /bending help for more information.");

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -225,6 +225,9 @@ public class ConfigManager {
 			config.addDefault("Commands.Display.NoCombosAvailable", "There are no {element} combos available.");
 			config.addDefault("Commands.Display.NoPassivesAvailable", "There are no {element} passives available.");
 			config.addDefault("Commands.Display.NoAbilitiesAvailable", "There are no {element} abilities on this server.");
+			config.addDefault("Commands.Display.NoCombosAccess", "You do not have access to any available {element} combos.");
+			config.addDefault("Commands.Display.NoPassivesAccess", "You do not have access to any available {element} passives.");
+			config.addDefault("Commands.Display.NoAbilitiesAccess", "You do not have access to any available {element} abilities.");
 			config.addDefault("Commands.Display.InvalidArgument", "Not a valid argument.");
 			config.addDefault("Commands.Display.PlayersOnly", "This command is only usable by players.");
 			config.addDefault("Commands.Display.NoBinds", "You do not have any abilities bound.\nIf you would like to see a list of available abilities, please use the /bending display [Element] command. Use /bending help for more information.");

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -223,12 +223,10 @@ public class ConfigManager {
 			config.addDefault("Commands.Display.InvalidArgument", "Not a valid argument.");
 			config.addDefault("Commands.Display.PlayersOnly", "This command is only usable by players.");
 			config.addDefault("Commands.Display.NoBinds", "You do not have any abilities bound.\nIf you would like to see a list of available abilities, please use the /bending display [Element] command. Use /bending help for more information.");
-			config.addDefault("Commands.Display.Format", "{ability} {bind}");
+			config.addDefault("Commands.Display.Format", "{ability}");
 			config.addDefault("Commands.Display.Separator", "\n");
 			config.addDefault("Commands.Display.HoverType", "Click to display {type}.");
 			config.addDefault("Commands.Display.HoverAbility", "Click to view how to use {ability}.");
-			config.addDefault("Commands.Display.HoverBindButton", "Click to bind {ability}.");
-			config.addDefault("Commands.Display.BindButton", "[+]");
 
 			config.addDefault("Commands.Debug.Description", "Outputs information on the current ProjectKorra installation to /plugins/ProjectKorra/debug.txt");
 			config.addDefault("Commands.Debug.SuccessfullyExported", "Debug File Created as debug.txt in the ProjectKorra plugin folder.\nPut contents on pastie.org and create a bug report  on the ProjectKorra forum if you need to.");

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -215,6 +215,11 @@ public class ConfigManager {
 			config.addDefault("Commands.Help.Elements.LearnMore", "Learn more at our website! ");
 			config.addDefault("Commands.Help.InvalidTopic", "That isn't a valid help topic. Use /bending help for more information.");
 			config.addDefault("Commands.Help.Usage", "Usage: ");
+			config.addDefault("Commands.Help.BindStart", "Bind: &7◂ ");
+			config.addDefault("Commands.Help.SlotFormat", "{element_color}{slot}");
+			config.addDefault("Commands.Help.BindSeparator", " &7| ");
+			config.addDefault("Commands.Help.BindEnd", " &7▸");
+			config.addDefault("Commands.Help.HoverBind", "Click to bind {ability} to slot {slot}!");
 
 			config.addDefault("Commands.Display.Description", "This command will show you all of the elements you have bound if you do not specify an element. If you do specify an element (Air, Water, Earth, Fire, or Chi), it will show you all of the available abilities of that element installed on the server.");
 			config.addDefault("Commands.Display.NoCombosAvailable", "There are no {element} combos available.");
@@ -372,7 +377,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.WaterBubble.Description", "WaterBubble is a basic waterbending ability that allows the bender to create air pockets under water. This is increddibly useful for building under water.");
 			config.addDefault("Abilities.Water.WaterBubble.Instructions", "Hold sneak when in range of water to push the water back and create a water bubble. Alternatively, you can click to create a bubble for a short amount of time.");
 			config.addDefault("Abilities.Water.WaterManipulation.Description", "WaterManipulation is a fundamental ability for waterbenders. Although it is a basic move, it allows for fast damage due to its rapid fire nature, which is incredibly useful when wanting to finish off low health targets.");
-			config.addDefault("Abilities.Water.WaterManipulation.Instructions", "Tap sneak on a water source and left click to send a water manipulation to the point that you clicked. Additionally, you can left click again to change the direction of this move. This includes other players' WaterManipulations.");
+			config.addDefault("Abilities.Water.WaterManipulation.Instructions", "Tap sneak while looking at a water source and left click to send a water manipulation to the point that you clicked. Additionally, you can left click again to change the direction of this move. This includes other players' WaterManipulations.");
 			config.addDefault("Abilities.Water.WaterManipulation.DeathMessage", "{victim} was drowned by {attacker}'s {ability}");
 			config.addDefault("Abilities.Water.WaterSpout.Description", "This ability provides a Waterbender with a means of transportation. It's the most useful mobility move that a waterbender possesses and is great for chasing down targets or escaping.");
 			config.addDefault("Abilities.Water.WaterSpout.Instructions", "\n" + "(Spout) Left click to activate a spout beneath you and hold spacebar to go higher. If you wish to go lower, simply hold sneak. To disable this ability, left click once again." + "\n" + "(Wave) Left click a water source and hold sneak until water has formed around you. Then, release sneak to ride a water wave that transports you in the direction you're looking. To cancel this water wave, left click with WaterSpout.");


### PR DESCRIPTION
## Additions
Discord Suggestion for Rewrite of the Command
Including hover text and /help and /display commands being run when clicking various parts of the messages
Video showcasing the changes: https://www.youtube.com/watch?v=3x9bnfx6CTo

## Fixes
Fixes various issues with the Display command
Dealing with the showing and categorizing of combos, sub elements and their combos passives, etc

## Removals
Removes the need of 2 separate methods for SubElements and normal Elements _and also removes a lot of the original code because its a rewrite lol_