### PR TITLE
1.11.3 Fixes + TempBlock Optimization

### DIFF
--- a/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -222,7 +222,7 @@ public class BendingPlayer extends OfflineBendingPlayer {
 
 	public boolean canUsePassive(final CoreAbility ability) {
 		final Element element = ability.getElement();
-		if (!this.isToggled() || !this.isElementToggled(element) || !this.isPassiveToggled(element) || !this.isToggledPassives()) {
+		if ((!this.isToggled() && ConfigManager.defaultConfig.get().getBoolean("Properties.TogglePassivesWithAllBending")) || !this.isElementToggled(element) || !this.isPassiveToggled(element) || !this.isToggledPassives()) {
 			return false;
 		} else if (this.isChiBlocked() || this.isParalyzed() || this.isBloodbent()) {
 			return false;
@@ -232,7 +232,7 @@ public class BendingPlayer extends OfflineBendingPlayer {
 	}
 
 	public boolean canCurrentlyBendWithWeapons() {
-		if (this.getBoundAbility() != null && this.player.getInventory().getItemInMainHand() != null) {
+		if (this.getBoundAbility() != null) {
 			final boolean hasWeapon = GeneralMethods.isWeapon(this.player.getInventory().getItemInMainHand().getType());
 			final boolean noWeaponElement = GeneralMethods.getElementsWithNoWeaponBending().contains(this.getBoundAbility().getElement());
 

--- a/src/com/projectkorra/projectkorra/Element.java
+++ b/src/com/projectkorra/projectkorra/Element.java
@@ -135,7 +135,7 @@ public class Element {
 		if (this instanceof SubElement) {
 			name_ = ((SubElement) this).parentElement.name;
 		}
-		return this.getColor() + ChatUtil.color(ConfigManager.languageConfig.get().getString("Chat.Prefixes." + name_)) + " ";
+		return this.getColor() + ChatUtil.color(ConfigManager.languageConfig.get().getString("Chat.Prefixes." + name_, this.name)) + " ";
 	}
 
 	public ChatColor getColor() {

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -556,10 +556,17 @@ public class PKListener implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.NORMAL)
 	public void onEntityDamageEvent(final EntityDamageEvent event) {
 		final Entity entity = event.getEntity();
 		double damage = event.getDamage();
+
+		//Fix for MythicLib firing false EntityDamageEvents to test its own stuff
+		if (entity instanceof Player && event.getCause() == DamageCause.ENTITY_ATTACK
+				&& event.getDamage(EntityDamageEvent.DamageModifier.BASE) == 0
+				&& event.getFinalDamage() == 0) {
+			return;
+		}
 
 		if (BendingPlayer.isWorldDisabled(entity.getWorld())) {
 			return;

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -247,6 +247,7 @@ public class PKListener implements Listener {
 		final Block block = event.getBlock();
 		final Player player = event.getPlayer();
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
+		if (bPlayer == null) return;
 		final String abil = bPlayer.getBoundAbilityName();
 		CoreAbility ability;
 
@@ -1175,7 +1176,7 @@ public class PKListener implements Listener {
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
 		//If the world is disabled
-		if (!bPlayer.canBendInWorld()) {
+		if (bPlayer == null || !bPlayer.canBendInWorld()) {
 			return;
 		}
 
@@ -1218,7 +1219,7 @@ public class PKListener implements Listener {
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
 		//If the world is disabled
-		if (!bPlayer.canBendInWorld()) {
+		if (bPlayer == null || !bPlayer.canBendInWorld()) {
 			return;
 		}
 

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -642,7 +642,7 @@ public class PKListener implements Listener {
 	public void onEntityDeath(final EntityDeathEvent event) {
 		if (TempArmor.hasTempArmor(event.getEntity())) {
 			for (final TempArmor tarmor : TempArmor.getTempArmorList(event.getEntity())) {
-				tarmor.revert(event.getDrops());
+				tarmor.revert(event.getDrops(), false);
 			}
 
 			if (MetalClips.isControlled(event.getEntity())) {
@@ -823,7 +823,7 @@ public class PKListener implements Listener {
 
 		if (entity instanceof LivingEntity && TempArmor.hasTempArmor((LivingEntity) entity)) {
 			for (final TempArmor armor : TempArmor.getTempArmorList((LivingEntity) entity)) {
-				armor.revert(null);
+				armor.revert();
 			}
 		}
 
@@ -1106,7 +1106,7 @@ public class PKListener implements Listener {
 		if (event.getKeepInventory()) {
 			if (TempArmor.hasTempArmor(event.getEntity())) {
 				for (final TempArmor armor : TempArmor.getTempArmorList(event.getEntity())) {
-					armor.revert(event.getDrops());
+					armor.revert(event.getDrops(), event.getKeepInventory());
 				}
 			} // Do nothing. TempArmor drops are handled by the EntityDeath event and not PlayerDeath.
 		}
@@ -1446,7 +1446,7 @@ public class PKListener implements Listener {
 
 		if (TempArmor.hasTempArmor(player)) {
 			for (final TempArmor armor : TempArmor.getTempArmorList(player)) {
-				armor.revert(null);
+				armor.revert();
 			}
 		}
 

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -197,6 +197,7 @@ import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -2153,6 +2154,11 @@ public class PKListener implements Listener {
 	public void onPluginUnload(PluginDisableEvent event) {
 		RegionProtection.unloadPlugin((JavaPlugin) event.getPlugin());
 		BendingPlayer.HOOKS.remove((JavaPlugin) event.getPlugin());
+	}
+
+	@EventHandler
+	public void onWorldUnload(WorldUnloadEvent event) {
+		TempBlock.removeAllInWorld(event.getWorld());
 	}
 
 	public static HashMap<Player, Pair<String, Player>> getBendingPlayerDeath() {

--- a/src/com/projectkorra/projectkorra/PKListener.java
+++ b/src/com/projectkorra/projectkorra/PKListener.java
@@ -550,7 +550,7 @@ public class PKListener implements Listener {
 					event.setCancelled(true);
 					FireDamageTimer.dealFlameDamage(event.getEntity(), event.getDamage());
 				});
-			} else if (!TempBlock.get(block).canSuffocate() && event.getCause() == DamageCause.SUFFOCATION) {
+			} else if (!TempBlock.get(block).canSuffocate()) {
 				event.setCancelled(true);
 			}
 		}
@@ -573,6 +573,26 @@ public class PKListener implements Listener {
 			event.setCancelled(true);
 			FireDamageTimer.dealFlameDamage(entity, damage);
 		}
+
+		if (event.getCause() == DamageCause.SUFFOCATION) {
+			Block block = event.getEntity().getLocation().getBlock();
+			if (event.getEntity() instanceof LivingEntity) block = ((LivingEntity) event.getEntity()).getEyeLocation().getBlock();
+
+			if (TempBlock.isTempBlock(block)) {
+				if (EarthAbility.isEarthbendable(block.getType(), true, true, true) && GeneralMethods.isSolid(block)) {
+					event.setCancelled(true);
+				} else if (event.getCause() == DamageCause.LAVA && EarthAbility.isLava(block)) {
+					TempBlock.get(block).getAbility().ifPresent(ability -> {
+						new FireDamageTimer(event.getEntity(), ability.getPlayer(), ability, true);
+						event.setCancelled(true);
+						FireDamageTimer.dealFlameDamage(event.getEntity(), event.getDamage());
+					});
+				} else if (!TempBlock.get(block).canSuffocate()) {
+					event.setCancelled(true);
+				}
+			}
+		}
+
 
 		if (entity instanceof Player) {
 			final Player player = (Player) entity;

--- a/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -956,6 +956,7 @@ public abstract class CoreAbility implements Ability {
 			this.attributeModifiers.get(attribute).put(priority, new HashSet<>());
 		}
 		this.attributeModifiers.get(attribute).get(priority).add(new StoredModifier(uuid, modificationType, value));
+		this.attributesModified = false;
 		return this;
 	}
 
@@ -964,6 +965,7 @@ public abstract class CoreAbility implements Ability {
 		Validate.notNull(value, "value cannot be null");
 		Validate.isTrue(ATTRIBUTE_FIELDS.containsKey(this.getClass()) && ATTRIBUTE_FIELDS.get(this.getClass()).containsKey(attribute), "Attribute " + attribute + " is not a defined Attribute for " + this.getName());
 		this.attributeValues.put(attribute, value);
+		this.attributesModified = false;
 		return this;
 	}
 

--- a/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/MultiAbilityManager.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.projectkorra.projectkorra.OfflineBendingPlayer;
+import com.projectkorra.projectkorra.board.BendingBoardManager;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -73,6 +74,7 @@ public class MultiAbilityManager {
 				bPlayer.getAbilities().put(i + 1, modes.get(i).getAbilityColor() + modes.get(i).getName());
 			}
 		}
+		BendingBoardManager.updateAllSlots(player);
 		
 		player.getInventory().setHeldItemSlot(0);
 	}
@@ -184,6 +186,7 @@ public class MultiAbilityManager {
 		playerAbilities.compute(player, MultiAbilityManager::resetBinds);
 		playerBoundAbility.remove(player);
 		playerSlot.remove(player);
+		BendingBoardManager.updateAllSlots(player);
 	}
 	
 	private static HashMap<Integer, String> resetBinds(OfflinePlayer player, HashMap<Integer, String> prevBinds) {

--- a/src/com/projectkorra/projectkorra/ability/util/PassiveManager.java
+++ b/src/com/projectkorra/projectkorra/ability/util/PassiveManager.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.projectkorra.projectkorra.configuration.ConfigManager;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.BendingPlayer;
@@ -74,7 +75,7 @@ public class PassiveManager {
 			return false;
 		} else if (!bPlayer.canBendPassive(passive)) {
 			return false;
-		} else if (!bPlayer.isToggled()) {
+		} else if (!bPlayer.isToggled() && ConfigManager.defaultConfig.get().getBoolean("Properties.TogglePassivesWithAllBending")) {
 			return false;
 		} else if (!bPlayer.isElementToggled(element)) {
 			return false;

--- a/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -192,6 +192,8 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 			}
 		}
 
+		FlightMode oldMode = this.mode;
+
 		switch (this.player.getInventory().getHeldItemSlot()) {
 			case 0:
 				this.mode = FlightMode.SOAR;
@@ -206,6 +208,10 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 			case 3:
 				this.mode = FlightMode.ENDING;
 				break;
+		}
+
+		if (!bPlayer.getPlayer().hasPermission("bending.ability.Flight." + mode.name().toLowerCase())) {
+			this.mode = oldMode;
 		}
 
 		this.speed = this.player.getVelocity().length();

--- a/src/com/projectkorra/projectkorra/command/CooldownCommand.java
+++ b/src/com/projectkorra/projectkorra/command/CooldownCommand.java
@@ -56,6 +56,10 @@ public class CooldownCommand extends PKCommand {
             return;
         }
 
+        if (!this.hasPermission(sender)) {
+            return;
+        }
+
         OfflinePlayer oPlayer = list.size() == 1 ? (Player)sender : Bukkit.getOfflinePlayer(list.get(1));
         if (!oPlayer.isOnline() && !oPlayer.hasPlayedBefore()) {
             ChatUtil.sendBrandingMessage(sender, ChatColor.RED + ConfigManager.languageConfig.get().getString("Commands.Cooldown.InvalidPlayer"));
@@ -64,6 +68,10 @@ public class CooldownCommand extends PKCommand {
 
         BendingPlayer.getOrLoadOfflineAsync(oPlayer).thenAccept(bPlayer -> {
             if (Arrays.asList(new String[] {"view", "v"}).contains(list.get(0).toLowerCase())) {
+                if (!this.hasPermission(sender, "view")) {
+                    return;
+                }
+
                 List<String> cooldowns = bPlayer.getCooldowns().entrySet().stream()
                         .sorted(Comparator.comparingLong(entry -> entry.getValue().getCooldown()))
                         .filter(entry -> entry.getValue().getCooldown() > 0)
@@ -107,6 +115,10 @@ public class CooldownCommand extends PKCommand {
                 cooldown = list.get(2);
 
             if (list.size() > 3 && set) {
+                if (!this.hasPermission(sender, "set")) {
+                    return;
+                }
+
                 long time;
                 try {
                     time = TimeUtil.unformatTime(list.get(3));
@@ -134,8 +146,14 @@ public class CooldownCommand extends PKCommand {
                         oPlayer.getName()).replace("{cooldown}", fixedCooldown).replace("{value}", TimeUtil.formatTime(time));
                 ChatUtil.sendBrandingMessage(sender, ChatColor.GREEN + message);
             } else if (set) {
+                if (!this.hasPermission(sender, "set")) {
+                    return;
+                }
                 ChatUtil.sendBrandingMessage(sender, ChatColor.RED + ConfigManager.languageConfig.get().getString("Commands.Cooldown.SetNoValue"));
             } else {
+                if (!this.hasPermission(sender, "reset")) {
+                    return;
+                }
                 if (cooldown.equals("*") || cooldown.equalsIgnoreCase("ALL")) {
                     bPlayer.getCooldowns().keySet().forEach(bPlayer::removeCooldown); //We do this instead of clear() because we need to call the event
                     bPlayer.saveCooldowns();

--- a/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -639,7 +639,11 @@ public class ConfigManager {
 			plantBlocks.add("CRIMSON_FUNGUS");
 			plantBlocks.add("CRIMSON_ROOTS");
 			plantBlocks.add("FERN");
-			plantBlocks.add("GRASS");
+			if (mcVersion < 1203) { //1.20.3 changed GRASS to SHORT_GRASS
+				plantBlocks.add("GRASS");
+			} else {
+				plantBlocks.add("SHORT_GRASS");
+			}
 			plantBlocks.add("LARGE_FERN");
 			plantBlocks.add("LILY_PAD");
 			plantBlocks.add("MELON");

--- a/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -162,9 +162,13 @@ public class Tremorsense extends EarthAbility {
 
 	@Override
 	public void progress() {
-		if (!this.bPlayer.canBendIgnoreBindsCooldowns(this) || this.player.getLocation().getBlock().getLightLevel() > this.lightThreshold) {
+		//A replacement for the canBendIgnoreBindsCooldowns. Since this is used a passive, it should not turn off when bending is toggled.
+		if (!this.bPlayer.canBind(this) || this.bPlayer.isChiBlocked() || this.bPlayer.isParalyzed()
+				|| this.bPlayer.isBloodbent() || this.bPlayer.isControlledByMetalClips()
+				|| getConfig().getStringList("Properties.DisabledWorlds").contains(player.getLocation().getWorld().getName())) {
 			this.remove();
-			return;
+		} else if (this.player.getLocation().getBlock().getLightLevel() > this.lightThreshold) {
+			this.remove();
 		} else {
 			this.tryToSetGlowBlock();
 		}
@@ -182,7 +186,9 @@ public class Tremorsense extends EarthAbility {
 	public static boolean canTremorSense(final Player player) {
 		final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
 
-		if (bPlayer != null && bPlayer.canBendIgnoreBindsCooldowns(getAbility("Tremorsense"))) {
+		final Tremorsense this_ = (Tremorsense) getAbility(Tremorsense.class);
+
+		if (bPlayer != null && this_.isEnabled() && bPlayer.canBendPassive(this_) && bPlayer.canUsePassive(this_)) {
 			return true;
 		}
 

--- a/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
+++ b/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
@@ -27,6 +27,10 @@ public class Extraction extends MetalAbility {
 
 	//Whether the server is on at least 1.17 or not. Used to change between raw iron and iron ingots
 	private final boolean is117;
+	private final Material iron;
+	private final Material gold;
+	private final Material copper;
+	private final Material deepslate;
 
 	public Extraction(final Player player) {
 		super(player);
@@ -37,6 +41,10 @@ public class Extraction extends MetalAbility {
 		this.selectRange = getConfig().getInt("Abilities.Earth.Extraction.SelectRange");
 
 		this.is117 = GeneralMethods.getMCVersion() >= 1170;
+		this.iron = is117 ? Material.getMaterial("RAW_IRON") : Material.IRON_INGOT;
+		this.gold = is117 ? Material.getMaterial("RAW_GOLD") : Material.GOLD_INGOT;
+		this.copper = Material.getMaterial("RAW_COPPER");
+		this.deepslate = Material.getMaterial("DEEPSLATE");
 
 		if (!this.bPlayer.canBend(this)) {
 			return;
@@ -71,14 +79,18 @@ public class Extraction extends MetalAbility {
 
 		switch (this.originBlock.getType().name()) {
 		case "IRON_ORE":
-		case "DEEPSLATE_IRON_ORE":
 			type = Material.STONE;
-			item = new ItemStack(is117 ? Material.getMaterial("RAW_IRON") : Material.IRON_INGOT, this.getAmount( is117 ? 2 : 1 ));
+			item = new ItemStack(iron, this.getAmount(is117 ? 2 : 1 ));
+		case "DEEPSLATE_IRON_ORE":
+			type = deepslate;
+			item = new ItemStack(iron, this.getAmount(2));
 			break;
 		case "GOLD_ORE":
-		case "DEEPSLATE_GOLD_ORE":
 			type = Material.STONE;
-			item = new ItemStack(is117 ? Material.getMaterial("RAW_GOLD") : Material.GOLD_INGOT, this.getAmount( is117 ? 2 : 1 ));
+			item = new ItemStack(gold, this.getAmount( is117 ? 2 : 1 ));
+		case "DEEPSLATE_GOLD_ORE":
+			type = deepslate;
+			item = new ItemStack(gold, this.getAmount(2));
 			break;
 		case "NETHER_QUARTZ_ORE":
 			type = Material.NETHERRACK;
@@ -93,9 +105,11 @@ public class Extraction extends MetalAbility {
 			item = new ItemStack(Material.GOLD_NUGGET, this.getAmount(5));
 			break;
 		case "COPPER_ORE":
-		case "DEEPSLATE_COPPER_ORE":
 			type = Material.STONE;
-			item = new ItemStack(Material.getMaterial("RAW_COPPER"), this.getAmount(2));
+			item = new ItemStack(copper, this.getAmount(2));
+		case "DEEPSLATE_COPPER_ORE":
+			type = deepslate;
+			item = new ItemStack(copper, this.getAmount(2));
 			break;
 		default:
 			return;

--- a/src/com/projectkorra/projectkorra/firebending/Illumination.java
+++ b/src/com/projectkorra/projectkorra/firebending/Illumination.java
@@ -77,7 +77,10 @@ public class Illumination extends FireAbility {
 
 	@Override
 	public void progress() {
-		if (!this.bPlayer.canBendIgnoreBindsCooldowns(this)) {
+		//A replacement for the canBendIgnoreBindsCooldowns. Since this is used a passive, it should not turn off when bending is toggled.
+		if (!this.bPlayer.canBind(this) || this.bPlayer.isChiBlocked() || this.bPlayer.isParalyzed()
+				|| this.bPlayer.isBloodbent() || this.bPlayer.isControlledByMetalClips()
+				|| getConfig().getStringList("Properties.DisabledWorlds").contains(player.getLocation().getWorld().getName())) {
 			this.remove();
 			return;
 		}

--- a/src/com/projectkorra/projectkorra/firebending/Illumination.java
+++ b/src/com/projectkorra/projectkorra/firebending/Illumination.java
@@ -174,12 +174,12 @@ public class Illumination extends FireAbility {
 			}
 		} else { //Legacy 1.16 illumination
 			final Block standingBlock = this.player.getLocation().getBlock();
-			final Block standBlock = standingBlock.getRelative(BlockFace.DOWN);
+			final Block bellowBlock = standingBlock.getRelative(BlockFace.DOWN);
 			if (!isIgnitable(standingBlock)) {
 				return;
 			} else if (standingBlock.equals(this.block)) {
 				return;
-			} else if (Tag.LEAVES.isTagged(standBlock.getType())) {
+			} else if (Tag.LEAVES.isTagged(bellowBlock.getType())) {
 				return;
 			} else if (standingBlock.getType().name().endsWith("_FENCE") || standingBlock.getType().name().endsWith("_FENCE_GATE") || standingBlock.getType().name().endsWith("_WALL") || standingBlock.getType() == Material.IRON_BARS || standingBlock.getType().name().endsWith("_PANE")) {
 				return;
@@ -187,7 +187,7 @@ public class Illumination extends FireAbility {
 
 			Material torch = bPlayer.canUseSubElement(SubElement.BLUE_FIRE) ? Material.SOUL_TORCH : Material.TORCH;
 
-			if (!standBlock.equals(this.block)) { //On block change
+			if (!standingBlock.equals(this.block)) { //On block change
 				this.revert();
 
 				this.oldLevel = player.getLocation().getBlock().getLightLevel();
@@ -196,7 +196,7 @@ public class Illumination extends FireAbility {
 					return;
 				}
 
-				this.block = standBlock;
+				this.block = standingBlock;
 				this.block.getWorld().getPlayers().forEach(p -> p.sendBlockChange(this.block.getLocation(), torch.createBlockData()));
 			} else if (getCurrentTick() % 10 == 0) { //Update to all players in the area every half a second anyway
 				//We have to set the block back to the actual one because if they couldn't render the initial block change,

--- a/src/com/projectkorra/projectkorra/region/GriefPrevention.java
+++ b/src/com/projectkorra/projectkorra/region/GriefPrevention.java
@@ -1,5 +1,6 @@
 package com.projectkorra.projectkorra.region;
 
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import me.ryanhamshire.GriefPrevention.Claim;
 import org.bukkit.Location;
@@ -15,9 +16,9 @@ class GriefPrevention extends RegionProtectionBase {
     public boolean isRegionProtectedReal(Player player, Location location, CoreAbility ability, boolean igniteAbility, boolean explosiveAbility) {
         final String reason = me.ryanhamshire.GriefPrevention.GriefPrevention.instance.allowBuild(player, location);
 
-        final Claim claim = me.ryanhamshire.GriefPrevention.GriefPrevention.instance.dataStore.getClaimAt(location, true, null);
+        //final Claim claim = me.ryanhamshire.GriefPrevention.GriefPrevention.instance.dataStore.getClaimAt(location, true, null);
 
-        if (reason != null && claim != null) {
+        if (reason != null) {
             return true;
         }
 

--- a/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/src/com/projectkorra/projectkorra/storage/Database.java
@@ -68,6 +68,8 @@ public abstract class Database {
 	public void close() {
 		if (this.connection != null) {
 			try {
+				this.connection.setAutoCommit(false);
+				this.connection.commit(); //Force all uncommitted changes to be written before closing
 				this.connection.close();
 			} catch (final SQLException e) {
 				e.printStackTrace();

--- a/src/com/projectkorra/projectkorra/util/DamageHandler.java
+++ b/src/com/projectkorra/projectkorra/util/DamageHandler.java
@@ -123,10 +123,12 @@ public class DamageHandler {
 
 		if (event.getEntity() instanceof ArmorStand) return; //ArmorStands produce errors when we modify the armor damage, so ignore them.
 
-		if (ignorePercentage == 1) {
-			event.setDamage(EntityDamageEvent.DamageModifier.ARMOR, 0);
+		if (ignorePercentage >= 1) {
+			event.setDamage(EntityDamageEvent.DamageModifier.ARMOR, 0); //Bypass armor points
+			event.setDamage(EntityDamageEvent.DamageModifier.MAGIC, 0); //Bypass protection enchantments
 		} else {
 			event.setDamage(EntityDamageEvent.DamageModifier.ARMOR, event.getDamage(EntityDamageEvent.DamageModifier.ARMOR) * (1d - ignorePercentage));
+			event.setDamage(EntityDamageEvent.DamageModifier.MAGIC, event.getDamage(EntityDamageEvent.DamageModifier.MAGIC) * (1d - ignorePercentage));
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/util/TempArmor.java
+++ b/src/com/projectkorra/projectkorra/util/TempArmor.java
@@ -198,7 +198,7 @@ public class TempArmor {
 	}
 
 	public void revert() {
-		revert(null);
+		revert(null, true);
 	}
 	
 	/**
@@ -209,8 +209,9 @@ public class TempArmor {
 	 * TempArmor instance was started, if the display queue is empty.
 	 * 
 	 * @param drops A list of drops to filter temporary armor from when reverting, null if n/a
+	 * @param keepInv Whether the keepInventory gamerule is on
 	 */
-	public void revert(List<ItemStack> drops) {
+	public void revert(List<ItemStack> drops, boolean keepInv) {
 		final PriorityQueue<TempArmor> queue = INSTANCES.get(this.entity);
 
 		if (queue.contains(this)) {
@@ -235,6 +236,15 @@ public class TempArmor {
 
 		if (queue.isEmpty()) {
 			this.entity.getEquipment().setArmorContents(ORIGINAL.get(this.entity));
+
+			if (drops != null && !keepInv) {
+				for (ItemStack is : ORIGINAL.get(this.entity)) {
+					if (is != null) {
+						drops.add(is);
+					}
+				}
+			}
+
 			INSTANCES.remove(this.entity);
 			ORIGINAL.remove(this.entity);
 		}
@@ -250,7 +260,7 @@ public class TempArmor {
 			while (!queue.isEmpty()) {
 				final TempArmor tarmor = queue.peek();
 				if (System.currentTimeMillis() >= tarmor.getStartTime() + tarmor.getDuration()) {
-					tarmor.revert(null);
+					tarmor.revert();
 				} else {
 					break;
 				}
@@ -266,7 +276,7 @@ public class TempArmor {
 		for (final LivingEntity entity : INSTANCES.keySet()) {
 			while (!INSTANCES.get(entity).isEmpty()) {
 				final TempArmor armor = INSTANCES.get(entity).poll();
-				armor.revert(null);
+				armor.revert();
 			}
 		}
 	}

--- a/src/com/projectkorra/projectkorra/util/TempArmor.java
+++ b/src/com/projectkorra/projectkorra/util/TempArmor.java
@@ -234,14 +234,6 @@ public class TempArmor {
 		}
 
 		if (queue.isEmpty()) {
-			if (drops != null) {
-				for (ItemStack is : ORIGINAL.get(this.entity)) {
-					if (is != null) {
-						drops.add(is);
-					}
-				}
-			}
-			
 			this.entity.getEquipment().setArmorContents(ORIGINAL.get(this.entity));
 			INSTANCES.remove(this.entity);
 			ORIGINAL.remove(this.entity);

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -42,7 +42,7 @@ public class TempBlock {
 	 */
 	@Deprecated
 	public static Map<Block, TempBlock> instances = new ConcurrentHashMap<>();
-	public static final PriorityQueue<TempBlock> REVERT_QUEUE = new PriorityQueue<>(100, (t1, t2) -> (int) (t1.revertTime - t2.revertTime));
+	private static final PriorityQueue<TempBlock> REVERT_QUEUE = new PriorityQueue<>(128, (t1, t2) -> (int) (t1.revertTime - t2.revertTime));
 	private static boolean REVERT_TASK_RUNNING;
 
 	private final Block block;
@@ -295,13 +295,9 @@ public class TempBlock {
 		if (revertTime <= 0 || state instanceof Container) {
 			return;
 		}
-		
-		if (this.inRevertQueue) {
-			REVERT_QUEUE.remove(this);
-		}
-		this.inRevertQueue = true;
 		this.revertTime = revertTime + System.currentTimeMillis();
-		if (!REVERT_QUEUE.contains(this)) {
+		if (!this.inRevertQueue) {
+			this.inRevertQueue = true;
 			REVERT_QUEUE.add(this);
 		}
 	}
@@ -320,6 +316,15 @@ public class TempBlock {
 	 * This is used to revert the block without removing the instances from memory. Used when multiple tempblocks are to be reverted at once
 	 */
 	private void trueRevertBlock() {
+		this.trueRevertBlock(true);
+	}
+
+	/**
+	 * This is used to revert the block without removing the instances from memory. Used when multiple tempblocks are to be reverted at once
+	 * @param removeFromQueue If the TempBlock should be removed from the queue. Should be false when it has already been removed from the revert queue
+
+	 */
+	private void trueRevertBlock(boolean removeFromQueue) {
 		this.reverted = true;
 		if (instances_.containsKey(this.block)) {
 			PaperLib.getChunkAtAsync(this.block.getLocation()).thenAccept(result -> {
@@ -330,7 +335,9 @@ public class TempBlock {
 			PaperLib.getChunkAtAsync(this.block.getLocation()).thenAccept(result -> revertState());
 		}
 
-		REVERT_QUEUE.remove(this);
+		if (removeFromQueue) { //Remove from the queue if it's in there. We only do this when required because it is an intensive action due to the collection type
+			REVERT_QUEUE.remove(this);
+		}
 		if (this.revertTask != null) {
 			this.revertTask.run();
 		}
@@ -487,5 +494,24 @@ public class TempBlock {
 				", isBendableSource=" + isBendableSource +
 				", suffocate=" + suffocate +
 				'}';
+	}
+
+	public static class TempBlockRevertTask implements Runnable {
+		@Override
+		public void run() {
+			final long currentTime = System.currentTimeMillis();
+			while (!REVERT_QUEUE.isEmpty()) {
+				final TempBlock tempBlock = REVERT_QUEUE.peek(); //Check if the top TempBlock is ready for reverting
+				if (currentTime >= tempBlock.getRevertTime()) {
+					REVERT_QUEUE.poll();
+					if (!tempBlock.reverted) {
+						remove(tempBlock);
+						tempBlock.trueRevertBlock(false); //It's already been removed from the poll(), so don't try remove it again
+					}
+				} else {
+					break;
+				}
+			}
+		}
 	}
 }

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -19,6 +19,7 @@ import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
@@ -185,6 +186,14 @@ public class TempBlock {
 			}
 		}
 		REVERT_QUEUE.clear();
+	}
+
+	public static void removeAllInWorld(World world) {
+		for (final Block block : new HashSet<>(instances_.keySet())) {
+			if (block.getWorld() == world) {
+				revertBlock(block, Material.AIR);
+			}
+		}
 	}
 
 	/**

--- a/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
+import com.projectkorra.projectkorra.ability.WaterAbility;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -85,6 +86,7 @@ public class TempBlock {
 		this.block = block;
 		this.newData = newData;
 		this.attachedTempBlocks = new HashSet<>(0);
+		this.suffocate = ability.isPresent() ? !(ability.get() instanceof WaterAbility) : false;
 
 		//Fire griefing will make the state update on its own, so we don't need to update it ourselves
 		if (!FireAbility.canFireGrief() && (newData.getMaterial() == Material.FIRE || newData.getMaterial() == Material.SOUL_FIRE)) {

--- a/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -181,7 +181,7 @@ public class OctopusForm extends WaterAbility {
 		} else if (isCauldron(this.sourceBlock)) {
 			GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
 		}
-		this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : GeneralMethods.getWaterData(0));
+		this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : GeneralMethods.getWaterData(0), this);
 	}
 
 	private void attack() {
@@ -258,7 +258,7 @@ public class OctopusForm extends WaterAbility {
 					this.sourceLocation = newBlock.getLocation();
 
 					if (!GeneralMethods.isSolid(newBlock)) {
-						this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0));
+						this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0), this);
 						this.sourceBlock = newBlock;
 					} else {
 						this.remove();
@@ -271,7 +271,7 @@ public class OctopusForm extends WaterAbility {
 					this.sourceLocation = newBlock.getLocation();
 
 					if (!GeneralMethods.isSolid(newBlock)) {
-						this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0));
+						this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0), this);
 						this.sourceBlock = newBlock;
 					} else {
 						this.remove();
@@ -287,7 +287,7 @@ public class OctopusForm extends WaterAbility {
 							this.source.revertBlock();
 						}
 						if (!GeneralMethods.isSolid(newBlock)) {
-							this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0));
+							this.source = new TempBlock(newBlock, GeneralMethods.getWaterData(0), this);
 							this.sourceBlock = newBlock;
 						}
 					}
@@ -440,7 +440,7 @@ public class OctopusForm extends WaterAbility {
 			if (isWater(block) && !TempBlock.isTempBlock(block)) {
 				ParticleEffect.WATER_BUBBLE.display(block.getLocation().clone().add(0.5, 0.5, 0.5), 5, Math.random(), Math.random(), Math.random(), 0);
 			}
-			this.newBlocks.add(new TempBlock(block, GeneralMethods.getWaterData(0)));
+			this.newBlocks.add(new TempBlock(block, GeneralMethods.getWaterData(0), this));
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -145,7 +145,7 @@ public class SurgeWall extends WaterAbility {
 
 		for (final Block block : WALL_BLOCKS.keySet()) {
 			if (WALL_BLOCKS.get(block) == this.player) {
-				tempBlocks.put(block, new TempBlock(block, Material.ICE));
+				tempBlocks.put(block, new TempBlock(block, Material.ICE.createBlockData(), this).setCanSuffocate(false));
 				playIcebendingSound(block.getLocation());
 			}
 		}
@@ -367,9 +367,9 @@ public class SurgeWall extends WaterAbility {
 
 	private void addWallBlock(final Block block) {
 		if (this.frozen) {
-			tempBlocks.put(block, new TempBlock(block, Material.ICE));
+			tempBlocks.put(block, new TempBlock(block, Material.ICE.createBlockData(), this));
 		} else {
-			tempBlocks.put(block, new TempBlock(block, Material.WATER));
+			tempBlocks.put(block, new TempBlock(block, Material.WATER.createBlockData(), this));
 		}
 	}
 

--- a/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -181,7 +181,7 @@ public class SurgeWave extends WaterAbility {
 				block.breakNaturally();
 			}
 
-			final TempBlock tblock = new TempBlock(block, Material.ICE);
+			final TempBlock tblock = new TempBlock(block, Material.ICE.createBlockData(), this).setCanSuffocate(false);
 
 			tblock.setRevertTask(() -> SurgeWave.this.frozenBlocks.remove(block));
 

--- a/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -160,7 +160,8 @@ public class Torrent extends WaterAbility {
 						}
 					}
 				}
-				final TempBlock tblock = new TempBlock(block, Material.ICE);
+				final TempBlock tblock = new TempBlock(block, Material.ICE.createBlockData(), this);
+				tblock.setCanSuffocate(false);
 				FROZEN_BLOCKS.put(tblock, Pair.of(this.player, this.getId()));
 				if (this.revert) {
 					tblock.setRevertTime(this.revertTime + (new Random().nextInt((500 + 500) + 1) - 500));

--- a/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -423,7 +423,7 @@ public class WaterSpoutWave extends WaterAbility {
 					}
 					if (ElementalAbility.isAir(block.getType()) || block.getType() == Material.ICE || this.isWaterbendable(block)) {
 						if (!FROZEN_BLOCKS.containsKey(block)) {
-							final TempBlock tblock = new TempBlock(block, Material.ICE);
+							final TempBlock tblock = new TempBlock(block, Material.ICE.createBlockData(), this).setCanSuffocate(false);
 							FROZEN_BLOCKS.put(block, tblock);
 							if (this.revertIceSphere) {
 								tblock.setRevertTime(this.revertSphereTime + ThreadLocalRandom.current().nextLong(-500, 500));

--- a/src/com/projectkorra/projectkorra/waterbending/combo/IceBullet.java
+++ b/src/com/projectkorra/projectkorra/waterbending/combo/IceBullet.java
@@ -186,7 +186,7 @@ public class IceBullet extends IceAbility implements ComboAbility {
 	}
 
 	public void createBlock(final Block block, final Material mat, final BlockData data) {
-		this.affectedBlocks.put(block, new TempBlock(block, data));
+		this.affectedBlocks.put(block, new TempBlock(block, data, this).setCanSuffocate(false));
 	}
 
 	public void drawWaterCircle(final Location loc, final double theta, final double increment, final double radius) {

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
@@ -244,6 +244,10 @@ public class IceBlast extends IceAbility {
 			this.remove();
 			return;
 		}
+		if (this.prepared && !isWaterbendable(this.sourceBlock)) {
+			this.remove();
+			return;
+		}
 
 		if (System.currentTimeMillis() < this.time + this.interval) {
 			return;

--- a/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -155,6 +155,9 @@ public class IceSpikeBlast extends IceAbility {
 		} else if (!this.bPlayer.getBoundAbilityName().equals(this.getName()) && this.prepared) {
 			this.remove();
 			return;
+		} else if (this.prepared && !isWaterbendable(this.sourceBlock)) {
+			this.remove();
+			return;
 		}
 		
 		if (System.currentTimeMillis() < this.time + this.interval) {
@@ -219,7 +222,7 @@ public class IceSpikeBlast extends IceAbility {
 			}
 
 			this.sourceBlock = block;
-			this.source = new TempBlock(this.sourceBlock, this.sourceType);
+			this.source = new TempBlock(this.sourceBlock, this.sourceType.createBlockData(), this);
 			this.source.setRevertTime(130);
 		} else if (this.prepared) {
 			if (this.sourceBlock != null) {

--- a/src/com/projectkorra/projectkorra/waterbending/ice/PhaseChange.java
+++ b/src/com/projectkorra/projectkorra/waterbending/ice/PhaseChange.java
@@ -304,6 +304,7 @@ public class PhaseChange extends IceAbility {
 		}
 		if (tb == null) {
 			tb = new TempBlock(b, Material.ICE);
+			tb.setCanSuffocate(false);
 		}
 		this.blocks.add(tb);
 		PLAYER_BY_BLOCK.put(tb, this.player);

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
@@ -127,7 +127,7 @@ public class WaterArmsFreeze extends IceAbility {
 
 	private void progressIce() {
 		ParticleEffect.SNOW_SHOVEL.display(this.location, 5, Math.random(), Math.random(), Math.random(), 0.05);
-		new TempBlock(this.location.getBlock(), Material.ICE).setRevertTime(10);
+		new TempBlock(this.location.getBlock(), Material.ICE.createBlockData(), this).setCanSuffocate(false).setRevertTime(10);
 
 		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, 2.5)) {
 			if (entity instanceof LivingEntity && entity.getEntityId() != this.player.getEntityId() && !(entity instanceof ArmorStand)) {

--- a/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
+++ b/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsSpear.java
@@ -204,7 +204,7 @@ public class WaterArmsSpear extends WaterAbility {
 						getIceBlocks().remove(block);
 					}
 
-					iceBlocks.add(new TempBlock(block, Material.ICE));
+					iceBlocks.add(new TempBlock(block, Material.ICE.createBlockData(), this).setCanSuffocate(false));
 
 					getIceBlocks().put(block, System.currentTimeMillis() + this.spearDuration + (long) (Math.random() * 500));
 				}
@@ -251,7 +251,7 @@ public class WaterArmsSpear extends WaterAbility {
 					}
 				}
 				playIcebendingSound(block.getLocation());
-				new TempBlock(block, Material.ICE);
+				new TempBlock(block, Material.ICE.createBlockData(), this).setCanSuffocate(false);
 				getIceBlocks().put(block, System.currentTimeMillis() + this.spearDuration + (long) (Math.random() * 500));
 			}
 		}


### PR DESCRIPTION
# Fixes
- Fixed Flight not checking perms for the different slot abilities
- Fixed the cooldown command not respecting permissions
- Fixed short_grass material on 1.20.3+
- Fixed illumination digging into the ground in 1.16
- Fixed bending damage that bypasses armor not bypassing protection enchantments
- Fixed TempArmor duping things
- Fixed waterbending ice suffocating players (https://github.com/ProjectKorra/ProjectKorra/issues/1309)
- Fixed IceSpike and IceBlast working when the source is removed before you click
- Fixed Multiability slots not updating when they start/end
- Fixed Extraction turning deepslate ores into stone when used
- Fixed MythicLib causing you to use abilities when mobs are hit
- Fixed passives being toggled with bending when Properties.TogglePassivesWithAllBending is disabled (https://github.com/ProjectKorra/ProjectKorra/issues/1288)
- Fixed attributes not being updated after the ability starts
- Fixed custom elements that aren't build right causing crashes due to their lack of name
- Fixed TempBlocks attempting to revert in unloaded worlds (https://github.com/ProjectKorra/ProjectKorra/issues/1319)
- Fixed Citizen NPCs causing errors due to no BendingPlayer existing

# Changes
- Optimized AirBlast putting out fire or triggering redstone related blocks. It now does it for every block along the path, and not just every single tick at the current location (so it would miss 33% of blocks)
- Made the database commit all uncommitted changes when the connection is closed
- Optimized TempBlock reverting
  - Reduced the lags caused from TempBlocks reverting. The main cause was due to removing blocks going through the entire queue to find the block to remove, when it could have just been removed from the top.
  - Additionally, there is no longer checks to see if it is already in the queue in some instances. This also caused a lot of pointless CPU processing

