### PR TITLE
Fix BendingBoard warning

### DIFF
--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -32,8 +32,8 @@ public class BendingBoard {
 		private int slot;
 		private Team team;
 		private String entry;
-		private Optional<BoardSlot> next = Optional.empty();
-		
+		private Optional<BoardSlot> next = Optional.empty(), prev = Optional.empty();
+
 		public BoardSlot(Scoreboard board, Objective obj, int slot) {
 			this.board = board;
 			this.obj = obj;
@@ -81,7 +81,11 @@ public class BendingBoard {
 		}
 		
 		private void setNext(BoardSlot slot) {
-			this.next = Optional.ofNullable(slot);
+			this.next = Optional.of(slot);
+		}
+
+		private void setPrev(BoardSlot slot) {
+			this.prev = Optional.of(slot);
 		}
 	}
 	
@@ -231,6 +235,8 @@ public class BendingBoard {
 	public void updateMisc(String name, ChatColor color, boolean cooldown) {
 		if (!cooldown) {
 			misc.computeIfPresent(name, (key, slot) -> {
+				slot.next.ifPresent(n -> n.prev = slot.prev);
+				slot.prev.ifPresent(p -> p.next = slot.next);
 				if (slot == miscTail) {
 					miscTail = null;
 				}
@@ -248,6 +254,7 @@ public class BendingBoard {
 			
 			if (miscTail != null) {
 				miscTail.setNext(slot);
+				slot.setPrev(miscTail);
 			}
 			
 			miscTail = slot;


### PR DESCRIPTION
## Fixes
* Fixes BendingBoard warning "java.lang.IllegalStateException: Unregistered scoreboard component"

This warning was very common and only needed one condition to be valid for it to screw up someone's bending board and continue throwing the warning for every further combo/misc ability cooldown. It was due to an incorrect linkage of the Optional<BoardSlot> "next" which you can read about on the PK Discord here https://discord.com/channels/292809844803502080/612873490709741577/1055965952677777429. My solution was to add a "prev" so the slots are doubly linked. This is also how @Simplicitee did it in his rework. I have fully tested my changes and have been using this on my server for weeks with no problems.