### PR TITLE
Added another constructor to MultiAbilityInfoSub

### DIFF
--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -241,10 +241,17 @@ public class MultiAbilityManager {
 	public static class MultiAbilityInfoSub {
 		private String name;
 		private Element element;
+		private ChatColor color;
 
 		public MultiAbilityInfoSub(final String name, final Element element) {
 			this.name = name;
 			this.element = element;
+		}
+
+		public MultiAbilityInfoSub(final String name, final Element element, final ChatColor color) {
+			this.name = name;
+			this.element = element;
+			this.color = color;
 		}
 
 		public Element getElement() {
@@ -264,7 +271,15 @@ public class MultiAbilityManager {
 		}
 
 		public ChatColor getAbilityColor() {
-			return this.element != null ? this.element.getColor() : null;
+			if (this.element == null){
+				return null;
+			}
+
+			if (this.color == null){
+				return this.element.getColor();
+			}else{
+				return this.color;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Additions
  > * Adds a new additional constructor to the MultiAbilityInfoSub class with one new ChatColor parameter that allows for the MutliAbilities sub-abilities to have a custom color.

## Misc. Changes
  > * Slightly changes the logic inside of the `getAbilityColor()` function to allow for the implementation of the new constructor. My logic is (hopefully) correct so it should have no side effects.

Here is an attached image of this in effect.
![Badlion Client Screenshot 2023 04 22 - 19 39 24 71](https://user-images.githubusercontent.com/88066768/233812080-fd4eb29e-c9d7-4485-a61e-106337807739.png)

My `getMultiAbilities` function looks like this

```java
   @Override
    public ArrayList<MultiAbilityManager.MultiAbilityInfoSub> getMultiAbilities() {
        ArrayList<MultiAbilityManager.MultiAbilityInfoSub> multiAbilityInfoSubs = new ArrayList<>();
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test1", Element.FIRE));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test2", Element.WATER));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test3", Element.EARTH));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test4", Element.AIR));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test5", Element.CHI));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test6", Element.PLANT, ChatColor.of("#283552")));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test7", Element.PLANT, ChatColor.of("#4a3245")));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("Test8", Element.PLANT, ChatColor.of("#f591e3")));
        multiAbilityInfoSubs.add(new MultiAbilityManager.MultiAbilityInfoSub("EXIT", Element.FIRE, ChatColor.of("#cfdcb5")));

        return multiAbilityInfoSubs;
    }
```