### PR TITLE
Add missing space between ability name and <passive / addon passive>

### DIFF
--- a/src/com/projectkorra/projectkorra/command/HelpCommand.java
+++ b/src/com/projectkorra/projectkorra/command/HelpCommand.java
@@ -125,7 +125,7 @@ public class HelpCommand extends PKCommand {
 			final boolean isPassiveAbility = ability instanceof PassiveAbility;
 			
 			
-			sender.sendMessage(color + (ChatColor.BOLD + ability.getName()) + ChatColor.WHITE + (isAddonAbility ? (isPassiveAbility ? "(Addon Passive)" : " (Addon)") : (isPassiveAbility ? "(Passive)" : "")));
+			sender.sendMessage(color + (ChatColor.BOLD + ability.getName()) + ChatColor.WHITE + (isAddonAbility ? (isPassiveAbility ? " (Addon Passive)" : " (Addon)") : (isPassiveAbility ? " (Passive)" : "")));
 			sender.sendMessage(color + ability.getDescription());
 			
 			if (!ability.getInstructions().isEmpty()) {


### PR DESCRIPTION
## Fixes
- Adds missing spaces between the ability name and the (Addon Passive) or (Passive)
