### PR TITLE
1.11.2 - More bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.projectkorra</groupId>
   <artifactId>projectkorra</artifactId>
-  <version>1.11.1</version>
+  <version>1.11.2</version>
   <name>ProjectKorra</name>
   <repositories>
     <!-- local jar files, add more using: mvn install:install-file -Dfile=aaa.jar -DgroupId=aaa -DartifactId=aaa -Dversion=aaa -Dpackaging=jar -DlocalRepositoryPath=path/to/ProjectKorra/localrepo/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>com.github.angeschossen</groupId>
       <artifactId>LandsAPI</artifactId>
-      <version>6.0.2</version>
+      <version>6.26.16</version>
       <scope>provided</scope>
     </dependency>
     <!-- Residence -->

--- a/src/com/projectkorra/projectkorra/BendingManager.java
+++ b/src/com/projectkorra/projectkorra/BendingManager.java
@@ -36,7 +36,7 @@ public class BendingManager implements Runnable {
 	private final HashMap<World, WorldTimeEvent.Time> times = new HashMap<>(); // true if day time
 
 	private final MCTiming CORE_ABILITY_TIMING, TEMP_POTION_TIMING, DAY_NIGHT_TIMING, HORIZONTAL_VELOCITY_TRACKER_TIMING,
-			COOLDOWN_TIMING, TEMP_ARMOR_TIMING, ACTIONBAR_STATUS_TIMING, TEMP_FALLING_BLOCK_TIMING, TEMP_BLOCK_TIMING, BPLAYER_TEMPELEMENT_TIMING;
+			COOLDOWN_TIMING, TEMP_ARMOR_TIMING, ACTIONBAR_STATUS_TIMING, TEMP_FALLING_BLOCK_TIMING, TEMP_BLOCK_TIMING;
 
 	public BendingManager() {
 		instance = this;
@@ -51,7 +51,6 @@ public class BendingManager implements Runnable {
 		this.ACTIONBAR_STATUS_TIMING = ProjectKorra.timing("ActionBarCheck");
 		this.TEMP_FALLING_BLOCK_TIMING = ProjectKorra.timing("TempFallingBlock#manage");
 		this.TEMP_BLOCK_TIMING = ProjectKorra.timing("TempBlockRevert");
-		this.BPLAYER_TEMPELEMENT_TIMING = ProjectKorra.timing("BendingPlayerTempElements");
 
 		times.clear();
 
@@ -173,19 +172,6 @@ public class BendingManager implements Runnable {
 				if (currentTime >= tempBlock.getRevertTime()) {
 					TempBlock.REVERT_QUEUE.poll();
 					tempBlock.revertBlock();
-				} else {
-					break;
-				}
-			}
-		}
-
-		try (MCTiming timing = this.BPLAYER_TEMPELEMENT_TIMING.startTiming()) {
-			while (!BendingPlayer.TEMP_ELEMENTS.isEmpty()) {
-				Pair<Player, Long> pair = BendingPlayer.TEMP_ELEMENTS.peek();
-
-				if (System.currentTimeMillis() > pair.getRight()) { //Check if the top temp element has expired
-					BendingPlayer.TEMP_ELEMENTS.poll(); //And if it has, recalculate temp elements for that player
-					BendingPlayer.getBendingPlayer(pair.getLeft()).recalculateTempElements(false);
 				} else {
 					break;
 				}

--- a/src/com/projectkorra/projectkorra/BendingManager.java
+++ b/src/com/projectkorra/projectkorra/BendingManager.java
@@ -97,11 +97,11 @@ public class BendingManager implements Runnable {
 						if (bPlayer == null) continue;
 
 						if (bPlayer.hasElement(Element.WATER) && player.hasPermission("bending.message.daymessage") && to == WorldTimeEvent.Time.DAY) {
-							String s = getMoonriseMessage();
+							String s = getMoonsetMessage();
 							player.sendMessage(Element.WATER.getColor() + s);
 						}
 						else if (bPlayer.hasElement(Element.WATER) && player.hasPermission("bending.message.nightmessage") && to == WorldTimeEvent.Time.NIGHT) {
-							String s = getMoonsetMessage();
+							String s = getMoonriseMessage();
 							player.sendMessage(Element.WATER.getColor() + s);
 						}
 

--- a/src/com/projectkorra/projectkorra/BendingManager.java
+++ b/src/com/projectkorra/projectkorra/BendingManager.java
@@ -125,33 +125,33 @@ public class BendingManager implements Runnable {
 		this.time = System.currentTimeMillis();
 		ProjectKorra.time_step = this.interval;
 
-		try (MCTiming timing = this.CORE_ABILITY_TIMING.startTiming()) {
+		//try (MCTiming timing = this.CORE_ABILITY_TIMING.startTiming()) {
 			CoreAbility.progressAll();
-		}
+		//}
 
-		try (MCTiming timing = this.TEMP_POTION_TIMING.startTiming()) {
+		//try (MCTiming timing = this.TEMP_POTION_TIMING.startTiming()) {
 			TempPotionEffect.progressAll();
-		}
+		//}
 
-		try (MCTiming timing = this.DAY_NIGHT_TIMING.startTiming()) {
+		//try (MCTiming timing = this.DAY_NIGHT_TIMING.startTiming()) {
 			this.handleDayNight();
-		}
+		//}
 
 		RevertChecker.revertAirBlocks();
 
-		try (MCTiming timing = this.HORIZONTAL_VELOCITY_TRACKER_TIMING.startTiming()) {
+		//try (MCTiming timing = this.HORIZONTAL_VELOCITY_TRACKER_TIMING.startTiming()) {
 			HorizontalVelocityTracker.updateAll();
-		}
+		//}
 
-		try (MCTiming timing = this.COOLDOWN_TIMING.startTiming()) {
+		//try (MCTiming timing = this.COOLDOWN_TIMING.startTiming()) {
 			this.handleCooldowns();
-		}
+		//}
 
-		try (MCTiming timing = this.TEMP_ARMOR_TIMING.startTiming()) {
+		//try (MCTiming timing = this.TEMP_ARMOR_TIMING.startTiming()) {
 			TempArmor.cleanup();
-		}
+		//}
 
-		try (MCTiming timing = this.ACTIONBAR_STATUS_TIMING.startTiming()) {
+		//try (MCTiming timing = this.ACTIONBAR_STATUS_TIMING.startTiming()) {
 			for (final Player player : Bukkit.getOnlinePlayers()) {
 				if (Bloodbending.isBloodbent(player)) {
 					ActionBar.sendActionBar(Element.BLOOD.getColor() + "* Bloodbent *", player);
@@ -159,13 +159,13 @@ public class BendingManager implements Runnable {
 					ActionBar.sendActionBar(Element.METAL.getColor() + "* MetalClipped *", player);
 				}
 			}
-		}
+		//}
 
-		try (MCTiming timing = this.TEMP_FALLING_BLOCK_TIMING.startTiming()) {
+		//try (MCTiming timing = this.TEMP_FALLING_BLOCK_TIMING.startTiming()) {
 			TempFallingBlock.manage();
-		}
+		//}
 
-		try (MCTiming timing = this.TEMP_BLOCK_TIMING.startTiming()) {
+		//try (MCTiming timing = this.TEMP_BLOCK_TIMING.startTiming()) {
 			final long currentTime = System.currentTimeMillis();
 			while (!TempBlock.REVERT_QUEUE.isEmpty()) {
 				final TempBlock tempBlock = TempBlock.REVERT_QUEUE.peek(); //Check if the top TempBlock is ready for reverting
@@ -176,7 +176,7 @@ public class BendingManager implements Runnable {
 					break;
 				}
 			}
-		}
+		//}
 	}
 
 	public static String getSunriseMessage() {

--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -1,11 +1,13 @@
 package com.projectkorra.projectkorra;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,6 +32,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
@@ -59,6 +62,7 @@ import org.jetbrains.annotations.NotNull;
 public class BendingPlayer extends OfflineBendingPlayer {
 
 	protected static Map<JavaPlugin, CanBendHook> HOOKS = new HashMap<>();
+	static Set<String> DISABLED_WORLDS = new HashSet<>();
 
 	private long slowTime;
 	private final Player player;
@@ -249,6 +253,18 @@ public class BendingPlayer extends OfflineBendingPlayer {
 		return (System.currentTimeMillis() > this.slowTime);
 	}
 
+	/**
+	 * Check if the {@link BendingPlayer} can bend in the world they are in
+	 */
+	public boolean canBendInWorld() {
+		return !DISABLED_WORLDS.contains(this.getPlayer().getWorld().getName());
+	}
+
+	/**
+	 * Check if the {@link BendingPlayer} can bind the provided {@link CoreAbility}
+	 * @param ability The {@link CoreAbility} to check
+	 * @return True if they can bind it
+	 */
 	public boolean canBind(final CoreAbility ability) {
 		if (ability == null || !this.player.isOnline() || !ability.isEnabled()) {
 			return false;
@@ -521,6 +537,15 @@ public class BendingPlayer extends OfflineBendingPlayer {
 	 */
 	public boolean isIlluminating() {
 		return this.illumination;
+	}
+
+	/**
+	 * Check if bending is disabled in the provided world
+	 * @param world The world to check
+	 * @return True if bending is disabled in the world
+	 */
+	public static boolean isWorldDisabled(World world) {
+		return DISABLED_WORLDS.contains(world.getName());
 	}
 
 	/**

--- a/src/com/projectkorra/projectkorra/Element.java
+++ b/src/com/projectkorra/projectkorra/Element.java
@@ -147,7 +147,7 @@ public class Element {
 			if (value == null && this instanceof SubElement && !(this instanceof MultiSubElement)) {
 				this.color = ((SubElement) this).parentElement.getSubColor();
 				return this.color;
-			}
+			} else if (value == null) value = "WHITE";
 
 			try {
 				this.color = ChatColor.of(value);
@@ -168,7 +168,8 @@ public class Element {
 			if (value == null && this instanceof SubElement && !(this instanceof MultiSubElement)) {
 				this.color = ((SubElement) this).parentElement.getSubColor();
 				return this.color;
-			}
+			} else if (value == null) value = getColor().getName();
+
 			try {
 				this.subColor = ChatColor.of(value);
 			} catch (IllegalArgumentException e) {

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1367,7 +1367,6 @@ public class GeneralMethods {
 		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new FirebendingManager(ProjectKorra.plugin), 0, 1);
 		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new ChiblockingManager(ProjectKorra.plugin), 0, 1);
 		ProjectKorra.plugin.revertChecker = ProjectKorra.plugin.getServer().getScheduler().runTaskTimerAsynchronously(ProjectKorra.plugin, new RevertChecker(ProjectKorra.plugin), 0, 200);
-		TempBlock.startReversion();
 
 		EarthTunnel.setupBendableMaterials();
 		Bloodbending.loadBloodlessFromConfig();

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1393,6 +1393,7 @@ public class GeneralMethods {
 		}
 		BendingPlayer.getOfflinePlayers().clear();
 		BendingPlayer.getPlayers().clear();
+		BendingPlayer.DISABLED_WORLDS = new HashSet<>(ConfigManager.defaultConfig.get().getStringList("Properties.DisabledWorlds"));
 		BendingBoardManager.reload();
 		for (final Player player : Bukkit.getOnlinePlayers()) {
 			Preset.unloadPreset(player);

--- a/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1580,7 +1580,9 @@ public class GeneralMethods {
 		final ClassLoader loader = ProjectKorra.class.getClassLoader();
 		try {
 			for (final ClassPath.ClassInfo info : ClassPath.from(loader).getTopLevelClasses()) {
-				if (info.getName().startsWith("com.projectkorra.") && !info.getName().contains("hooks") && !info.getName().startsWith("com.projectkorra.projectkorra.region")) {
+				if (info.getName().startsWith("com.projectkorra.") && !info.getName().contains("hooks")
+						&& !info.getName().startsWith("com.projectkorra.projectkorra.region")
+						&& !info.getName().startsWith("com.projectkorra.projectkorra.ProjectKorra")) {
 					try {
 						final Class<?> clazz = info.load();
 						for (final Field field : clazz.getDeclaredFields()) {

--- a/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
@@ -848,6 +848,13 @@ public class OfflineBendingPlayer {
     }
 
     /**
+     * @return Is the player online?
+     */
+    public boolean isOnline() {
+        return this instanceof BendingPlayer;
+    }
+
+    /**
      * Checks if the {@link BendingPlayer} has the specified element toggled on
      *
      * @param element The element to check

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -239,6 +239,10 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onBlockBreak(final BlockBreakEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getBlock().getWorld())) {
+			return;
+		}
+
 		final Block block = event.getBlock();
 		final Player player = event.getPlayer();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
@@ -307,6 +311,10 @@ public class PKListener implements Listener {
 		final Block toblock = event.getToBlock();
 		final Block fromblock = event.getBlock();
 
+		if (BendingPlayer.isWorldDisabled(event.getBlock().getWorld())) {
+			return;
+		}
+
 		if (TempBlock.isTempBlock(fromblock) || TempBlock.isTempBlock(toblock)) {
 			event.setCancelled(true);
 		} else {
@@ -323,6 +331,10 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onFluidLevelChange(final FluidLevelChangeEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getBlock().getWorld())) {
+			return;
+		}
+
 		if (TempBlock.isTempBlock(event.getBlock())) {
 			event.setCancelled(true);
 		} else if (TempBlock.isTouchingTempBlock(event.getBlock())) {
@@ -332,6 +344,10 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onBlockForm(final BlockFormEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getBlock().getWorld())) {
+			return;
+		}
+
 		if (TempBlock.isTempBlock(event.getBlock())) {
 			event.setCancelled(true);
 		}
@@ -482,6 +498,10 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityChangeBlockEvent(final EntityChangeBlockEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getBlock().getWorld())) {
+			return;
+		}
+
 		final Entity entity = event.getEntity();
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity)) {
 			event.setCancelled(true);
@@ -517,6 +537,8 @@ public class PKListener implements Listener {
 		final Block block = event.getDamager();
 		if (block == null) {
 			return;
+		} else if (BendingPlayer.isWorldDisabled(block.getWorld())) {
+			return;
 		}
 
 		if (TempBlock.isTempBlock(block)) {
@@ -539,6 +561,10 @@ public class PKListener implements Listener {
 		final Entity entity = event.getEntity();
 		double damage = event.getDamage();
 
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
+
 		if (event.getCause() == DamageCause.FIRE && FireAbility.getSourcePlayers().containsKey(entity.getLocation().getBlock())) {
 			new FireDamageTimer(entity, FireAbility.getSourcePlayers().get(entity.getLocation().getBlock()), null, true);
 		}
@@ -551,7 +577,7 @@ public class PKListener implements Listener {
 		if (entity instanceof Player) {
 			final Player player = (Player) entity;
 			final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer == null) {
+			if (bPlayer == null || !bPlayer.canBendInWorld()) {
 				return;
 			}
 
@@ -674,16 +700,20 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityExplodeEvent(final EntityExplodeEvent event) {
 		final Entity entity = event.getEntity();
-		if (entity != null) {
-			if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity)) {
-				event.setCancelled(true);
-			}
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
+		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity)) {
+			event.setCancelled(true);
 		}
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityInteractEvent(final EntityInteractEvent event) {
 		final Entity entity = event.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity)) {
 			event.setCancelled(true);
 		}
@@ -692,6 +722,9 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityProjectileLaunchEvent(final ProjectileLaunchEvent event) {
 		final Entity entity = event.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity)) {
 			event.setCancelled(true);
 		}
@@ -700,6 +733,9 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityShootBowEvent(final EntityShootBowEvent event) {
 		final Entity entity = event.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity)) {
 			event.setCancelled(true);
 		}
@@ -708,23 +744,29 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntitySlimeSplitEvent(final SlimeSplitEvent event) {
 		final Entity entity = event.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity)) {
 			event.setCancelled(true);
 		}
 	}
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	/*@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntitySuffocatedByTempBlocks(final EntityDamageEvent event) {
 		if (event.getCause() == DamageCause.SUFFOCATION) {
 			if (TempBlock.isTempBlock(event.getEntity().getLocation().add(0, 1, 0).getBlock())) {
 				event.setCancelled(true);
 			}
 		}
-	}
+	}*/
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityTarget(final EntityTargetEvent event) {
 		final Entity entity = event.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity)) {
 			event.setCancelled(true);
 		}
@@ -733,6 +775,9 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityTargetLiving(final EntityTargetLivingEntityEvent event) {
 		final Entity entity = event.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity)) {
 			event.setCancelled(true);
 		}
@@ -741,6 +786,9 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onEntityTeleportEvent(final EntityTeleportEvent event) {
 		final Entity entity = event.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
 		if (MovementHandler.isStopped(entity) || Bloodbending.isBloodbent(entity) || Suffocate.isBreathbent(entity) || (entity instanceof LivingEntity && MetalClips.isControlled((LivingEntity) entity))) {
 			event.setCancelled(true);
 		}
@@ -819,12 +867,6 @@ public class PKListener implements Listener {
 		}
 	}
 
-	@EventHandler
-	public void onPlayerBucketEmpty(final PlayerBucketEmptyEvent event) {
-		final Block block = event.getBlockClicked().getRelative(event.getBlockFace());
-
-	}
-
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerChat(final AsyncPlayerChatEvent event) {
 		final Player player = event.getPlayer();
@@ -860,6 +902,9 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerDamage(final EntityDamageEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getEntity().getWorld())) {
+			return;
+		}
 		if (event.getEntity() instanceof Player) {
 			final Player player = (Player) event.getEntity();
 			final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
@@ -941,6 +986,10 @@ public class PKListener implements Listener {
 	public void onPlayerDamageByPlayer(final EntityDamageByEntityEvent e) {
 		final Entity source = e.getDamager();
 		final Entity entity = e.getEntity();
+		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
+			return;
+		}
+
 		final FireBlastCharged fireball = FireBlastCharged.getFireball(source);
 
 		if (fireball != null) {
@@ -1032,7 +1081,6 @@ public class PKListener implements Listener {
 					armor.revert(event.getDrops());
 				}
 			} // Do nothing. TempArmor drops are handled by the EntityDeath event and not PlayerDeath.
-
 		}
 		
 		if (BENDING_PLAYER_DEATH.containsKey(event.getEntity())) {
@@ -1098,6 +1146,11 @@ public class PKListener implements Listener {
 		final Player player = event.getPlayer();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
+		//If the world is disabled
+		if (!bPlayer.canBendInWorld()) {
+			return;
+		}
+
 		if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
 			final UUID uuid = player.getUniqueId();
 
@@ -1135,6 +1188,11 @@ public class PKListener implements Listener {
 	public void onPlayerInteractEntity(final PlayerInteractAtEntityEvent event) {
 		final Player player = event.getPlayer();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+
+		//If the world is disabled
+		if (!bPlayer.canBendInWorld()) {
+			return;
+		}
 
 		if (bPlayer.canCurrentlyBendWithWeapons()) {
 			ComboManager.addComboAbility(player, ClickType.RIGHT_CLICK_ENTITY);
@@ -1238,6 +1296,9 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerMove(final PlayerMoveEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getPlayer().getWorld())) {
+			return;
+		}
 		if (event.getTo().getX() == event.getFrom().getX() && event.getTo().getY() == event.getFrom().getY() && event.getTo().getZ() == event.getFrom().getZ()) {
 			return;
 		}
@@ -1386,6 +1447,10 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerSneak(final PlayerToggleSneakEvent event) {
 		final Player player = event.getPlayer();
+		if (BendingPlayer.isWorldDisabled(player.getWorld())) {
+			return;
+		}
+
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
 		if (bPlayer == null) {
@@ -1580,6 +1645,9 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onPlayerSlotChange(final PlayerItemHeldEvent event) {
 		final Player player = event.getPlayer();
+		if (BendingPlayer.isWorldDisabled(player.getWorld())) {
+			return;
+		}
 		if (!MultiAbilityManager.canChangeSlot(player, event.getNewSlot())) {
 			event.setCancelled(true);
 			return;
@@ -1618,6 +1686,10 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void onPlayerInteract(final PlayerInteractEvent event) {
 		final Player player = event.getPlayer();
+
+		if (BendingPlayer.isWorldDisabled(player.getWorld())) {
+			return;
+		}
 
 		if (PLAYER_DROPPED_ITEM.contains(player)) {
 			PLAYER_DROPPED_ITEM.remove(player);
@@ -1681,6 +1753,9 @@ public class PKListener implements Listener {
 	@EventHandler
 	public void onPlayerInteract(PlayerSwingEvent event) {
 		Player player = event.getPlayer();
+		if (BendingPlayer.isWorldDisabled(player.getWorld())) {
+			return;
+		}
 		BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
 		String abil = bPlayer.getBoundAbilityName();
@@ -1866,6 +1941,9 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerToggleFlight(final PlayerToggleFlightEvent event) {
 		final Player player = event.getPlayer();
+		if (BendingPlayer.isWorldDisabled(player.getWorld())) {
+			return;
+		}
 		if (CoreAbility.hasAbility(player, Tornado.class) || Bloodbending.isBloodbent(player) || Suffocate.isBreathbent(player) || CoreAbility.hasAbility(player, FireJet.class) || CoreAbility.hasAbility(player, AvatarState.class)) {
 			event.setCancelled(player.getGameMode() != GameMode.CREATIVE);
 			return;
@@ -1880,7 +1958,7 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerToggleGlide(final EntityToggleGlideEvent event) {
-		if (!(event.getEntity() instanceof Player)) {
+		if (!(event.getEntity() instanceof Player) || BendingPlayer.isWorldDisabled(event.getEntity().getWorld())) {
 			return;
 		}
 		final Player player = (Player) event.getEntity();
@@ -1915,6 +1993,9 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPickupItem(final EntityPickupItemEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getEntity().getWorld())) {
+			return;
+		}
 		for (final MetalClips metalClips : CoreAbility.getAbilities(MetalClips.class)) {
 			if (metalClips.getTrackedIngots().contains(event.getItem())) {
 				event.setCancelled(true);
@@ -1951,6 +2032,9 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onInventoryPickupItem(final InventoryPickupItemEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getItem().getWorld())) {
+			return;
+		}
 		for (final MetalClips metalClips : CoreAbility.getAbilities(MetalClips.class)) {
 			if (metalClips.getTrackedIngots().contains(event.getItem())) {
 				event.setCancelled(true);
@@ -1960,6 +2044,9 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onItemMerge(final ItemMergeEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getEntity().getWorld())) {
+			return;
+		}
 		for (final MetalClips metalClips : CoreAbility.getAbilities(MetalClips.class)) {
 			if (metalClips.getTrackedIngots().contains(event.getEntity()) || metalClips.getTrackedIngots().contains(event.getTarget())) {
 				event.setCancelled(true);
@@ -1969,6 +2056,9 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockPistonExtendEvent(final BlockPistonExtendEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getBlock().getWorld())) {
+			return;
+		}
 		for (final Block b : event.getBlocks()) {
 			if (TempBlock.isTempBlock(b)) {
 				event.setCancelled(true);
@@ -1979,6 +2069,9 @@ public class PKListener implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockPistonRetractEvent(final BlockPistonRetractEvent event) {
+		if (BendingPlayer.isWorldDisabled(event.getBlock().getWorld())) {
+			return;
+		}
 		for (final Block b : event.getBlocks()) {
 			if (TempBlock.isTempBlock(b)) {
 				event.setCancelled(true);

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -412,33 +412,33 @@ public class PKListener implements Listener {
 	public void onBlockPhysics(final BlockPhysicsEvent event) {
 		final Block block = event.getBlock();
 
-		try (MCTiming timing = TimingPhysicsWaterManipulationCheck.startTiming()) {
+		//try (MCTiming timing = TimingPhysicsWaterManipulationCheck.startTiming()) {
 			if (!WaterManipulation.canPhysicsChange(block)) {
 				event.setCancelled(true);
 				return;
 			}
-		}
+		//}
 
-		try (MCTiming timing = TimingPhysicsEarthPassiveCheck.startTiming()) {
+		//try (MCTiming timing = TimingPhysicsEarthPassiveCheck.startTiming()) {
 			if (!EarthPassive.canPhysicsChange(block)) {
 				event.setCancelled(true);
 				return;
 			}
-		}
+		//}
 
-		try (MCTiming timing = TimingPhysicsEarthAbilityCheck.startTiming()) {
+		//try (MCTiming timing = TimingPhysicsEarthAbilityCheck.startTiming()) {
 			if (EarthAbility.getPreventPhysicsBlocks().contains(block)) {
 				event.setCancelled(true);
 				return;
 			}
-		}
+		//}
 
 		// If there is a TempBlock of Air bellow FallingSand blocks, prevent it from updating.
-		try (MCTiming timing = TimingPhysicsAirTempBlockBelowFallingBlockCheck.startTiming()) {
+		//try (MCTiming timing = TimingPhysicsAirTempBlockBelowFallingBlockCheck.startTiming()) {
 			if ((block.getType() == Material.SAND || block.getType() == Material.RED_SAND || block.getType() == Material.GRAVEL || block.getType() == Material.ANVIL || block.getType() == Material.DRAGON_EGG) && ElementalAbility.isAir(block.getRelative(BlockFace.DOWN).getType()) && TempBlock.isTempBlock(block.getRelative(BlockFace.DOWN))) {
 				event.setCancelled(true);
 			}
-		}
+		//}
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -1306,16 +1306,16 @@ public class PKListener implements Listener {
 		final Player player = event.getPlayer();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
-		try (MCTiming timing = TimingPlayerMoveMovementHandlerCheck.startTiming()) {
+		//try (MCTiming timing = TimingPlayerMoveMovementHandlerCheck.startTiming()) {
 			if (MovementHandler.isStopped(player)) {
 				if (event.getTo().getX() != event.getFrom().getX() || event.getTo().getZ() != event.getFrom().getZ() || event.getTo().getY() > event.getFrom().getY()) {
 					event.setCancelled(true);
 				}
 				return;
 			}
-		}
+		//}
 
-		try (MCTiming timing = TimingPlayerMoveSpoutCheck.startTiming()) {
+		//try (MCTiming timing = TimingPlayerMoveSpoutCheck.startTiming()) {
 			if (CoreAbility.hasAbility(player, WaterSpout.class) || CoreAbility.hasAbility(player, AirSpout.class)) {
 				Vector vel = new Vector();
 				vel.setX(event.getTo().getX() - event.getFrom().getX());
@@ -1331,9 +1331,9 @@ public class PKListener implements Listener {
 				}
 				return;
 			}
-		}
+		//}
 
-		try (MCTiming timing = TimingPlayerMoveBloodbentCheck.startTiming()) {
+		//try (MCTiming timing = TimingPlayerMoveBloodbentCheck.startTiming()) {
 			if (Bloodbending.isBloodbent(player)) {
 				final BendingPlayer bender = Bloodbending.getBloodbender(player);
 				if (bender.isAvatarState()) {
@@ -1349,23 +1349,23 @@ public class PKListener implements Listener {
 				}
 				return;
 			}
-		}
+		//}
 
 		if (bPlayer != null) {
-			try (MCTiming timing = TimingPlayerMoveAirChiPassiveCheck) {
+			//try (MCTiming timing = TimingPlayerMoveAirChiPassiveCheck) {
 				if (bPlayer.hasElement(Element.AIR) || bPlayer.hasElement(Element.CHI)) {
 					PassiveHandler.checkExhaustionPassives(player);
 				}
-			}
+			//}
 
-			try (MCTiming timing = TimingPlayerMoveFirePassiveCheck.startTiming()) {
+			//try (MCTiming timing = TimingPlayerMoveFirePassiveCheck.startTiming()) {
 				if (event.getTo().getBlock() != event.getFrom().getBlock()) {
 					FirePassive.handle(player);
 				}
-			}
+			//}
 		}
 
-		try (MCTiming timing = TimingPlayerMoveJumpCheck.startTiming()) {
+		//try (MCTiming timing = TimingPlayerMoveJumpCheck.startTiming()) {
 			if (event.getTo().getY() > event.getFrom().getY()) {
 				if (!(player.getLocation().getBlock().getType() == Material.VINE) && !(player.getLocation().getBlock().getType() == Material.LADDER)) {
 					final int current = player.getStatistic(Statistic.JUMP);
@@ -1382,7 +1382,7 @@ public class PKListener implements Listener {
 					}
 				}
 			}
-		}
+		//}
 	}
 
 	@EventHandler

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1663,14 +1663,14 @@ public class PKListener implements Listener {
 			return;
 		}
 
+		BlockSource.update(player, ClickType.LEFT_CLICK);
+
 		PlayerSwingEvent swingEvent = new PlayerSwingEvent(event.getPlayer()); //Allow addons to handle a swing without
 		Bukkit.getPluginManager().callEvent(swingEvent);                       //needing to repeat the checks above themselves
 		if (swingEvent.isCancelled()) {
 			event.setCancelled(true);
 			return;
 		}
-
-		BlockSource.update(player, ClickType.LEFT_CLICK);
 	}
 
 	@EventHandler

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -523,9 +523,11 @@ public class PKListener implements Listener {
 			if (EarthAbility.isEarthbendable(block.getType(), true, true, true) && GeneralMethods.isSolid(block)) {
 				event.setCancelled(true);
 			} else if (event.getCause() == DamageCause.LAVA && EarthAbility.isLava(block)) {
-				TempBlock.get(block).getAbility().ifPresent(ability -> new FireDamageTimer(event.getEntity(), ability.getPlayer(), ability, true));
-				event.setCancelled(true);
-				FireDamageTimer.dealFlameDamage(event.getEntity(), event.getDamage());
+				TempBlock.get(block).getAbility().ifPresent(ability -> {
+					new FireDamageTimer(event.getEntity(), ability.getPlayer(), ability, true);
+					event.setCancelled(true);
+					FireDamageTimer.dealFlameDamage(event.getEntity(), event.getDamage());
+				});
 			} else if (!TempBlock.get(block).canSuffocate() && event.getCause() == DamageCause.SUFFOCATION) {
 				event.setCancelled(true);
 			}

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -1375,7 +1375,12 @@ public class PKListener implements Listener {
 		}
 
 		Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, //Run 1 tick later so they actually are offline
-				() -> OfflineBendingPlayer.convertToOffline(bPlayer).uncacheAfter(ConfigManager.defaultConfig.get().getLong("Properties.PlayerDataUnloadTime", 5 * 60 * 1000)), 1L);
+				() -> {
+					OfflineBendingPlayer converted = OfflineBendingPlayer.convertToOffline(bPlayer);
+					if (!converted.isOnline()) { //We test if they are still offline. If they relog by joining on a different client, they will be online now, and an error will be thrown otherwise.
+						converted.uncacheAfter(ConfigManager.defaultConfig.get().getLong("Properties.PlayerDataUnloadTime", 5 * 60 * 1000));
+					}
+				}, 1L);
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -186,6 +186,7 @@ public class ProjectKorra extends JavaPlugin {
 		return ConfigManager.getConfig().getBoolean("Properties.DatabaseCooldowns");
 	}
 
+	@Deprecated
 	public static MCTiming timing(final String name) {
 		return timingManager.of(name);
 	}

--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -88,8 +88,6 @@ public class ProjectKorra extends JavaPlugin {
 		this.getServer().getScheduler().scheduleSyncRepeatingTask(this, new ChiblockingManager(this), 0, 1);
 		this.revertChecker = this.getServer().getScheduler().runTaskTimerAsynchronously(this, new RevertChecker(this), 0, 200);
 
-		TempBlock.startReversion();
-
 		for (final Player player : Bukkit.getOnlinePlayers()) {
 			PKListener.getJumpStatistics().put(player, player.getStatistic(Statistic.JUMP));
 

--- a/src/com/projectkorra/projectkorra/ProjectKorra.java
+++ b/src/com/projectkorra/projectkorra/ProjectKorra.java
@@ -1,6 +1,7 @@
 package com.projectkorra.projectkorra;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.logging.Logger;
 
 import co.aikar.timings.lib.MCTiming;
@@ -78,6 +79,7 @@ public class ProjectKorra extends JavaPlugin {
 
 		Manager.startup();
 		BendingBoardManager.setup();
+		BendingPlayer.DISABLED_WORLDS = new HashSet<>(ConfigManager.defaultConfig.get().getStringList("Properties.DisabledWorlds"));
 
 		this.getServer().getPluginManager().registerEvents(new PKListener(this), this);
 		this.getServer().getScheduler().scheduleSyncRepeatingTask(this, new BendingManager(), 0, 1);

--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -273,9 +273,9 @@ public abstract class CoreAbility implements Ability {
 						abil.attributesModified = true;
 					}
 
-					try (MCTiming timing = ProjectKorra.timing(abil.getName()).startTiming()) {
+					//try (MCTiming timing = ProjectKorra.timing(abil.getName()).startTiming()) {
 						abil.progress();
-					}
+					//}
 
 					Bukkit.getServer().getPluginManager().callEvent(new AbilityProgressEvent(abil));
 				} catch (final Exception e) {

--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -21,6 +21,7 @@ import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 
 import net.md_5.bungee.api.ChatColor;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a player's scoreboard for bending purposes
@@ -59,7 +60,7 @@ public class BendingBoard {
 			obj.getScore(entry).setScore(-s);
 		}
 		
-		public void update(String prefix, String name) {
+		public void update(@NotNull String prefix, @NotNull String name) {
 			team.setPrefix(prefix);
 			team.setSuffix(name);
 			set();
@@ -68,11 +69,6 @@ public class BendingBoard {
 		public void setSlot(int slot) {
 			this.slot = slot + 1;
 			set();
-		}
-
-		public void decreaseSlot() {
-			--this.slot;
-			clear(true);
 		}
 
 		public void clear(boolean formNewTeam) {
@@ -86,8 +82,6 @@ public class BendingBoard {
 				}
 			}
 			board.resetScores(entry);
-
-			next.ifPresent(BoardSlot::decreaseSlot);
 		}
 		
 		private void setNext(BoardSlot slot) {

--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -76,13 +76,16 @@ public class BendingBoard {
 		}
 
 		public void clear(boolean formNewTeam) {
-			String prefix = team.getPrefix(), suffix = team.getSuffix();
-			board.resetScores(entry);
-			team.unregister();
-			if (formNewTeam) {
-				formTeam();
-				update(prefix, suffix);
+			if (team.getScoreboard() != null) { //In case the team has already been unregistered
+				String prefix = team.getPrefix(), suffix = team.getSuffix();
+				team.unregister();
+				if (formNewTeam) {
+					formTeam();
+					update(prefix, suffix);
+				}
 			}
+			board.resetScores(entry);
+
 			next.ifPresent(BoardSlot::decreaseSlot);
 		}
 		

--- a/src/com/projectkorra/projectkorra/board/BendingBoard.java
+++ b/src/com/projectkorra/projectkorra/board/BendingBoard.java
@@ -76,7 +76,8 @@ public class BendingBoard {
 		}
 
 		public void clear(boolean formNewTeam) {
-			if (team.getScoreboard() != null) { //In case the team has already been unregistered
+			//Make sure the team hasn't already been unregistered
+			if (team.getScoreboard() != null && team.getScoreboard().getTeam("slot" + this.slot) != null) {
 				String prefix = team.getPrefix(), suffix = team.getSuffix();
 				team.unregister();
 				if (formNewTeam) {

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1307,6 +1307,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.WaterSpout.Wave.FlightDuration", 2500);
 			config.addDefault("Abilities.Water.WaterSpout.Wave.Speed", 1.3);
 			config.addDefault("Abilities.Water.WaterSpout.Wave.Cooldown", 6000);
+			config.addDefault("Abilities.Water.WaterSpout.Wave.TrailRevertTime", 1000);
 
 			config.addDefault("Abilities.Water.IceWave.Enabled", true);
 			config.addDefault("Abilities.Water.IceWave.Damage", 3);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1533,7 +1533,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Fire.Combustion.Enabled", true);
 			config.addDefault("Abilities.Fire.Combustion.Cooldown", 10000);
 			config.addDefault("Abilities.Fire.Combustion.BreakBlocks", false);
-			config.addDefault("Abilities.Fire.Combustion.ExplosivePower", 1.0);
+			config.addDefault("Abilities.Fire.Combustion.ExplosivePower", 2.0);
 			config.addDefault("Abilities.Fire.Combustion.Damage", 4);
 			config.addDefault("Abilities.Fire.Combustion.Radius", 4);
 			config.addDefault("Abilities.Fire.Combustion.Range", 35);

--- a/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
+++ b/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
@@ -1,6 +1,5 @@
 package com.projectkorra.projectkorra.firebending.combustion;
 
-import com.projectkorra.projectkorra.region.RegionProtection;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -18,6 +17,7 @@ import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.avatar.AvatarState;
 import com.projectkorra.projectkorra.util.DamageHandler;
 import com.projectkorra.projectkorra.util.ParticleEffect;
+import com.projectkorra.projectkorra.region.RegionProtection;
 
 public class Combustion extends CombustionAbility {
 

--- a/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
+++ b/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
@@ -1,5 +1,6 @@
 package com.projectkorra.projectkorra.firebending.combustion;
 
+import com.projectkorra.projectkorra.region.RegionProtection;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -71,7 +72,7 @@ public class Combustion extends CombustionAbility {
 			this.damage = this.getDayFactor(this.damage);
 		}*/
 
-		if (GeneralMethods.isRegionProtectedFromBuild(this, GeneralMethods.getTargetedLocation(player, this.range))) {
+		if (RegionProtection.isRegionProtected(this, GeneralMethods.getTargetedLocation(player, this.range))) {
 			return;
 		}
 
@@ -115,12 +116,7 @@ public class Combustion extends CombustionAbility {
 	}
 
 	private void createExplosion(final Location block, final float power, final boolean canBreakBlocks) {
-		ParticleEffect.EXPLOSION_LARGE.display(block, 3, 2, 2, 2, 0);
-		
-		if (canFireGrief()) {
-			block.getWorld().createExplosion(block.getX(), block.getY(), block.getZ(), power, true, canBreakBlocks);
-		}
-		for (final Entity entity : block.getWorld().getEntities()) {
+		for (Entity entity : GeneralMethods.getEntitiesAroundPoint(block, power)) {
 			if (entity instanceof LivingEntity) {
 				if (entity.getLocation().distanceSquared(block) < this.radius * this.radius) { // They are close enough to the explosion.
 					DamageHandler.damageEntity(entity, this.damage, this);
@@ -128,6 +124,8 @@ public class Combustion extends CombustionAbility {
 				}
 			}
 		}
+
+		block.getWorld().createExplosion(block.getX(), block.getY(), block.getZ(), power, canFireGrief(), canBreakBlocks);
 		
 		this.remove();
 	}
@@ -137,7 +135,7 @@ public class Combustion extends CombustionAbility {
 		if (!this.bPlayer.canBendIgnoreCooldowns(this)) {
 			this.remove();
 			return;
-		} else if (GeneralMethods.isRegionProtectedFromBuild(this, this.location)) {
+		} else if (RegionProtection.isRegionProtected(this, this.location)) {
 			this.remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/region/FactionsUUID.java
+++ b/src/com/projectkorra/projectkorra/region/FactionsUUID.java
@@ -17,7 +17,7 @@ class FactionsUUID extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final FPlayer fPlayer = FPlayers.getInstance().getByPlayer(player);
         FLocation fLoc = new FLocation(location.getWorld().getName(), location.getBlockX() >> 4, location.getBlockZ() >> 4);
         final Faction faction = com.massivecraft.factions.Board.getInstance().getFactionAt(fLoc);

--- a/src/com/projectkorra/projectkorra/region/GriefDefender.java
+++ b/src/com/projectkorra/projectkorra/region/GriefDefender.java
@@ -12,10 +12,11 @@ class GriefDefender extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final com.griefdefender.api.claim.Claim claim = com.griefdefender.api.GriefDefender.getCore().getClaimAt(location);
         if (claim != null) {
             final User user = com.griefdefender.api.GriefDefender.getCore().getUser(player.getUniqueId());
+
             return !claim.canBreak(player, location, user);
         }
 

--- a/src/com/projectkorra/projectkorra/region/GriefPrevention.java
+++ b/src/com/projectkorra/projectkorra/region/GriefPrevention.java
@@ -12,7 +12,7 @@ class GriefPrevention extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final String reason = me.ryanhamshire.GriefPrevention.GriefPrevention.instance.allowBuild(player, location);
 
         final Claim claim = me.ryanhamshire.GriefPrevention.GriefPrevention.instance.dataStore.getClaimAt(location, true, null);

--- a/src/com/projectkorra/projectkorra/region/LWC.java
+++ b/src/com/projectkorra/projectkorra/region/LWC.java
@@ -12,7 +12,7 @@ class LWC extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final com.griefcraft.lwc.LWC lwc2 = com.griefcraft.lwc.LWC.getInstance();
         final Protection protection = lwc2.getProtectionCache().getProtection(location.getBlock());
         if (protection != null) {

--- a/src/com/projectkorra/projectkorra/region/Lands.java
+++ b/src/com/projectkorra/projectkorra/region/Lands.java
@@ -2,8 +2,11 @@ package com.projectkorra.projectkorra.region;
 
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.CoreAbility;
+import me.angeschossen.lands.api.LandsIntegration;
 import me.angeschossen.lands.api.flags.Flags;
-import me.angeschossen.lands.api.integration.LandsIntegration;
+import me.angeschossen.lands.api.flags.enums.FlagTarget;
+import me.angeschossen.lands.api.flags.enums.RoleFlagCategory;
+import me.angeschossen.lands.api.flags.type.RoleFlag;
 import me.angeschossen.lands.api.land.Area;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -15,17 +18,17 @@ class Lands extends RegionProtectionBase {
     protected Lands() {
         super("Lands");
 
-        this.landsIntegration = new LandsIntegration(ProjectKorra.plugin);
+        this.landsIntegration = LandsIntegration.of(ProjectKorra.plugin);
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
-        final Area area = landsIntegration.getAreaByLoc(location);
-        final boolean isClaimed = landsIntegration.isClaimed(location);
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
+        final Area area = this.landsIntegration.getArea(location);
+        final boolean isClaimed = area != null;
 
         if (isClaimed) {
             if (igniteAbility && !area.hasFlag(player.getUniqueId(), Flags.BLOCK_IGNITE)) return true;
-            if (explosiveAbility && !area.hasFlag(Flags.TNT_GRIEFING)) return true;
+            if (explosiveAbility && !area.hasNaturalFlag(Flags.TNT_GRIEFING)) return true;
             return !area.hasFlag(player.getUniqueId(), Flags.BLOCK_BREAK);
         }
 

--- a/src/com/projectkorra/projectkorra/region/RedProtect.java
+++ b/src/com/projectkorra/projectkorra/region/RedProtect.java
@@ -13,11 +13,11 @@ class RedProtect extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final RedProtectAPI api = br.net.fabiozumbi12.RedProtect.Bukkit.RedProtect.get().getAPI();
         final Region region = api.getRegion(location);
         if (region != null) {
-            if (!region.canBuild(player) && !harmless) return true;
+            if (!region.canBuild(player)) return true;
             return !region.canFire() && (igniteAbility || explosiveAbility);
         }
 

--- a/src/com/projectkorra/projectkorra/region/RegionProtectionBase.java
+++ b/src/com/projectkorra/projectkorra/region/RegionProtectionBase.java
@@ -46,13 +46,13 @@ public abstract class RegionProtectionBase implements RegionProtectionHook {
                 isHarmless = ability.isHarmlessAbility();
             }
 
-            if (ability == null && allowHarmless) {
+            if ((ability == null || isHarmless) && allowHarmless) {
                 return false;
             }
-            return isRegionProtectedReal(player, location, ability, isHarmless, isIgnite, isExplosive);
+            return isRegionProtectedReal(player, location, ability, isIgnite, isExplosive);
         }
         return false;
     }
 
-    public abstract boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility);
+    public abstract boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility);
 }

--- a/src/com/projectkorra/projectkorra/region/Residence.java
+++ b/src/com/projectkorra/projectkorra/region/Residence.java
@@ -28,7 +28,7 @@ class Residence extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final ResidenceInterface res = com.bekvon.bukkit.residence.Residence.getInstance().getResidenceManagerAPI();
         final ClaimedResidence claim = res.getByLoc(location);
         if (claim != null) {
@@ -36,7 +36,7 @@ class Residence extends RegionProtectionBase {
             //If is their residence
             if (perms.hasResidencePermission(player, false)) return false;
             //If the bending flag is turned off
-            if (!perms.playerHas(player.getName(), this.flag, false)) {
+            if (!perms.playerHas(player, this.flag, false)) {
                 return true;
             }
         }

--- a/src/com/projectkorra/projectkorra/region/SaberFactions.java
+++ b/src/com/projectkorra/projectkorra/region/SaberFactions.java
@@ -16,7 +16,7 @@ class SaberFactions extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final FPlayer fPlayer = FPlayers.getInstance().getByPlayer(player);
         FLocation fLoc = new FLocation(location.getWorld().getName(), location.getBlockX() >> 4, location.getBlockZ() >> 4);
         final Faction faction = com.massivecraft.factions.Board.getInstance().getFactionAt(fLoc);

--- a/src/com/projectkorra/projectkorra/region/Towny.java
+++ b/src/com/projectkorra/projectkorra/region/Towny.java
@@ -14,7 +14,7 @@ class Towny extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         if (!PlayerCacheUtil.getCachePermission(player, location, Material.DIRT, TownyPermission.ActionType.BUILD)) {
             return true;
         }

--- a/src/com/projectkorra/projectkorra/region/WorldGuard.java
+++ b/src/com/projectkorra/projectkorra/region/WorldGuard.java
@@ -16,7 +16,7 @@ class WorldGuard extends RegionProtectionBase {
     }
 
     @Override
-    public boolean isRegionProtectedReal(Player player, org.bukkit.Location reallocation, CoreAbility ability, boolean harmless, boolean igniteAbility, boolean explosiveAbility) {
+    public boolean isRegionProtectedReal(Player player, org.bukkit.Location reallocation, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         World world = reallocation.getWorld();
 
         if (player.hasPermission("worldguard.region.bypass." + world.getName())) return false;

--- a/src/com/projectkorra/projectkorra/util/ChatUtil.java
+++ b/src/com/projectkorra/projectkorra/util/ChatUtil.java
@@ -8,6 +8,7 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.apache.logging.log4j.util.Strings;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -22,6 +23,8 @@ public class ChatUtil {
      * @param message
      */
     public static void sendBrandingMessage(final CommandSender receiver, final String message) {
+        if (Strings.isEmpty(ChatColor.stripColor(message))) return;
+
         ChatColor color;
         try {
             color = ChatColor.of(ConfigManager.languageConfig.get().getString("Chat.Branding.Color").toUpperCase());

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -5,6 +5,7 @@ import com.projectkorra.projectkorra.ProjectKorra;
 import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -119,6 +120,8 @@ public class DamageHandler {
 		ARMOR_PERCENTAGE_BY_ENTITY_ID.remove(event.getEntity().getEntityId()); // We get rid of the entry, so it doesn't call back future non-ability related damage.
 
 		if (ignorePercentage == 0) return;
+
+		if (event.getEntity() instanceof ArmorStand) return; //ArmorStands produce errors when we modify the armor damage, so ignore them.
 
 		if (ignorePercentage == 1) {
 			event.setDamage(EntityDamageEvent.DamageModifier.ARMOR, 0);

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -20,6 +20,7 @@ import com.projectkorra.projectkorra.event.EntityBendingDeathEvent;
 
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.hooks.NCPExemptionManager;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,21 +37,21 @@ public class DamageHandler {
 		return entity.getNoDamageTicks() > entity.getMaximumNoDamageTicks() / 2.0f && damage <= entity.getLastDamage();
 	}
 
-
-
-
-
 	/**
 	 *
 	 * @param entity The entity that is being damaged.
 	 * @return If this damage event should be call-backed to {@link #entityDamageCallback(EntityDamageEvent)}.
 	 */
-	public static boolean ignoreArmor(Entity entity) {
+	public static boolean ignoreArmor(@NotNull Entity entity) {
 		return ARMOR_PERCENTAGE_BY_ENTITY_ID.containsKey(entity.getEntityId());
 	}
 
-
-	public static double getIgnoreArmorPercentage(final Ability ability) {
+	/**
+	 * Get the percentage of armor that should be ignored for this ability.
+	 * @param ability The ability
+	 * @return The percentage, between 0.0 and 1.0
+	 */
+	public static double getIgnoreArmorPercentage(@NotNull final Ability ability) {
 		FileConfiguration config = ProjectKorra.plugin.getConfig();
 
 		double percentage = config.getDouble(IGNORE_ARMOR_PREFIX + "Default", 0.0);
@@ -236,7 +237,7 @@ public class DamageHandler {
 	}
 	
 	public static void damageEntity(final Entity entity, final Player source, final double damage, final Ability ability, final boolean ignoreArmor) {
-		damageEntity(entity, source, damage, ability, ignoreArmor);
+		damageEntity(entity, source, damage, ability, ignoreArmor, false);
 	}
 	
 	public static void damageEntity(final Entity entity, final double damage, final Ability ability, final boolean ignoreArmor) {

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -431,24 +431,6 @@ public class TempBlock {
 		this.block.setBlockData(data, applyPhysics(data.getMaterial()));
 	}
 
-	public static void startReversion() {
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				final long currentTime = System.currentTimeMillis();
-				while (!REVERT_QUEUE.isEmpty()) {
-					final TempBlock tempBlock = REVERT_QUEUE.peek();
-					if (currentTime >= tempBlock.revertTime) {
-						REVERT_QUEUE.poll();
-						tempBlock.revertBlock();
-					} else {
-						break;
-					}
-				}
-			}
-		}.runTaskTimer(ProjectKorra.plugin, 0, 1);
-	}
-
 	/**
 	 * @return If the TempBlock has reverted
 	 */

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -472,4 +472,18 @@ public class TempBlock {
 		}
 	}
 
+	@Override
+	public String toString() {
+		return "TempBlock{" +
+				"block=[" + block.getX() + "," + block.getY() + "," + block.getZ() + "]" +
+				", newData=" + newData.getAsString() +
+				", attachedTempBlocks=" + attachedTempBlocks.size() +
+				", revertTime=" + (revertTime == 0 ? "N/A" : (revertTime - System.currentTimeMillis()) + "ms") +
+				", reverted=" + reverted +
+				", revertTask=" + (revertTask != null) +
+				", ability=" + (ability.isPresent() ? ability.get().getClass() : "null") +
+				", isBendableSource=" + isBendableSource +
+				", suffocate=" + suffocate +
+				'}';
+	}
 }

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -71,6 +71,7 @@ public class WaterSpoutWave extends WaterAbility {
 	@Attribute(Attribute.DAMAGE)
 	private double damage;
 	private double animationSpeed;
+	private long trailRevertTime;
 	private AbilityType type;
 	private AnimateState animation;
 	private Block sourceBlock;
@@ -101,6 +102,7 @@ public class WaterSpoutWave extends WaterAbility {
 		this.cooldown = applyInverseModifiers(getConfig().getLong("Abilities.Water.WaterSpout.Wave.Cooldown"));
 		this.revertSphereTime = getConfig().getLong("Abilities.Water.IceWave.RevertSphereTime");
 		this.revertIceSphere = getConfig().getBoolean("Abilities.Water.IceWave.RevertSphere");
+		this.trailRevertTime = getConfig().getLong("Abilities.Water.WaterSpout.Wave.TrailRevertTime");
 		this.affectedBlocks = new ConcurrentHashMap<>();
 		this.affectedEntities = new ArrayList<>();
 		this.tasks = new ArrayList<>();
@@ -383,8 +385,8 @@ public class WaterSpoutWave extends WaterAbility {
 		if (this.affectedBlocks.containsKey(block)) {
 			this.affectedBlocks.get(block).revertBlock();
 		}
-		TempBlock tb = new TempBlock(block, mat.createBlockData(), 20L);
-		tb.setRevertTask(() -> affectedBlocks.remove(block));
+		TempBlock tb = new TempBlock(block, mat.createBlockData(), this.trailRevertTime);
+		tb.setRevertTask(() -> this.affectedBlocks.remove(block));
 		this.affectedBlocks.put(block, tb);
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -2,10 +2,9 @@ package com.projectkorra.projectkorra.waterbending;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -25,6 +24,7 @@ import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;
+import com.projectkorra.projectkorra.region.RegionProtection;
 import com.projectkorra.projectkorra.util.DamageHandler;
 import com.projectkorra.projectkorra.util.TempBlock;
 import com.projectkorra.projectkorra.waterbending.combo.IceWave;
@@ -254,7 +254,7 @@ public class WaterSpoutWave extends WaterAbility {
 				}
 			} else if (this.animation == AnimateState.TOWARD_PLAYER) {
 				this.revertBlocks();
-				final Location eyeLoc = this.player.getTargetBlock((HashSet<Material>) null, 2).getLocation();
+				final Location eyeLoc = this.player.getTargetBlock(null, 2).getLocation();
 				eyeLoc.setY(this.player.getEyeLocation().getY());
 				final Vector vec = GeneralMethods.getDirection(this.location, eyeLoc);
 				this.location.add(vec.normalize().multiply(this.animationSpeed));
@@ -303,7 +303,7 @@ public class WaterSpoutWave extends WaterAbility {
 				}
 				GeneralMethods.setVelocity(this, this.player, this.player.getEyeLocation().getDirection().normalize().multiply(currentSpeed));
 				for (final Block block : GeneralMethods.getBlocksAroundPoint(this.player.getLocation().add(0, -1, 0), this.waveRadius)) {
-					if (ElementalAbility.isAir(block.getType()) && !GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
+					if (ElementalAbility.isAir(block.getType()) && !RegionProtection.isRegionProtected(this, block.getLocation())) {
 						if (this.iceWave) {
 							this.createBlockDelay(block, Material.ICE, 2L);
 						} else {
@@ -311,7 +311,6 @@ public class WaterSpoutWave extends WaterAbility {
 						}
 					}
 				}
-				this.revertBlocksDelay(20L);
 
 				if (this.iceWave && this.progressCounter % 3 == 0) {
 					for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.player.getLocation().add(0, -1, 0), this.waveRadius * 1.5)) {
@@ -381,10 +380,12 @@ public class WaterSpoutWave extends WaterAbility {
 	}
 
 	public void createBlock(final Block block, final Material mat) {
-		if (this.affectedBlocks.contains(block)) {
+		if (this.affectedBlocks.containsKey(block)) {
 			this.affectedBlocks.get(block).revertBlock();
 		}
-		this.affectedBlocks.put(block, new TempBlock(block, mat));
+		TempBlock tb = new TempBlock(block, mat.createBlockData(), 20L);
+		tb.setRevertTask(() -> affectedBlocks.remove(block));
+		this.affectedBlocks.put(block, tb);
 	}
 
 	public void revertBlocks() {
@@ -396,24 +397,6 @@ public class WaterSpoutWave extends WaterAbility {
 		}
 	}
 
-	public void revertBlocksDelay(final long delay) {
-		final Enumeration<Block> keys = this.affectedBlocks.keys();
-		while (keys.hasMoreElements()) {
-			final Block block = keys.nextElement();
-			final TempBlock tblock = this.affectedBlocks.get(block);
-			this.affectedBlocks.remove(block);
-
-			new BukkitRunnable() {
-				@Override
-				public void run() {
-					if (!FROZEN_BLOCKS.containsKey(block)) {
-						tblock.revertBlock();
-					}
-				}
-			}.runTaskLater(ProjectKorra.plugin, delay);
-		}
-	}
-
 	public void createIceSphere(final Player player, final Entity entity, final double radius) {
 		for (double x = -radius; x <= radius; x += 0.5) {
 			for (double y = -radius; y <= radius; y += 0.5) {
@@ -422,11 +405,11 @@ public class WaterSpoutWave extends WaterAbility {
 					if (block.getLocation().distanceSquared(entity.getLocation().getBlock().getLocation()) > radius * radius) {
 						continue;
 					}
-					if (GeneralMethods.isRegionProtectedFromBuild(this, block.getLocation())) {
+					if (RegionProtection.isRegionProtected(this, block.getLocation())) {
 						continue;
 					}
 					if (entity instanceof Player) {
-						if (Commands.invincible.contains(((Player) entity).getName())) {
+						if (Commands.invincible.contains(entity.getName())) {
 							return;
 						}
 						if (!getConfig().getBoolean("Properties.Water.FreezePlayerHead") && GeneralMethods.playerHeadIsInBlock((Player) entity, block)) {
@@ -441,7 +424,7 @@ public class WaterSpoutWave extends WaterAbility {
 							final TempBlock tblock = new TempBlock(block, Material.ICE);
 							FROZEN_BLOCKS.put(block, tblock);
 							if (this.revertIceSphere) {
-								tblock.setRevertTime(this.revertSphereTime + (new Random().nextInt(1000) - 500));
+								tblock.setRevertTime(this.revertSphereTime + ThreadLocalRandom.current().nextLong(-500, 500));
 							}
 						}
 					}
@@ -468,7 +451,7 @@ public class WaterSpoutWave extends WaterAbility {
 	}
 
 	public static ArrayList<WaterSpoutWave> getType(final Player player, final AbilityType type) {
-		final ArrayList<WaterSpoutWave> list = new ArrayList<WaterSpoutWave>();
+		final ArrayList<WaterSpoutWave> list = new ArrayList<>();
 		for (final WaterSpoutWave wave : getAbilities(player, WaterSpoutWave.class)) {
 			if (wave.type.equals(type)) {
 				list.add(wave);
@@ -541,7 +524,7 @@ public class WaterSpoutWave extends WaterAbility {
 
 	@Override
 	public boolean isSneakAbility() {
-		return this.isIceWave() ? true : false;
+		return this.isIceWave();
 	}
 
 	@Override

--- a/src/com/projectkorra/projectkorra/waterbending/ice/PhaseChange.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/PhaseChange.java
@@ -481,7 +481,7 @@ public class PhaseChange extends IceAbility {
 	}
 
 	public void revertFrozenBlocks() {
-		if (this.active_types.contains(PhaseChangeType.FREEZE)) {
+		if (this.active_types.contains(PhaseChangeType.FREEZE) || this.active_types.contains(PhaseChangeType.CUSTOM)) {
 			for (final TempBlock tb : this.blocks) {
 				PLAYER_BY_BLOCK.remove(tb);
 				BLOCKS.remove(tb.getBlock());

--- a/src/staff.txt
+++ b/src/staff.txt
@@ -6,6 +6,8 @@ a47a4d04-9f51-44ba-9d35-8de6053e9289/&5ProjectKorra Developer/ AlexTheCoder
 592fb564-701a-4a5e-9d65-13f7ed0acf59/&5ProjectKorra Developer/ Vahagn
 5e7db6d3-add9-4aab-b1fc-3dda8f5713f4/&5ProjectKorra Developer/ Prride
 f6c4aac7-9cc2-4da2-9038-e26bb808461d/&5ProjectKorra Developer/ Tyson
+476ca51b-ec04-431b-87da-dd22b20aa8bf/&5ProjectKorra Developer/ JustAHuman_xD
+71d42b35-dd94-408e-941d-88d4a61031c7/&5ProjectKorra Developer/ Dreig_Michihi
 383764b8-5473-43c7-8255-a7304c55746a/&dProjectKorra Discord Helper/ Shad
 e98a2f7d-d571-4900-a625-483cbe6774fe/&5ProjectKorra Contributor/ Aztl
 dd578a4f-d35e-4fed-94db-9d5a627ff962/&5ProjectKorra Contributor/ Sobki
@@ -23,8 +25,6 @@ c364ffe2-de9e-4117-9735-6d14bde038f6/&3ProjectKorra Contributor/ Carbogen
 de68cc29-e4ee-4986-990c-ae3e4365a3bc/&3ProjectKorra Contributor/ Sammycocobear
 929b14fc-aaf1-4f0f-84c2-f20c55493f53/&3ProjectKorra Contributor/ Vidcom
 dbd59467-7307-4981-8e3e-7dcf36dd569c/&3ProjectKorra Contributor/ Bit
-476ca51b-ec04-431b-87da-dd22b20aa8bf/&3ProjectKorra Contributor/ JustAHuman_xD
-71d42b35-dd94-408e-941d-88d4a61031c7/&3ProjectKorra Contributor/ Dreig_Michihi
 5e30a511-c9eb-4326-be40-ba4dfc5cd7c1/&3ProjectKorra Contributor/ DomiRusz24
 b6bd2ceb-4922-4707-9173-8a02044e9069/&3ProjectKorra Contributor/ Dooder07
 524f1fdb-28dd-456b-a005-7f61d71fe836/&3ProjectKorra Contributor/ KWilson272


### PR DESCRIPTION
Contains the bug fixes:

- Muted paper timing spam
- Fixed BendingBoard slowly disappearing as more combos are used over time
- Fixed Temp Lava not doing damage to entities if it doesn't belong to any ability. (#1280)
- Fixed passives not working in region protection (#1278)
- Fixed dynamic sourcing being weird for left click moves. This would require double clicking for a lot of moves, like RaiseEarth and Torrent. (#1277)
- Fixed OctopusForm ice not reverting if you log out
- Fixed placing blocks in Surge shield (SurgeWall) deleting blocks (#1216)
- Fixed day/night messages being the wrong way around
- Fixed damaging ArmorStands with bending causing errors
- Fixed StackOverFlow when using a certain damageEntity method
- Made Combustion work better when FireGrief is false
- Fixed sourcing and BendingPreview working in disabled worlds
- Fixed bending reload command erroring without PAPI installed
- Fixed 'IllegalArgumentException: string cannot be null' when the sub color for an element isn't provided/was deleted from the config
- Fixed IceWave leaving behind some ice blocks that can't be melted when freezing players. Thanks @Aztlon for fixing this issue! Appreciate it <3
- Made the WaterWave trail length configurable
- Updated Lands support to 6.26.X and higher

To fix Surge deleting blocks, I switched Surge to use the new TempBlock system. Previously, it just reverted all blocks in that spot, so making it revert individual TempBlocks stops it from eating placed blocks within the water.