### PR TITLE
Fix PKListener FireCombo Issue

### DIFF
--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -622,6 +622,9 @@ public class PKListener implements Listener {
 		if (BENDING_ENTITY_DEATH.containsKey(event.getEntity())) {
 			final CoreAbility coreAbility = (CoreAbility) BENDING_ENTITY_DEATH.get(event.getEntity());
 			for (final CoreAbility fireCombo : cookingFireCombos) {
+				if (fireCombo == null) {
+					continue;
+				}
 				if (coreAbility.getName().equalsIgnoreCase(fireCombo.getName())) {
 					final List<ItemStack> drops = event.getDrops();
 					final List<ItemStack> newDrops = new ArrayList<>();


### PR DESCRIPTION
## Fixes
* Fixes NullPointerException caused by disabling Fire Combos

<html>
<body>
<!--StartFragment-->

[02:36:58] [Server thread/ERROR]: Could not pass event EntityDeathEvent to ProjectKorra v1.10.2
--
285 | java.lang.NullPointerException: Cannot invoke "com.projectkorra.projectkorra.ability.CoreAbility.getName()" because "fireCombo" is null
286 | at com.projectkorra.projectkorra.PKListener.onEntityDeath(PKListener.java:599) ~[ProjectKorra-1.10.2.jar:?]
287 | at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor146.execute(Unknown Source) ~[?:?]
288 | at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
289 | at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:git-Paper-379]
290 | at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
291 | at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:672) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
292 | at org.bukkit.craftbukkit.v1_19_R2.event.CraftEventFactory.callEntityDeathEvent(CraftEventFactory.java:879) ~[paper-1.19.3.jar:git-Paper-379]
293 | at net.minecraft.world.entity.LivingEntity.dropAllDeathLoot(LivingEntity.java:1767) ~[?:?]
294 | at net.minecraft.world.entity.LivingEntity.die(LivingEntity.java:1664) ~[?:?]
295 | at net.minecraft.world.entity.LivingEntity.hurt(LivingEntity.java:1491) ~[?:?]
296 | at org.bukkit.craftbukkit.v1_19_R2.entity.CraftLivingEntity.damage(CraftLivingEntity.java:376) ~[paper-1.19.3.jar:git-Paper-379]
297 | at com.projectkorra.projectkorra.util.DamageHandler.damageEntity(DamageHandler.java:88) ~[ProjectKorra-1.10.2.jar:?]
298 | at com.projectkorra.projectkorra.util.DamageHandler.damageEntity(DamageHandler.java:112) ~[ProjectKorra-1.10.2.jar:?]
299 | at com.projectkorra.projectkorra.util.DamageHandler.damageEntity(DamageHandler.java:116) ~[ProjectKorra-1.10.2.jar:?]
300 | at com.projectkorra.projectkorra.airbending.AirSwipe$1.run(AirSwipe.java:250) ~[ProjectKorra-1.10.2.jar:?]
301 | at org.bukkit.craftbukkit.v1_19_R2.scheduler.CraftTask.run(CraftTask.java:101) ~[paper-1.19.3.jar:git-Paper-379]
302 | at org.bukkit.craftbukkit.v1_19_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[paper-1.19.3.jar:git-Paper-379]
303 | at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1473) ~[paper-1.19.3.jar:git-Paper-379]
304 | at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:440) ~[paper-1.19.3.jar:git-Paper-379]
305 | at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1397) ~[paper-1.19.3.jar:git-Paper-379]
306 | at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1173) ~[paper-1.19.3.jar:git-Paper-379]
307 | at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.19.3.jar:git-Paper-379]
308 | at java.lang.Thread.run(Unknown Source) ~[?:?]

<!--EndFragment-->
</body>
</html>


Looking at PKListener, the issue seemed to be attempting to get the names of FireCombo abilities, which may have been disabled by a configuration change. **This may be an issue elsewhere in the code**, I just thought that this was a simple enough fix!