### PR TITLE
Add duration setting to Torrent

### DIFF
--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1203,7 +1203,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.Torrent.Knockup", 0.2);
 			config.addDefault("Abilities.Water.Torrent.Interval", 30);
 			config.addDefault("Abilities.Water.Torrent.Cooldown", 0);
-			config.addDefault("Abilities.Water.Torrent.Duration", 0);
+			config.addDefault("Abilities.Water.Torrent.ChargeTimeout", 0);
 			config.addDefault("Abilities.Water.Torrent.Revert", true);
 			config.addDefault("Abilities.Water.Torrent.RevertTime", 60000);
 			config.addDefault("Abilities.Water.Torrent.Wave.Radius", 12);

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1203,6 +1203,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.Torrent.Knockup", 0.2);
 			config.addDefault("Abilities.Water.Torrent.Interval", 30);
 			config.addDefault("Abilities.Water.Torrent.Cooldown", 0);
+			config.addDefault("Abilities.Water.Torrent.Duration", 0);
 			config.addDefault("Abilities.Water.Torrent.Revert", true);
 			config.addDefault("Abilities.Water.Torrent.RevertTime", 60000);
 			config.addDefault("Abilities.Water.Torrent.Wave.Radius", 12);

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -55,7 +55,7 @@ public class Torrent extends WaterAbility {
 	@Attribute(Attribute.COOLDOWN)
 	private long cooldown;
 	@Attribute(Attribute.DURATION)
-	private long duration;
+	private long chargeTimeout;
 	private long revertTime;
 	private double startAngle;
 	private double angle;
@@ -100,7 +100,7 @@ public class Torrent extends WaterAbility {
 		this.range = applyModifiers(getConfig().getDouble("Abilities.Water.Torrent.Range"));
 		this.selectRange = applyModifiers(getConfig().getDouble("Abilities.Water.Torrent.SelectRange"));
 		this.cooldown = applyInverseModifiers(getConfig().getLong("Abilities.Water.Torrent.Cooldown"));
-		this.duration = applyInverseModifiers(getConfig().getLong("Abilities.Water.Torrent.Duration"));
+		this.chargeTimeout = applyInverseModifiers(getConfig().getLong("Abilities.Water.Torrent.ChargeTimeout"));
 		this.revert = getConfig().getBoolean("Abilities.Water.Torrent.Revert");
 		this.revertTime = getConfig().getLong("Abilities.Water.Torrent.RevertTime");
 		this.blocks = new ArrayList<>();
@@ -177,7 +177,7 @@ public class Torrent extends WaterAbility {
 			return;
 		}
 
-		if (this.duration > 0 && System.currentTimeMillis() > this.getStartTime() + this.duration) {
+		if (this.chargeTimeout > 0 && System.currentTimeMillis() > this.getStartTime() + this.chargeTimeout) {
 			this.remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -54,6 +54,8 @@ public class Torrent extends WaterAbility {
 	private long interval;
 	@Attribute(Attribute.COOLDOWN)
 	private long cooldown;
+	@Attribute(Attribute.DURATION)
+	private long duration;
 	private long revertTime;
 	private double startAngle;
 	private double angle;
@@ -98,6 +100,7 @@ public class Torrent extends WaterAbility {
 		this.range = applyModifiers(getConfig().getDouble("Abilities.Water.Torrent.Range"));
 		this.selectRange = applyModifiers(getConfig().getDouble("Abilities.Water.Torrent.SelectRange"));
 		this.cooldown = applyInverseModifiers(getConfig().getLong("Abilities.Water.Torrent.Cooldown"));
+		this.duration = applyInverseModifiers(getConfig().getLong("Abilities.Water.Torrent.Duration"));
 		this.revert = getConfig().getBoolean("Abilities.Water.Torrent.Revert");
 		this.revertTime = getConfig().getLong("Abilities.Water.Torrent.RevertTime");
 		this.blocks = new ArrayList<>();
@@ -172,7 +175,12 @@ public class Torrent extends WaterAbility {
 		if (!this.bPlayer.canBendIgnoreCooldowns(this)) {
 			this.remove();
 			return;
-		} 
+		}
+
+		if (this.duration > 0 && System.currentTimeMillis() > this.getStartTime() + this.duration) {
+			this.remove();
+			return;
+		}
 
 		if (System.currentTimeMillis() > this.time + this.interval) {
 			this.time = System.currentTimeMillis();


### PR DESCRIPTION
## Additions
* Adds a duration setting to Torrent. Defaults to zero, which is the current behavior of infinite duration. Duration refers to the amount of time water can circle the player before the ability ends. The motivation behind this change is that Torrent allows players to afk at mob grinders by holding down shift or using a weight. Now server owners can limit this if they choose to.