### PR TITLE
Addressed HorizontalVelocityTracker tracking

### DIFF
--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -820,14 +820,12 @@ public class PKListener implements Listener {
 
 	@EventHandler
 	public void onHorizontalCollision(final HorizontalVelocityChangeEvent e) {
-		if (e.getEntity() instanceof LivingEntity) {
-			if (e.getEntity().getEntityId() != e.getInstigator().getEntityId()) {
-				final double minimumDistance = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageMinimumDistance");
-				final double maxDamage = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageCap");
-				final double damage = ((e.getDistanceTraveled() - minimumDistance) < 0 ? 0 : e.getDistanceTraveled() - minimumDistance) / (e.getDifference().length());
-				if (damage > 0) {
-					DamageHandler.damageEntity(e.getEntity(), Math.min(damage, maxDamage), e.getAbility());
-				}
+		if (e.getEntity().getUniqueId() != e.getInstigator().getUniqueId()) {
+			final double minimumDistance = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageMinimumDistance");
+			final double maxDamage = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageCap");
+			final double damage = ((e.getDistanceTraveled() - minimumDistance) < 0 ? 0 : e.getDistanceTraveled() - minimumDistance) / (e.getDifference().length());
+			if (damage > 0) {
+				DamageHandler.damageEntity(e.getEntity(), Math.min(damage, maxDamage), e.getAbility());
 			}
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -820,12 +820,14 @@ public class PKListener implements Listener {
 
 	@EventHandler
 	public void onHorizontalCollision(final HorizontalVelocityChangeEvent e) {
-		if (e.getEntity().getUniqueId() != e.getInstigator().getUniqueId()) {
-			final double minimumDistance = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageMinimumDistance");
-			final double maxDamage = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageCap");
-			final double damage = ((e.getDistanceTraveled() - minimumDistance) < 0 ? 0 : e.getDistanceTraveled() - minimumDistance) / (e.getDifference().length());
-			if (damage > 0) {
-				DamageHandler.damageEntity(e.getEntity(), Math.min(damage, maxDamage), e.getAbility());
+		if (e instanceof LivingEntity) {
+			if (e.getEntity().getUniqueId() != e.getInstigator().getUniqueId()) {
+				final double minimumDistance = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageMinimumDistance");
+				final double maxDamage = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageCap");
+				final double damage = ((e.getDistanceTraveled() - minimumDistance) < 0 ? 0 : e.getDistanceTraveled() - minimumDistance) / (e.getDifference().length());
+				if (damage > 0) {
+					DamageHandler.damageEntity(e.getEntity(), Math.min(damage, maxDamage), e.getAbility());
+				}
 			}
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -820,7 +820,7 @@ public class PKListener implements Listener {
 
 	@EventHandler
 	public void onHorizontalCollision(final HorizontalVelocityChangeEvent e) {
-		if (e instanceof LivingEntity) {
+		if (e.getEntity() instanceof LivingEntity) {
 			if (e.getEntity().getUniqueId() != e.getInstigator().getUniqueId()) {
 				final double minimumDistance = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageMinimumDistance");
 				final double maxDamage = this.plugin.getConfig().getDouble("Properties.HorizontalCollisionPhysics.WallDamageCap");

--- a/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
+++ b/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
@@ -1,8 +1,5 @@
 package com.projectkorra.projectkorra.object;
 
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
+++ b/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
@@ -70,7 +70,7 @@ public class HorizontalVelocityTracker {
 			return;
 		}
 
-		if (this.entity.isOnGround()) {
+		if (this.entity.isOnGround() && System.currentTimeMillis() > this.fireTime + 1000) {
 			this.remove();
 			return;
 		}
@@ -100,7 +100,7 @@ public class HorizontalVelocityTracker {
 				this.impactLocation = this.entity.getLocation();
 				for (final Block b : blocks) {
 					if (b.getType() == Material.BARRIER && !this.barrier) {
-						return;
+						continue;
 					}
 					if (GeneralMethods.isSolid(b) && (this.entity.getLocation().getBlock().getRelative(BlockFace.EAST, 1).equals(b) || this.entity.getLocation().getBlock().getRelative(BlockFace.NORTH, 1).equals(b) || this.entity.getLocation().getBlock().getRelative(BlockFace.WEST, 1).equals(b) || this.entity.getLocation().getBlock().getRelative(BlockFace.SOUTH, 1).equals(b))) {
 						if (!ElementalAbility.isTransparent(this.instigator, b)) {

--- a/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
+++ b/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.object;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -61,6 +62,11 @@ public class HorizontalVelocityTracker {
 		this.abil = ability;
 		this.update();
 		instances.put(this.entity, this);
+	}
+
+	@Deprecated
+	public HorizontalVelocityTracker(final Entity e, final Player instigator, final long delay, final Ability ability) {
+		this(e, instigator, delay, (CoreAbility) ability);
 	}
 
 	public void update() {

--- a/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
+++ b/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
@@ -49,9 +49,7 @@ public class HorizontalVelocityTracker {
 			return;
 		}
 
-		if (!(e instanceof LivingEntity)) {
-			return;
-		} else if (instances.containsKey(e)) {
+		if (instances.containsKey(e)) {
 			return;
 		}
 


### PR DESCRIPTION
Fixed `HorizontalVelocityTracker` to actually track velocity when applied to an entity.

## Fixes
* Fixed `HorizontalVelocityTracker` to remove and update properly.
    - `isOnGround()` is problematic. It's necessary when we need to check when an entity lands, but it will remove the tracker prematurely, hence the velocity checks (more in comments).
    - `(diff.getX() > 1 || diff.getX() < -1) || (diff.getZ() > 1 || diff.getZ() < -1)` is too imprecise. Difference is usually: -1.0 < x < 1.0.
    - ~~Better wall/block touching collisions.~~
        > ~~TODO: Get cardinal direction opposite to the applied vector so that only blocks behind the entity will be checked.~~ Moving forward without this for now.

## Removals

Removed `if (e.getEntity() instanceof LivingEntity)` check because `HorizontalVelocityTracker` entities are all `LivingEntity`s from the check in construction.

##

This fix is tested, though some more bug tests would be great. (If the entity isn't damaged when collided into something, it's likely that the travel distance when velocity is applied isn't significant enough to be considered a damaging collision. Look in L827 in `PKListener.java`.)