### PR TITLE
Implementing suggestions: Mudbending viability, AvatarState sound change, cooking food with fire, using and drying sponges, WaterArms action bar

### DIFF
--- a/core/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/core/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -923,7 +923,7 @@ public class GeneralMethods {
 	}
 	
 	public static BlockData getCauldronData(final Material material, final int level) {
-		if (!material.name().contains("_CAULDRON")) {
+		if (!material.name().contains("CAULDRON")) {
 			return null;
 		}
 		return material.createBlockData(d -> ((Levelled) d).setLevel((level > 3 || level > ((Levelled) d).getMaximumLevel()) ? 3 : level < 1 ? 1 : level));
@@ -1371,7 +1371,7 @@ public class GeneralMethods {
 		Arrays.stream(Element.getSubElements()).forEach(e -> {e.setColor(null); e.setSubColor(null);}); //Same for subs
 		ElementalAbility.clearBendableMaterials(); // Clear and re-cache the material lists on reload.
 		ElementalAbility.setupBendableMaterials();
-		WaterAbility.setupWaterTransformableBlocks();
+		// WaterAbility.setupWaterTransformableBlocks();
 		EarthTunnel.clearBendableMaterials();
 
 		Bukkit.getScheduler().cancelTasks(ProjectKorra.plugin);

--- a/core/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/core/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1371,6 +1371,7 @@ public class GeneralMethods {
 		Arrays.stream(Element.getSubElements()).forEach(e -> {e.setColor(null); e.setSubColor(null);}); //Same for subs
 		ElementalAbility.clearBendableMaterials(); // Clear and re-cache the material lists on reload.
 		ElementalAbility.setupBendableMaterials();
+		WaterAbility.setupWaterTransformableBlocks();
 		EarthTunnel.clearBendableMaterials();
 
 		Bukkit.getScheduler().cancelTasks(ProjectKorra.plugin);

--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -642,50 +642,45 @@ public class PKListener implements Listener {
 			}
 		}
 
-		final CoreAbility[] cookingFireCombos = { CoreAbility.getAbility("JetBlast"), CoreAbility.getAbility("FireWheel"), CoreAbility.getAbility("FireSpin"), CoreAbility.getAbility("FireKick") };
+		// final CoreAbility[] cookingFireCombos = { CoreAbility.getAbility("JetBlast"), CoreAbility.getAbility("FireWheel"), CoreAbility.getAbility("FireSpin"), CoreAbility.getAbility("FireKick") };
 
 		if (BENDING_ENTITY_DEATH.containsKey(event.getEntity())) {
-			final CoreAbility coreAbility = (CoreAbility) BENDING_ENTITY_DEATH.get(event.getEntity());
-			for (final CoreAbility fireCombo : cookingFireCombos) {
-				if (fireCombo == null) {
-					continue;
-				}
-				if (coreAbility.getName().equalsIgnoreCase(fireCombo.getName())) {
-					final List<ItemStack> drops = event.getDrops();
-					final List<ItemStack> newDrops = new ArrayList<>();
-					for (ItemStack cooked : drops) {
-						final Material material = cooked.getType();
-						switch (material) {
-							case BEEF:
-								cooked = new ItemStack(Material.COOKED_BEEF);
-								break;
-							case SALMON:
-								cooked = new ItemStack(Material.COOKED_SALMON);
-								break;
-							case CHICKEN:
-								cooked = new ItemStack(Material.COOKED_CHICKEN);
-								break;
-							case PORKCHOP:
-								cooked = new ItemStack(Material.COOKED_PORKCHOP);
-								break;
-							case MUTTON:
-								cooked = new ItemStack(Material.COOKED_MUTTON);
-								break;
-							case RABBIT:
-								cooked = new ItemStack(Material.COOKED_RABBIT);
-								break;
-							case COD:
-								cooked = new ItemStack(Material.COOKED_COD);
-								break;
-							default:
-								break;
-						}
-						newDrops.add(cooked);
+			final CoreAbility ability = (CoreAbility) BENDING_ENTITY_DEATH.get(event.getEntity());
+
+			if (FireDamageTimer.isEnflamed(event.getEntity()) || (ability != null && ability instanceof FireAbility)) {
+				final List<ItemStack> drops = event.getDrops();
+				final List<ItemStack> newDrops = new ArrayList<>();
+				for (ItemStack cooked : drops) {
+					final Material material = cooked.getType();
+					switch (material) {
+						case BEEF:
+							cooked = new ItemStack(Material.COOKED_BEEF);
+							break;
+						case SALMON:
+							cooked = new ItemStack(Material.COOKED_SALMON);
+							break;
+						case CHICKEN:
+							cooked = new ItemStack(Material.COOKED_CHICKEN);
+							break;
+						case PORKCHOP:
+							cooked = new ItemStack(Material.COOKED_PORKCHOP);
+							break;
+						case MUTTON:
+							cooked = new ItemStack(Material.COOKED_MUTTON);
+							break;
+						case RABBIT:
+							cooked = new ItemStack(Material.COOKED_RABBIT);
+							break;
+						case COD:
+							cooked = new ItemStack(Material.COOKED_COD);
+							break;
+						default:
+							break;
 					}
-					event.getDrops().clear();
-					event.getDrops().addAll(newDrops);
-					break;
+					newDrops.add(cooked);
 				}
+				event.getDrops().clear();
+				event.getDrops().addAll(newDrops);
 			}
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/ability/AvatarAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/AvatarAbility.java
@@ -34,7 +34,7 @@ public abstract class AvatarAbility extends ElementalAbility {
 			final float volume = (float) ConfigManager.avatarStateConfig.get().getDouble("AvatarState.Sound.Volume");
 			final float pitch = (float) ConfigManager.avatarStateConfig.get().getDouble("AvatarState.Sound.Pitch");
 
-			Sound sound = Sound.BLOCK_BEACON_ACTIVATE;
+			Sound sound = Sound.BLOCK_BEACON_POWER_SELECT;
 
 			try {
 				sound = Sound.valueOf(ConfigManager.avatarStateConfig.get().getString("AvatarState.Sound.Sound"));

--- a/core/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -102,8 +102,12 @@ public abstract class EarthAbility extends ElementalAbility {
 		return DensityShift.getSandBlocks().contains(tempBlock);
 	}
 
+	public static boolean isEarthbendable(final Material material, final boolean metal, final boolean sand, final boolean lava, final boolean mud) {
+		return isEarth(material) || (metal && isMetal(material)) || (sand && isSand(material)) || (lava && isLava(material)) || (mud && isMud(material));
+	}
+
 	public static boolean isEarthbendable(final Material material, final boolean metal, final boolean sand, final boolean lava) {
-		return isEarth(material) || (metal && isMetal(material)) || (sand && isSand(material)) || (lava && isLava(material));
+		return isEarthbendable(material, metal, sand, lava, true);
 	}
 
 	public boolean isEarthbendable(final Block block) {
@@ -515,6 +519,26 @@ public abstract class EarthAbility extends ElementalAbility {
 				sound = Sound.valueOf(getConfig().getString("Properties.Earth.MetalSound.Sound"));
 			} catch (final IllegalArgumentException exception) {
 				ProjectKorra.log.warning("Your current value for 'Properties.Earth.MetalSound.Sound' is not valid.");
+			} finally {
+				loc.getWorld().playSound(loc, sound, volume, pitch);
+			}
+		}
+	}
+
+	public static void playMudbendingSound(final Location loc) {
+		if (getConfig().getBoolean("Properties.Earth.PlaySound")) {
+			final float volume = (float) getConfig().getDouble("Properties.Earth.MudSound.Volume");
+			final float pitch = (float) getConfig().getDouble("Properties.Earth.MudSound.Pitch");
+
+			Sound sound = Sound.BLOCK_GRAVEL_BREAK;
+			if (GeneralMethods.getMCVersion() >= 1190) {
+				sound = Sound.valueOf("BLOCK_MUD_PLACE");
+			}
+
+			try {
+				sound = Sound.valueOf(getConfig().getString("Properties.Earth.MudSound.Sound"));
+			} catch (final IllegalArgumentException exception) {
+				ProjectKorra.log.warning("Your current value for 'Properties.Earth.MudSound.Sound' is not valid.");
 			} finally {
 				loc.getWorld().playSound(loc, sound, volume, pitch);
 			}

--- a/core/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -196,6 +196,14 @@ public abstract class ElementalAbility extends CoreAbility {
 		return isMetal(block);
 	}
 
+	public static boolean isMud(final Block block) {
+		return block != null ? isMud(block.getType()) : false;
+	}
+
+	public static boolean isMud(final Material material) {
+		return GeneralMethods.getMCVersion() >= 1190 && (material == Material.getMaterial("MUD") || material == Material.getMaterial("PACKED_MUD") || material == Material.getMaterial("MUDDY_MANGROVE_ROOTS"));
+	}
+
 	public static boolean isNegativeEffect(final PotionEffectType effect) {
 		for (final PotionEffectType effect2 : NEGATIVE_EFFECTS) {
 			if (effect2.equals(effect)) {

--- a/core/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -41,6 +41,18 @@ public abstract class ElementalAbility extends CoreAbility {
 	private static final Set<String> SAND_BLOCKS = new HashSet<String>();
 	private static final Set<String> SNOW_BLOCKS = new HashSet<String>();
 
+	// Once 1.16.5 no longer becomes LTS, this becomes obsolete and
+	// we can remove the version check and reference these materials directly instead of doing standard lookups.
+	protected static final Material LIGHT = Material.getMaterial("LIGHT");
+	protected static final Set<Material> MUD_BLOCKS = getMudBlocks();
+	private static Set<Material> getMudBlocks() {
+		Set<Material> mudBlocks = new HashSet<>();
+		mudBlocks.add(Material.getMaterial("MUD"));
+		mudBlocks.add(Material.getMaterial("PACKED_MUD"));
+		mudBlocks.add(Material.getMaterial("MUDDY_MANGROVE_ROOTS"));
+		return mudBlocks;
+	}
+
 	static {
 		TRANSPARENT.clear();
 		for (final Material mat : Material.values()) {
@@ -97,7 +109,7 @@ public abstract class ElementalAbility extends CoreAbility {
 
 	public static boolean isAir(final Material material) {
 		return material == Material.AIR || material == Material.CAVE_AIR || material == Material.VOID_AIR ||
-				(GeneralMethods.getMCVersion() >= 1170 && material == Material.getMaterial("LIGHT"));
+				(GeneralMethods.getMCVersion() >= 1170 && material == LIGHT);
 	}
 
 	public static boolean isDay(final World world) {
@@ -201,7 +213,7 @@ public abstract class ElementalAbility extends CoreAbility {
 	}
 
 	public static boolean isMud(final Material material) {
-		return GeneralMethods.getMCVersion() >= 1190 && (material == Material.getMaterial("MUD") || material == Material.getMaterial("PACKED_MUD") || material == Material.getMaterial("MUDDY_MANGROVE_ROOTS"));
+		return GeneralMethods.getMCVersion() >= 1190 && MUD_BLOCKS.contains(material);
 	}
 
 	public static boolean isNegativeEffect(final PotionEffectType effect) {

--- a/core/src/com/projectkorra/projectkorra/ability/FireAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/FireAbility.java
@@ -12,6 +12,7 @@ import com.projectkorra.projectkorra.util.TempBlock;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -162,6 +163,30 @@ public abstract class FireAbility extends ElementalAbility {
 		}
 
 		return fire;
+	}
+
+	public static void dryWetBlocks(final Block block, final CoreAbility ability, boolean playSound) {
+		if (GeneralMethods.isRegionProtectedFromBuild(ability, block.getLocation())) {
+			return;
+		}
+		if (block.getType() == Material.WET_SPONGE) {
+			block.setType(Material.SPONGE);
+
+			if (playSound) {
+				block.getWorld().playSound(block.getLocation(), Sound.BLOCK_FIRE_EXTINGUISH, 0.5F, 1);
+			}
+		} else if (isSnow(block)) {
+			block.getWorld().spawnParticle(Particle.BLOCK_DUST, block.getLocation().add(0.5, 0.5, 0.5), 2, 0.5, 0.5, 0.5, 0.1, Material.SNOW_BLOCK.createBlockData());
+			block.setType(Material.AIR);
+
+			if (playSound) {
+				block.getWorld().playSound(block.getLocation(), Sound.BLOCK_SNOW_BREAK, 1, 1);
+			}
+		}
+	}
+
+	public static void dryWetBlocks(final Block block, final CoreAbility ability) {
+		dryWetBlocks(block, ability, false);
 	}
 
 	/**

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.projectkorra.projectkorra.region.RegionProtection;
-import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -17,7 +16,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.entity.Player;
-import org.bukkit.util.Consumer;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.BendingPlayer;

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -401,25 +401,19 @@ public abstract class WaterAbility extends ElementalAbility {
 	}
 
 	public static void updateSourceBlock(final Block sourceBlock) {
-		updateSourceBlock(sourceBlock, (block) -> {
-			if (isCauldron(block)) {
-				GeneralMethods.setCauldronData(block, ((Levelled) block.getBlockData()).getLevel() - 1);
-			} else if (isMud(block)) {
-				if (block.getType() == Material.getMaterial("MUD") || block.getType() == Material.getMaterial("PACKED_MUD")) {
-					block.setType(Material.DIRT);
-				} else {
-					block.setType(Material.getMaterial("MANGROVE_ROOTS"));
-				}
-				playMudbendingSound(block.getLocation());
-			} else if (isSponge(block)) {
-				block.setType(Material.SPONGE);
-				block.getWorld().playSound(block.getLocation(), Sound.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
+		if (isCauldron(sourceBlock)) {
+			GeneralMethods.setCauldronData(sourceBlock, ((Levelled) sourceBlock.getBlockData()).getLevel() - 1);
+		} else if (isMud(sourceBlock)) {
+			if (sourceBlock.getType() == Material.getMaterial("MUD") || sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
+				sourceBlock.setType(Material.DIRT);
+			} else {
+				sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
 			}
-		});
-	}
-
-	public static void updateSourceBlock(final Block sourceBlock, final Consumer<Block> consumer) {
-		consumer.accept(sourceBlock);
+			playMudbendingSound(sourceBlock.getLocation());
+		} else if (isSponge(sourceBlock)) {
+			sourceBlock.setType(Material.SPONGE);
+			sourceBlock.getWorld().playSound(sourceBlock.getLocation(), Sound.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
+		}
 	}
 
 	/**

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -226,7 +226,7 @@ public abstract class WaterAbility extends ElementalAbility {
 
 		for (double i = 0; i <= range; i++) {
 			final Block block = location.clone().add(vector.clone().multiply(i)).getBlock();
-			if ((!isTransparent(player, block) && !isIce(block) && !isPlant(block) && !isSnow(block) && !isCauldron(block) && !isMud(block) && isSponge(block)) || RegionProtection.isRegionProtected(player, location, "WaterManipulation")) {
+			if ((!isTransparent(player, block) && !isIce(block) && !isPlant(block) && !isSnow(block) && !isCauldron(block) && !isMud(block) && !isSponge(block)) || RegionProtection.isRegionProtected(player, location, "WaterManipulation")) {
 				continue;
 			} else if (isWaterbendable(player, null, block) && (!isPlant(block) || plantbending)) {
 				if (TempBlock.isTempBlock(block) && !isBendableWaterTempBlock(block)) {

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -130,7 +130,7 @@ public abstract class WaterAbility extends ElementalAbility {
 	}
 
 	public static boolean isWaterbendable(final Material material) {
-		return isWater(material) || isIce(material) || isPlant(material) || isSnow(material) || isCauldron(material);
+		return isWater(material) || isIce(material) || isPlant(material) || isSnow(material) || isCauldron(material) || isMud(material);
 	}
 
 	public static Block getIceSourceBlock(final Player player, final double range) {
@@ -222,7 +222,7 @@ public abstract class WaterAbility extends ElementalAbility {
 
 		for (double i = 0; i <= range; i++) {
 			final Block block = location.clone().add(vector.clone().multiply(i)).getBlock();
-			if ((!isTransparent(player, block) && !isIce(block) && !isPlant(block) && !isSnow(block) && !isCauldron(block)) || RegionProtection.isRegionProtected(player, location, "WaterManipulation")) {
+			if ((!isTransparent(player, block) && !isIce(block) && !isPlant(block) && !isSnow(block) && !isCauldron(block) && !isMud(block)) || RegionProtection.isRegionProtected(player, location, "WaterManipulation")) {
 				continue;
 			} else if (isWaterbendable(player, null, block) && (!isPlant(block) || plantbending)) {
 				if (TempBlock.isTempBlock(block) && !isBendableWaterTempBlock(block)) {
@@ -315,6 +315,26 @@ public abstract class WaterAbility extends ElementalAbility {
 				sound = Sound.valueOf(getConfig().getString("Properties.Water.IceSound.Sound"));
 			} catch (final IllegalArgumentException exception) {
 				ProjectKorra.log.warning("Your current value for 'Properties.Water.IceSound.Sound' is not valid.");
+			} finally {
+				loc.getWorld().playSound(loc, sound, volume, pitch);
+			}
+		}
+	}
+
+	public static void playMudbendingSound(final Location loc) {
+		if (getConfig().getBoolean("Properties.Water.PlaySound")) {
+			final float volume = (float) getConfig().getDouble("Properties.Water.MudSound.Volume");
+			final float pitch = (float) getConfig().getDouble("Properties.Water.MudSound.Pitch");
+
+			Sound sound = Sound.BLOCK_WET_GRASS_STEP;
+			if (GeneralMethods.getMCVersion() >= 1190) {
+				sound = Sound.valueOf("BLOCK_MUD_STEP");
+			}
+
+			try {
+				sound = Sound.valueOf(getConfig().getString("Properties.Water.MudSound.Sound"));
+			} catch (final IllegalArgumentException exception) {
+				ProjectKorra.log.warning("Your current value for 'Properties.Water.MudSound.Sound' is not valid.");
 			} finally {
 				loc.getWorld().playSound(loc, sound, volume, pitch);
 			}

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -306,9 +306,7 @@ public abstract class WaterAbility extends ElementalAbility {
 	}
 
 	public static boolean isTransformableBlock(final Material material) {
-		// TODO: If we decide that users have complete freedom to change transformable blocks, we can just do a simple map check.
-		// return isCauldron(material) || WATER_TRANSFORMABLE_BLOCKS.containsKey(material);
-		return isCauldron(material) || (WATER_TRANSFORMABLE_BLOCKS.containsKey(material) && (isMud(material) || isSponge(material)));
+		return WATER_TRANSFORMABLE_BLOCKS.containsKey(material);
 	}
 
 	public static boolean isWaterbendable(final Player player, final String abilityName, final Block block) {
@@ -329,6 +327,9 @@ public abstract class WaterAbility extends ElementalAbility {
 	}
 
 	public static Map<Material, Material> getWaterTransformableBlocks() {
+		// If we want to revisit this configurably in the future, we can reuse this code.
+
+		/*
 		List<String> transformableBlocks = getConfig().getStringList("Properties.Water.TransformableBlocks");
 		Map<Material, Material> transformables = new HashMap<>();
 
@@ -346,15 +347,27 @@ public abstract class WaterAbility extends ElementalAbility {
 			}
 			transformables.put(from, to);
 		}
+		 */
+		Map<Material, Material> transformables = new HashMap<>();
+		if (GeneralMethods.getMCVersion() >= 1170) {
+			transformables.put(Material.getMaterial("MUD"), Material.DIRT);
+			transformables.put(Material.getMaterial("PACKED_MUD"), Material.DIRT);
+		}
+		if (GeneralMethods.getMCVersion() >= 1190) {
+			transformables.put(Material.getMaterial("MUDDY_MANGROVE_ROOTS"), Material.getMaterial("MANGROVE_ROOTS"));
+		}
+		transformables.put(Material.WET_SPONGE, Material.SPONGE);
 		return transformables;
 	}
 
+	/*
 	public static void setupWaterTransformableBlocks() {
 		if (!WATER_TRANSFORMABLE_BLOCKS.isEmpty()) {
 			WATER_TRANSFORMABLE_BLOCKS.clear();
 		}
 		WATER_TRANSFORMABLE_BLOCKS.putAll(getWaterTransformableBlocks());
 	}
+	 */
 
 	public static void playFocusWaterEffect(final Block block) {
 		ParticleEffect.SMOKE_NORMAL.display(block.getLocation().add(0.5, 0.5, 0.5), 4);
@@ -435,7 +448,7 @@ public abstract class WaterAbility extends ElementalAbility {
 		if (isCauldron(sourceBlock)) {
 			GeneralMethods.setCauldronData(sourceBlock, ((Levelled) sourceBlock.getBlockData()).getLevel() - 1);
 			return true;
-		} else if (isTransformableBlock(sourceBlock) && !isCauldron(sourceBlock)) {
+		} else if (isTransformableBlock(sourceBlock)) {
 			if (isMud(sourceBlock)) {
 				playMudbendingSound(sourceBlock.getLocation());
 			} else if (isSponge(sourceBlock)) {

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -306,9 +306,9 @@ public abstract class WaterAbility extends ElementalAbility {
 	}
 
 	public static boolean isTransformableBlock(final Material material) {
-		// TODO: If we decide that users have complete freedom to change transformable blocks, we can just do a map check.
-		// return WATER_TRANSFORMABLE_BLOCKS.containsKey(material);
-		return isCauldron(material) || isMud(material) || isSponge(material);
+		// TODO: If we decide that users have complete freedom to change transformable blocks, we can just do a simple map check.
+		// return isCauldron(material) || WATER_TRANSFORMABLE_BLOCKS.containsKey(material);
+		return isCauldron(material) || (WATER_TRANSFORMABLE_BLOCKS.containsKey(material) && (isMud(material) || isSponge(material)));
 	}
 
 	public static boolean isWaterbendable(final Player player, final String abilityName, final Block block) {
@@ -435,20 +435,7 @@ public abstract class WaterAbility extends ElementalAbility {
 		if (isCauldron(sourceBlock)) {
 			GeneralMethods.setCauldronData(sourceBlock, ((Levelled) sourceBlock.getBlockData()).getLevel() - 1);
 			return true;
-		} else if (isMud(sourceBlock) || isSponge(sourceBlock)) {
-			if (WATER_TRANSFORMABLE_BLOCKS.containsKey(sourceBlock.getType())) {
-				if (isMud(sourceBlock)) {
-					playMudbendingSound(sourceBlock.getLocation());
-				} else if (isSponge(sourceBlock)) {
-					sourceBlock.getWorld().playSound(sourceBlock.getLocation(), Sound.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
-				}
-				sourceBlock.setType(WATER_TRANSFORMABLE_BLOCKS.get(sourceBlock.getType()));
-				return true;
-			}
-		}
-		// TODO: If we decide that users have complete freedom to change transformable blocks, we can change the above check to this one.
-		/*
-		else if (WATER_TRANSFORMABLE_BLOCKS.containsKey(sourceBlock.getType())) {
+		} else if (isTransformableBlock(sourceBlock) && !isCauldron(sourceBlock)) {
 			if (isMud(sourceBlock)) {
 				playMudbendingSound(sourceBlock.getLocation());
 			} else if (isSponge(sourceBlock)) {
@@ -457,7 +444,6 @@ public abstract class WaterAbility extends ElementalAbility {
 			sourceBlock.setType(WATER_TRANSFORMABLE_BLOCKS.get(sourceBlock.getType()));
 			return true;
 		}
-		 */
 		return false;
 	}
 

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -295,25 +295,20 @@ public abstract class WaterAbility extends ElementalAbility {
 		return material == Material.WET_SPONGE;
 	}
 
-	// A "non-transparent source" is a PK supported default non-transparent source block, not one from the config.
-	// I.e, cauldrons, mud and sponges.
-	// Used so that non-transparent sources aren't replaced with AIR.
-	public static boolean isNonTransparentSource(final Block block) {
-		return isNonTransparentSource(block.getType());
+	/**
+	 * Checks if a source block is a transformable source.
+	 *
+	 * @param block
+	 * @return True if the block is a non-transparent source, False otherwise.
+	 */
+	public static boolean isTransformableBlock(final Block block) {
+		return isTransformableBlock(block.getType());
 	}
 
-	public static boolean isNonTransparentSource(final Material material) {
+	public static boolean isTransformableBlock(final Material material) {
+		// TODO: If we decide that users have complete freedom to change transformable blocks, we can just do a map check.
+		// return WATER_TRANSFORMABLE_BLOCKS.containsKey(material);
 		return isCauldron(material) || isMud(material) || isSponge(material);
-	}
-
-	// A "solid source" is a PK supported default solid source block, not one from the config.
-	// I.e., cauldrons, mud, sponges, ice and solid snow.
-	public static boolean isSolidSource(final Block block) {
-		return isSolidSource(block.getType());
-	}
-
-	public static boolean isSolidSource(final Material material) {
-		return isNonTransparentSource(material) || isIce(material) || isSnow(material);
 	}
 
 	public static boolean isWaterbendable(final Player player, final String abilityName, final Block block) {
@@ -441,16 +436,28 @@ public abstract class WaterAbility extends ElementalAbility {
 			GeneralMethods.setCauldronData(sourceBlock, ((Levelled) sourceBlock.getBlockData()).getLevel() - 1);
 			return true;
 		} else if (isMud(sourceBlock) || isSponge(sourceBlock)) {
+			if (WATER_TRANSFORMABLE_BLOCKS.containsKey(sourceBlock.getType())) {
+				if (isMud(sourceBlock)) {
+					playMudbendingSound(sourceBlock.getLocation());
+				} else if (isSponge(sourceBlock)) {
+					sourceBlock.getWorld().playSound(sourceBlock.getLocation(), Sound.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
+				}
+				sourceBlock.setType(WATER_TRANSFORMABLE_BLOCKS.get(sourceBlock.getType()));
+				return true;
+			}
+		}
+		// TODO: If we decide that users have complete freedom to change transformable blocks, we can change the above check to this one.
+		/*
+		else if (WATER_TRANSFORMABLE_BLOCKS.containsKey(sourceBlock.getType())) {
 			if (isMud(sourceBlock)) {
 				playMudbendingSound(sourceBlock.getLocation());
 			} else if (isSponge(sourceBlock)) {
 				sourceBlock.getWorld().playSound(sourceBlock.getLocation(), Sound.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
 			}
-			if (WATER_TRANSFORMABLE_BLOCKS.containsKey(sourceBlock.getType())) {
-				sourceBlock.setType(WATER_TRANSFORMABLE_BLOCKS.get(sourceBlock.getType()));
-				return true;
-			}
+			sourceBlock.setType(WATER_TRANSFORMABLE_BLOCKS.get(sourceBlock.getType()));
+			return true;
 		}
+		 */
 		return false;
 	}
 

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -790,6 +790,9 @@ public class ConfigManager {
 			config.addDefault("Properties.Water.PlantSound.Sound", "BLOCK_GRASS_STEP");
 			config.addDefault("Properties.Water.IceSound.Volume", 1);
 			config.addDefault("Properties.Water.IceSound.Pitch", 1);
+			config.addDefault("Properties.Water.MudSound.Sound", "BLOCK_MUD_STEP");
+			config.addDefault("Properties.Water.MudSound.Volume", 1);
+			config.addDefault("Properties.Water.MudSound.Pitch", 1);
 
 			config.addDefault("Properties.Earth.DynamicSourcing", true);
 			config.addDefault("Properties.Earth.RevertEarthbending", true);
@@ -813,6 +816,9 @@ public class ConfigManager {
 			config.addDefault("Properties.Earth.LavaSound.Sound", "BLOCK_LAVA_AMBIENT");
 			config.addDefault("Properties.Earth.LavaSound.Volume", 1);
 			config.addDefault("Properties.Earth.LavaSound.Pitch", 1);
+			config.addDefault("Properties.Earth.MudSound.Sound", "BLOCK_MUD_PLACE");
+			config.addDefault("Properties.Earth.MudSound.Volume", 1);
+			config.addDefault("Properties.Earth.MudSound.Pitch", 1);
 
 			config.addDefault("Properties.Fire.CanBendWithWeapons", true);
 			config.addDefault("Properties.Fire.DayFactor", 1.25);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -727,11 +727,13 @@ public class ConfigManager {
 			final ArrayList<String> snowBlocks = new ArrayList<>();
 			snowBlocks.add("#snow"); // added in 1.17
 
+			/*
 			final ArrayList<String> waterTransformableBlocks = new ArrayList<>();
 			waterTransformableBlocks.add("MUD>DIRT");
 			waterTransformableBlocks.add("PACKED_MUD>DIRT");
 			waterTransformableBlocks.add("MUDDY_MANGROVE_ROOTS>MANGROVE_ROOTS");
 			waterTransformableBlocks.add("WET_SPONGE>SPONGE");
+			 */
 
 			config.addDefault("Properties.UpdateChecker", true);
 			config.addDefault("Properties.Statistics", true);
@@ -785,7 +787,7 @@ public class ConfigManager {
 			config.addDefault("Properties.Water.IceBlocks", iceBlocks);
 			config.addDefault("Properties.Water.PlantBlocks", plantBlocks);
 			config.addDefault("Properties.Water.SnowBlocks", snowBlocks);
-			config.addDefault("Properties.Water.TransformableBlocks", waterTransformableBlocks);
+			// config.addDefault("Properties.Water.TransformableBlocks", waterTransformableBlocks);
 			config.addDefault("Properties.Water.NightFactor", 1.25);
 			config.addDefault("Properties.Water.PlaySound", true);
 			config.addDefault("Properties.Water.WaterSound.Sound", "BLOCK_WATER_AMBIENT");

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -727,6 +727,12 @@ public class ConfigManager {
 			final ArrayList<String> snowBlocks = new ArrayList<>();
 			snowBlocks.add("#snow"); // added in 1.17
 
+			final ArrayList<String> waterTransformableBlocks = new ArrayList<>();
+			waterTransformableBlocks.add("MUD>DIRT");
+			waterTransformableBlocks.add("PACKED_MUD>DIRT");
+			waterTransformableBlocks.add("MUDDY_MANGROVE_ROOTS>MANGROVE_ROOTS");
+			waterTransformableBlocks.add("WET_SPONGE>SPONGE");
+
 			config.addDefault("Properties.UpdateChecker", true);
 			config.addDefault("Properties.Statistics", true);
 			config.addDefault("Properties.DatabaseCooldowns", true);
@@ -779,6 +785,7 @@ public class ConfigManager {
 			config.addDefault("Properties.Water.IceBlocks", iceBlocks);
 			config.addDefault("Properties.Water.PlantBlocks", plantBlocks);
 			config.addDefault("Properties.Water.SnowBlocks", snowBlocks);
+			config.addDefault("Properties.Water.TransformableBlocks", waterTransformableBlocks);
 			config.addDefault("Properties.Water.NightFactor", 1.25);
 			config.addDefault("Properties.Water.PlaySound", true);
 			config.addDefault("Properties.Water.WaterSound.Sound", "BLOCK_WATER_AMBIENT");

--- a/core/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -3,11 +3,13 @@ package com.projectkorra.projectkorra.firebending;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import com.projectkorra.projectkorra.region.RegionProtection;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.block.BlastFurnace;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Campfire;
@@ -150,6 +152,15 @@ public class FireBlast extends FireAbility {
 			this.remove();
 			return false;
 		}
+		for (Block b : GeneralMethods.getBlocksAroundPoint(block.getLocation(), 1.4)) {
+			if (!isSnow(b)) continue;
+
+			if (ThreadLocalRandom.current().nextInt(4) == 0) {
+				dryWetBlocks(b, this, true);
+			} else {
+				dryWetBlocks(b, this);
+			}
+		}
 		if (!block.isPassable()) {
 			if (block.getType() == Material.FURNACE && this.powerFurnace) {
 				final Furnace furnace = (Furnace) block.getState();
@@ -174,6 +185,8 @@ public class FireBlast extends FireAbility {
 				if (!this.isFireBurst || this.fireBurstIgnite) {
 					this.ignite(this.location);
 				}
+			} else if (block.getType() == Material.WET_SPONGE) {
+				dryWetBlocks(block, this, true);
 			}
 			this.remove();
 			return false;

--- a/core/src/com/projectkorra/projectkorra/firebending/FireBlast.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireBlast.java
@@ -155,11 +155,7 @@ public class FireBlast extends FireAbility {
 		for (Block b : GeneralMethods.getBlocksAroundPoint(block.getLocation(), 1.4)) {
 			if (!isSnow(b)) continue;
 
-			if (ThreadLocalRandom.current().nextInt(4) == 0) {
-				dryWetBlocks(b, this, true);
-			} else {
-				dryWetBlocks(b, this);
-			}
+			dryWetBlocks(b, this, ThreadLocalRandom.current().nextInt(4) == 0);
 		}
 		if (!block.isPassable()) {
 			if (block.getType() == Material.FURNACE && this.powerFurnace) {

--- a/core/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireBlastCharged.java
@@ -216,6 +216,9 @@ public class FireBlastCharged extends FireAbility {
 
 			if ((new Random()).nextInt(4) == 0) {
 				playFirebendingSound(this.location);
+				dryWetBlocks(block, this, true);
+			} else {
+				dryWetBlocks(block, this);
 			}
 		}
 

--- a/core/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireManipulation.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -129,6 +131,9 @@ public class FireManipulation extends FireAbility {
 						DamageHandler.damageEntity(entity, this.shieldDamage, this);
 					}
 				}
+				for (Block block : GeneralMethods.getBlocksAroundPoint(point, 1.2D)) {
+					dryWetBlocks(block, this);
+				}
 				if (new Random().nextInt(this.points.keySet().size()) == 0) {
 					playFirebendingSound(point);
 				}
@@ -190,6 +195,9 @@ public class FireManipulation extends FireAbility {
 				if (entity instanceof LivingEntity && entity.getUniqueId() != this.player.getUniqueId()) {
 					DamageHandler.damageEntity(entity, this.streamDamage, this);
 				}
+			}
+			for (Block block : GeneralMethods.getBlocksAroundPoint(this.shotPoint, 2)) {
+				dryWetBlocks(block, this);
 			}
 			if (new Random().nextInt(5) == 0) {
 				playFirebendingSound(this.shotPoint);

--- a/core/src/com/projectkorra/projectkorra/firebending/FireShield.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireShield.java
@@ -1,9 +1,11 @@
 package com.projectkorra.projectkorra.firebending;
 
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import org.bukkit.Location;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -150,6 +152,13 @@ public class FireShield extends FireAbility {
 					entity.remove();
 				}
 			}
+			for (final Block block : GeneralMethods.getBlocksAroundPoint(this.location, this.shieldRadius)) {
+				if (ThreadLocalRandom.current().nextInt(5) == 0) {
+					dryWetBlocks(block, this, true);
+				} else {
+					dryWetBlocks(block, this);
+				}
+			}
 		} else {
 			this.location = this.player.getEyeLocation().clone();
 			final Vector direction = this.location.getDirection();
@@ -181,6 +190,13 @@ public class FireShield extends FireAbility {
 					}
 				} else if (entity instanceof Projectile) {
 					entity.remove();
+				}
+			}
+			for (final Block block : GeneralMethods.getBlocksAroundPoint(this.location, this.discRadius)) {
+				if (ThreadLocalRandom.current().nextInt(5) == 0) {
+					dryWetBlocks(block, this, true);
+				} else {
+					dryWetBlocks(block, this);
 				}
 			}
 		}

--- a/core/src/com/projectkorra/projectkorra/firebending/FireShield.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireShield.java
@@ -153,11 +153,7 @@ public class FireShield extends FireAbility {
 				}
 			}
 			for (final Block block : GeneralMethods.getBlocksAroundPoint(this.location, this.shieldRadius)) {
-				if (ThreadLocalRandom.current().nextInt(5) == 0) {
-					dryWetBlocks(block, this, true);
-				} else {
-					dryWetBlocks(block, this);
-				}
+				dryWetBlocks(block, this, ThreadLocalRandom.current().nextInt(5) == 0);
 			}
 		} else {
 			this.location = this.player.getEyeLocation().clone();
@@ -193,11 +189,7 @@ public class FireShield extends FireAbility {
 				}
 			}
 			for (final Block block : GeneralMethods.getBlocksAroundPoint(this.location, this.discRadius)) {
-				if (ThreadLocalRandom.current().nextInt(5) == 0) {
-					dryWetBlocks(block, this, true);
-				} else {
-					dryWetBlocks(block, this);
-				}
+				dryWetBlocks(block, this, ThreadLocalRandom.current().nextInt(5) == 0);
 			}
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -17,7 +17,9 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Levelled;
+import org.bukkit.block.data.Waterlogged;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -199,6 +201,10 @@ public class HeatControl extends FireAbility {
 
 					block.setType(Material.AIR);
 					block.getWorld().playEffect(block.getLocation(), Effect.EXTINGUISH, 0);
+				} else if (block.getType() == Material.WET_SPONGE) {
+					if (!isWater(block.getRelative(BlockFace.UP)) && !isWater(block.getRelative(BlockFace.DOWN)) && !isWater(block.getRelative(BlockFace.NORTH)) && !isWater(block.getRelative(BlockFace.SOUTH)) && !isWater(block.getRelative(BlockFace.EAST)) && !isWater(block.getRelative(BlockFace.WEST))) {
+						dryWetBlocks(block, this, true);
+					}
 				}
 			}
 
@@ -337,7 +343,7 @@ public class HeatControl extends FireAbility {
 		IceWave.thaw(block);
 
 		if (isMeltable(block) && !TempBlock.isTempBlock(block) && WaterManipulation.canPhysicsChange(block)) {
-			if (block.getType() == Material.SNOW) {
+			if (isSnow(block)) {
 				block.setType(Material.AIR);
 				return;
 			} else {

--- a/core/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import com.projectkorra.projectkorra.region.RegionProtection;
@@ -202,7 +203,7 @@ public class HeatControl extends FireAbility {
 					block.getWorld().playEffect(block.getLocation(), Effect.EXTINGUISH, 0);
 				} else if (block.getType() == Material.WET_SPONGE) {
 					if (!isWater(block.getRelative(BlockFace.UP)) && !isWater(block.getRelative(BlockFace.DOWN)) && !isWater(block.getRelative(BlockFace.NORTH)) && !isWater(block.getRelative(BlockFace.SOUTH)) && !isWater(block.getRelative(BlockFace.EAST)) && !isWater(block.getRelative(BlockFace.WEST))) {
-						dryWetBlocks(block, this, true);
+						dryWetBlocks(block, this, ThreadLocalRandom.current().nextInt(5) == 0);
 					}
 				}
 			}

--- a/core/src/com/projectkorra/projectkorra/firebending/HeatControl.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/HeatControl.java
@@ -19,7 +19,6 @@ import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Levelled;
-import org.bukkit.block.data.Waterlogged;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;

--- a/core/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.firebending;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import org.bukkit.Location;
@@ -130,6 +131,11 @@ public class WallOfFire extends FireAbility {
 	private void display() {
 		for (final Block block : this.blocks) {
 			if (!this.isTransparent(block)) {
+				if (ThreadLocalRandom.current().nextInt(5) == 0) {
+					dryWetBlocks(block, this, true);
+				} else {
+					dryWetBlocks(block, this);
+				}
 				continue;
 			}
 

--- a/core/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -131,11 +131,7 @@ public class WallOfFire extends FireAbility {
 	private void display() {
 		for (final Block block : this.blocks) {
 			if (!this.isTransparent(block)) {
-				if (ThreadLocalRandom.current().nextInt(5) == 0) {
-					dryWetBlocks(block, this, true);
-				} else {
-					dryWetBlocks(block, this);
-				}
+				dryWetBlocks(block, this, ThreadLocalRandom.current().nextInt(5) == 0);
 				continue;
 			}
 

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -25,6 +25,18 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.Element.SubElement;
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.ability.ElementalAbility;
+import com.projectkorra.projectkorra.command.Commands;
+import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
+import com.projectkorra.projectkorra.util.DamageHandler;
+import com.projectkorra.projectkorra.util.ParticleEffect;
+
+import java.util.concurrent.ThreadLocalRandom;
+
 /***
  * Is only here for legacy purposes. All fire combos used to use a form of this
  * stream for all their progress methods. If someone else was reliant on that,
@@ -122,7 +134,7 @@ public class FireComboStream extends BukkitRunnable {
 				}
 			}
 			for (Block b : GeneralMethods.getBlocksAroundPoint(this.location, this.collisionRadius)) {
-				FireAbility.dryWetBlocks(b, this.coreAbility);
+				FireAbility.dryWetBlocks(b, this.coreAbility, ThreadLocalRandom.current().nextInt(5) == 0);
 			}
 		}
 

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -5,6 +5,7 @@ import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
+import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.command.Commands;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -121,6 +121,9 @@ public class FireComboStream extends BukkitRunnable {
 					this.collision((LivingEntity) entity, this.direction, this.coreAbility);
 				}
 			}
+			for (Block b : GeneralMethods.getBlocksAroundPoint(this.location, this.collisionRadius)) {
+				FireAbility.dryWetBlocks(b, this.coreAbility);
+			}
 		}
 
 		this.checkCollisionCounter++;

--- a/core/src/com/projectkorra/projectkorra/util/BlockSource.java
+++ b/core/src/com/projectkorra/projectkorra/util/BlockSource.java
@@ -33,7 +33,7 @@ public class BlockSource {
 	 * @author kingbirdy
 	 */
 	public static enum BlockSourceType {
-		WATER, ICE, PLANT, EARTH, METAL, LAVA, SNOW
+		WATER, ICE, PLANT, EARTH, METAL, LAVA, SNOW, MUD
 	}
 
 	private static HashMap<Player, HashMap<BlockSourceType, HashMap<ClickType, BlockSourceInformation>>> playerSources = new HashMap<Player, HashMap<BlockSourceType, HashMap<ClickType, BlockSourceInformation>>>();
@@ -72,6 +72,9 @@ public class BlockSource {
 				if (WaterAbility.isSnow(waterBlock) || (WaterAbility.isCauldron(waterBlock.getType()) && waterBlock.getType() == Material.getMaterial("POWDER_SNOW_CAULDRON"))) {
 					putSource(player, waterBlock, BlockSourceType.SNOW, clickType);
 				}
+				if (ElementalAbility.isMud(waterBlock)) {
+					putSource(player, waterBlock, BlockSourceType.MUD, clickType);
+				}
 			}
 		} else if (coreAbil instanceof EarthAbility) {
 			final Block earthBlock = EarthAbility.getEarthSourceBlock(player, null, MAX_RANGE);
@@ -79,6 +82,9 @@ public class BlockSource {
 				putSource(player, earthBlock, BlockSourceType.EARTH, clickType);
 				if (ElementalAbility.isMetal(earthBlock)) {
 					putSource(player, earthBlock, BlockSourceType.METAL, clickType);
+				}
+				if (ElementalAbility.isMud(earthBlock)) {
+					putSource(player, earthBlock, BlockSourceType.MUD, clickType);
 				}
 			}
 
@@ -270,7 +276,7 @@ public class BlockSource {
 		} else {
 			sourceBlock = WaterAbility.getWaterSourceBlock(player, range, allowPlant);
 		}
-		if (sourceBlock != null && !ElementalAbility.isAir(sourceBlock.getType()) && (ElementalAbility.isWater(sourceBlock) || ElementalAbility.isPlant(sourceBlock) || WaterAbility.isSnow(sourceBlock) || ElementalAbility.isIce(sourceBlock) || WaterAbility.isCauldron(sourceBlock))) {
+		if (sourceBlock != null && !ElementalAbility.isAir(sourceBlock.getType()) && (ElementalAbility.isWater(sourceBlock) || ElementalAbility.isPlant(sourceBlock) || WaterAbility.isSnow(sourceBlock) || ElementalAbility.isIce(sourceBlock) || WaterAbility.isCauldron(sourceBlock) || WaterAbility.isMud(sourceBlock))) {
 			if (TempBlock.isTempBlock(sourceBlock) && !WaterAbility.isBendableWaterTempBlock(sourceBlock)) {
 				return null;
 			}
@@ -400,6 +406,8 @@ public class BlockSource {
 		} else if (info.getSourceType() == BlockSourceType.METAL && (!ElementalAbility.isMetal(info.getBlock()) || !EarthAbility.isEarthbendable(info.getPlayer(), info.getBlock()))) {
 			return false;
 		} else if (info.getSourceType() == BlockSourceType.LAVA && (!ElementalAbility.isLava(info.getBlock()) || !EarthAbility.isLavabendable(info.getPlayer(), info.getBlock()))) {
+			return false;
+		} else if (info.getSourceType() == BlockSourceType.MUD && (!ElementalAbility.isMud(info.getBlock()) || (!EarthAbility.isEarthbendable(info.getPlayer(), info.getBlock())) || !WaterAbility.isWaterbendable(info.getPlayer(), null, info.getBlock()))) {
 			return false;
 		}
 		return true;

--- a/core/src/com/projectkorra/projectkorra/util/BlockSource.java
+++ b/core/src/com/projectkorra/projectkorra/util/BlockSource.java
@@ -276,7 +276,7 @@ public class BlockSource {
 		} else {
 			sourceBlock = WaterAbility.getWaterSourceBlock(player, range, allowPlant);
 		}
-		if (sourceBlock != null && !ElementalAbility.isAir(sourceBlock.getType()) && (ElementalAbility.isWater(sourceBlock) || ElementalAbility.isPlant(sourceBlock) || WaterAbility.isSnow(sourceBlock) || ElementalAbility.isIce(sourceBlock) || WaterAbility.isCauldron(sourceBlock) || WaterAbility.isMud(sourceBlock))) {
+		if (sourceBlock != null && !ElementalAbility.isAir(sourceBlock.getType()) && (ElementalAbility.isWater(sourceBlock) || ElementalAbility.isPlant(sourceBlock) || WaterAbility.isSnow(sourceBlock) || ElementalAbility.isIce(sourceBlock) || WaterAbility.isCauldron(sourceBlock) || WaterAbility.isMud(sourceBlock) || WaterAbility.isSponge(sourceBlock))) {
 			if (TempBlock.isTempBlock(sourceBlock) && !WaterAbility.isBendableWaterTempBlock(sourceBlock)) {
 				return null;
 			}

--- a/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -175,10 +175,10 @@ public class OctopusForm extends WaterAbility {
 		if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 			new PlantRegrowth(this.player, this.sourceBlock);
 			this.sourceBlock.setType(Material.AIR);
-		} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && this.sourceBlock != null && !isTransformableBlock(this.sourceBlock)) {
-			this.sourceBlock.setType(Material.AIR);
-		} else if (isTransformableBlock(this.sourceBlock)) {
+		} else if (isCauldron(this.sourceBlock) || isTransformableBlock(this.sourceBlock)) {
 			updateSourceBlock(this.sourceBlock);
+		} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && this.sourceBlock != null) {
+			this.sourceBlock.setType(Material.AIR);
 		}
 		this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : GeneralMethods.getWaterData(0), this);
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -179,6 +179,13 @@ public class OctopusForm extends WaterAbility {
 			this.sourceBlock.setType(Material.AIR);
 		} else if (isCauldron(this.sourceBlock)) {
 			GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
+		} else if (isMud(this.sourceBlock)) {
+			if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
+				this.sourceBlock.setType(Material.DIRT);
+			} else {
+				this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
+			}
+			playMudbendingSound(this.sourceBlock.getLocation());
 		}
 		this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : GeneralMethods.getWaterData(0), this);
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -175,17 +175,10 @@ public class OctopusForm extends WaterAbility {
 		if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 			new PlantRegrowth(this.player, this.sourceBlock);
 			this.sourceBlock.setType(Material.AIR);
-		} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && this.sourceBlock != null && !isCauldron(this.sourceBlock)) {
+		} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && this.sourceBlock != null && !isNonTransparentSource(this.sourceBlock)) {
 			this.sourceBlock.setType(Material.AIR);
-		} else if (isCauldron(this.sourceBlock)) {
-			GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
-		} else if (isMud(this.sourceBlock)) {
-			if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
-				this.sourceBlock.setType(Material.DIRT);
-			} else {
-				this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
-			}
-			playMudbendingSound(this.sourceBlock.getLocation());
+		} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+			updateSourceBlock(this.sourceBlock);
 		}
 		this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : GeneralMethods.getWaterData(0), this);
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -175,9 +175,9 @@ public class OctopusForm extends WaterAbility {
 		if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 			new PlantRegrowth(this.player, this.sourceBlock);
 			this.sourceBlock.setType(Material.AIR);
-		} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && this.sourceBlock != null && !isNonTransparentSource(this.sourceBlock)) {
+		} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && this.sourceBlock != null && !isTransformableBlock(this.sourceBlock)) {
 			this.sourceBlock.setType(Material.AIR);
-		} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+		} else if (isTransformableBlock(this.sourceBlock)) {
 			updateSourceBlock(this.sourceBlock);
 		}
 		this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : GeneralMethods.getWaterData(0), this);

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -210,7 +210,7 @@ public class SurgeWall extends WaterAbility {
 				if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 					new PlantRegrowth(this.player, this.sourceBlock);
 					this.sourceBlock.setType(Material.AIR, false);
-				} else if (isTransformableBlock(this.sourceBlock)) {
+				} else if (isCauldron(this.sourceBlock) || isTransformableBlock(this.sourceBlock)) {
 					updateSourceBlock(this.sourceBlock);
 				}
 				this.addWater(this.sourceBlock);

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -210,15 +210,8 @@ public class SurgeWall extends WaterAbility {
 				if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 					new PlantRegrowth(this.player, this.sourceBlock);
 					this.sourceBlock.setType(Material.AIR, false);
-				} else if (isCauldron(this.sourceBlock)) {
-					GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
-				} else if (isMud(this.sourceBlock)) {
-					if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
-						this.sourceBlock.setType(Material.DIRT);
-					} else {
-						this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
-					}
-					playMudbendingSound(this.sourceBlock.getLocation());
+				} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+					updateSourceBlock(this.sourceBlock);
 				}
 				this.addWater(this.sourceBlock);
 			}

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -210,7 +210,7 @@ public class SurgeWall extends WaterAbility {
 				if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 					new PlantRegrowth(this.player, this.sourceBlock);
 					this.sourceBlock.setType(Material.AIR, false);
-				} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+				} else if (isTransformableBlock(this.sourceBlock)) {
 					updateSourceBlock(this.sourceBlock);
 				}
 				this.addWater(this.sourceBlock);

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -212,6 +212,13 @@ public class SurgeWall extends WaterAbility {
 					this.sourceBlock.setType(Material.AIR, false);
 				} else if (isCauldron(this.sourceBlock)) {
 					GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
+				} else if (isMud(this.sourceBlock)) {
+					if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
+						this.sourceBlock.setType(Material.DIRT);
+					} else {
+						this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
+					}
+					playMudbendingSound(this.sourceBlock.getLocation());
 				}
 				this.addWater(this.sourceBlock);
 			}

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -239,7 +239,7 @@ public class SurgeWave extends WaterAbility {
 				if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 					new PlantRegrowth(this.player, this.sourceBlock);
 					this.sourceBlock.setType(Material.AIR, false);
-				} else if (isTransformableBlock(this.sourceBlock)) {
+				} else if (isCauldron(this.sourceBlock) || isTransformableBlock(this.sourceBlock)) {
 					updateSourceBlock(this.sourceBlock);
 				}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -239,7 +239,7 @@ public class SurgeWave extends WaterAbility {
 				if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 					new PlantRegrowth(this.player, this.sourceBlock);
 					this.sourceBlock.setType(Material.AIR, false);
-				} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+				} else if (isTransformableBlock(this.sourceBlock)) {
 					updateSourceBlock(this.sourceBlock);
 				}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -239,15 +239,8 @@ public class SurgeWave extends WaterAbility {
 				if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 					new PlantRegrowth(this.player, this.sourceBlock);
 					this.sourceBlock.setType(Material.AIR, false);
-				} else if (isCauldron(this.sourceBlock)) {
-					GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
-				} else if (isMud(this.sourceBlock)) {
-					if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
-						this.sourceBlock.setType(Material.DIRT);
-					} else {
-						this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
-					}
-					playMudbendingSound(this.sourceBlock.getLocation());
+				} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+					updateSourceBlock(this.sourceBlock);
 				}
 
 				if (TempBlock.isTempBlock(this.sourceBlock)) {

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -241,6 +241,13 @@ public class SurgeWave extends WaterAbility {
 					this.sourceBlock.setType(Material.AIR, false);
 				} else if (isCauldron(this.sourceBlock)) {
 					GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
+				} else if (isMud(this.sourceBlock)) {
+					if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
+						this.sourceBlock.setType(Material.DIRT);
+					} else {
+						this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
+					}
+					playMudbendingSound(this.sourceBlock.getLocation());
 				}
 
 				if (TempBlock.isTempBlock(this.sourceBlock)) {

--- a/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.entity.Entity;
@@ -210,17 +211,10 @@ public class Torrent extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && !isCauldron(this.sourceBlock) && !isMud(this.sourceBlock)) {
+					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && !isNonTransparentSource(this.sourceBlock)) {
 						this.sourceBlock.setType(Material.AIR);
-					} else if (isCauldron(this.sourceBlock)) {
-						GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
-					} else if (isMud(this.sourceBlock)) {
-						if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
-							this.sourceBlock.setType(Material.DIRT);
-						} else {
-							this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
-						}
-						playMudbendingSound(this.sourceBlock.getLocation());
+					} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+						updateSourceBlock(this.sourceBlock);
 					}
 					
 					this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : Material.WATER.createBlockData());

--- a/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -210,10 +210,17 @@ public class Torrent extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && !isCauldron(this.sourceBlock)) {
+					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && !isCauldron(this.sourceBlock) && !isMud(this.sourceBlock)) {
 						this.sourceBlock.setType(Material.AIR);
 					} else if (isCauldron(this.sourceBlock)) {
 						GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
+					} else if (isMud(this.sourceBlock)) {
+						if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
+							this.sourceBlock.setType(Material.DIRT);
+						} else {
+							this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
+						}
+						playMudbendingSound(this.sourceBlock.getLocation());
 					}
 					
 					this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : Material.WATER.createBlockData());

--- a/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -211,9 +211,9 @@ public class Torrent extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && !isNonTransparentSource(this.sourceBlock)) {
+					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && !isTransformableBlock(this.sourceBlock)) {
 						this.sourceBlock.setType(Material.AIR);
-					} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+					} else if (isTransformableBlock(this.sourceBlock)) {
 						updateSourceBlock(this.sourceBlock);
 					}
 					

--- a/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -211,10 +211,10 @@ public class Torrent extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock) && !isTransformableBlock(this.sourceBlock)) {
-						this.sourceBlock.setType(Material.AIR);
-					} else if (isTransformableBlock(this.sourceBlock)) {
+					} else if (isCauldron(this.sourceBlock) || isTransformableBlock(this.sourceBlock)) {
 						updateSourceBlock(this.sourceBlock);
+					} else if (!GeneralMethods.isAdjacentToThreeOrMoreSources(this.sourceBlock)) {
+						this.sourceBlock.setType(Material.AIR);
 					}
 					
 					this.source = new TempBlock(this.sourceBlock, isCauldron(this.sourceBlock) ? this.sourceBlock.getBlockData() : Material.WATER.createBlockData());

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -192,10 +192,10 @@ public class WaterManipulation extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!isIce(this.sourceBlock) && !isTransformableBlock(this.sourceBlock)) {
-						addWater(this.sourceBlock);
-					} else if (isTransformableBlock(this.sourceBlock)) {
+					} else if (isCauldron(this.sourceBlock) || isTransformableBlock(this.sourceBlock)) {
 						updateSourceBlock(this.sourceBlock);
+					} else if (!isIce(this.sourceBlock)) {
+						addWater(this.sourceBlock);
 					}
 				}
 			}

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -192,10 +192,17 @@ public class WaterManipulation extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!isIce(this.sourceBlock) && !isCauldron(this.sourceBlock)) {
+					} else if (!isIce(this.sourceBlock) && !isCauldron(this.sourceBlock) && !isMud(this.sourceBlock)) {
 						addWater(this.sourceBlock);
 					} else if (isCauldron(this.sourceBlock)) {
 						GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
+					} else if (isMud(this.sourceBlock)) {
+						if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
+							this.sourceBlock.setType(Material.DIRT);
+						} else {
+							this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
+						}
+						playMudbendingSound(this.sourceBlock.getLocation());
 					}
 				}
 			}
@@ -231,7 +238,7 @@ public class WaterManipulation extends WaterAbility {
 				return;
 			} else {
 				if (!this.progressing) {
-					if (!(isWater(this.sourceBlock.getType()) || isCauldron(this.sourceBlock) || (isIce(this.sourceBlock) && this.bPlayer.canIcebend()) || (isSnow(this.sourceBlock) && this.bPlayer.canIcebend()) || (isPlant(this.sourceBlock) && this.bPlayer.canPlantbend()))) {
+					if (!(isWater(this.sourceBlock.getType()) || isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || (isIce(this.sourceBlock) && this.bPlayer.canIcebend()) || (isSnow(this.sourceBlock) && this.bPlayer.canIcebend()) || (isPlant(this.sourceBlock) && this.bPlayer.canPlantbend()))) {
 						this.remove();
 						return;
 					}
@@ -365,7 +372,7 @@ public class WaterManipulation extends WaterAbility {
 			return;
 		}
 		if (AFFECTED_BLOCKS.containsKey(block)) {
-			if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isCauldron(block)) {
+			if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isCauldron(block) && !isMud(block)) {
 				block.setType(Material.AIR);
 			}
 			AFFECTED_BLOCKS.remove(block);
@@ -375,7 +382,7 @@ public class WaterManipulation extends WaterAbility {
 	private void removeWater(final Block block) {
 		if (block != null) {
 			if (AFFECTED_BLOCKS.containsKey(block)) {
-				if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isCauldron(block)) {
+				if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isCauldron(block) && !isMud(block)) {
 					block.setType(Material.AIR);
 				}
 				AFFECTED_BLOCKS.remove(block);

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -192,9 +192,9 @@ public class WaterManipulation extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!isIce(this.sourceBlock) && !isNonTransparentSource(this.sourceBlock)) {
+					} else if (!isIce(this.sourceBlock) && !isTransformableBlock(this.sourceBlock)) {
 						addWater(this.sourceBlock);
-					} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+					} else if (isTransformableBlock(this.sourceBlock)) {
 						updateSourceBlock(this.sourceBlock);
 					}
 				}
@@ -365,7 +365,7 @@ public class WaterManipulation extends WaterAbility {
 			return;
 		}
 		if (AFFECTED_BLOCKS.containsKey(block)) {
-			if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isNonTransparentSource(block)) {
+			if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isTransformableBlock(block)) {
 				block.setType(Material.AIR);
 			}
 			AFFECTED_BLOCKS.remove(block);
@@ -375,7 +375,7 @@ public class WaterManipulation extends WaterAbility {
 	private void removeWater(final Block block) {
 		if (block != null) {
 			if (AFFECTED_BLOCKS.containsKey(block)) {
-				if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isNonTransparentSource(block)) {
+				if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isTransformableBlock(block)) {
 					block.setType(Material.AIR);
 				}
 				AFFECTED_BLOCKS.remove(block);

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -192,17 +192,10 @@ public class WaterManipulation extends WaterAbility {
 					if (isPlant(this.sourceBlock) || isSnow(this.sourceBlock)) {
 						new PlantRegrowth(this.player, this.sourceBlock);
 						this.sourceBlock.setType(Material.AIR);
-					} else if (!isIce(this.sourceBlock) && !isCauldron(this.sourceBlock) && !isMud(this.sourceBlock)) {
+					} else if (!isIce(this.sourceBlock) && !isNonTransparentSource(this.sourceBlock)) {
 						addWater(this.sourceBlock);
-					} else if (isCauldron(this.sourceBlock)) {
-						GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
-					} else if (isMud(this.sourceBlock)) {
-						if (this.sourceBlock.getType() == Material.getMaterial("MUD") || this.sourceBlock.getType() == Material.getMaterial("PACKED_MUD")) {
-							this.sourceBlock.setType(Material.DIRT);
-						} else {
-							this.sourceBlock.setType(Material.getMaterial("MANGROVE_ROOTS"));
-						}
-						playMudbendingSound(this.sourceBlock.getLocation());
+					} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+						updateSourceBlock(this.sourceBlock);
 					}
 				}
 			}
@@ -238,7 +231,7 @@ public class WaterManipulation extends WaterAbility {
 				return;
 			} else {
 				if (!this.progressing) {
-					if (!(isWater(this.sourceBlock.getType()) || isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || (isIce(this.sourceBlock) && this.bPlayer.canIcebend()) || (isSnow(this.sourceBlock) && this.bPlayer.canIcebend()) || (isPlant(this.sourceBlock) && this.bPlayer.canPlantbend()))) {
+					if (!(isWater(this.sourceBlock.getType()) || isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock) || (isIce(this.sourceBlock) && this.bPlayer.canIcebend()) || (isSnow(this.sourceBlock) && this.bPlayer.canIcebend()) || (isPlant(this.sourceBlock) && this.bPlayer.canPlantbend()))) {
 						this.remove();
 						return;
 					}
@@ -372,7 +365,7 @@ public class WaterManipulation extends WaterAbility {
 			return;
 		}
 		if (AFFECTED_BLOCKS.containsKey(block)) {
-			if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isCauldron(block) && !isMud(block)) {
+			if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isNonTransparentSource(block)) {
 				block.setType(Material.AIR);
 			}
 			AFFECTED_BLOCKS.remove(block);
@@ -382,7 +375,7 @@ public class WaterManipulation extends WaterAbility {
 	private void removeWater(final Block block) {
 		if (block != null) {
 			if (AFFECTED_BLOCKS.containsKey(block)) {
-				if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isCauldron(block) && !isMud(block)) {
+				if (!GeneralMethods.isAdjacentToThreeOrMoreSources(block) && !isNonTransparentSource(block)) {
 					block.setType(Material.AIR);
 				}
 				AFFECTED_BLOCKS.remove(block);

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -210,7 +210,7 @@ public class WaterSpoutWave extends WaterAbility {
 				if (isPlant(this.origin.getBlock()) || isSnow(this.origin.getBlock())) {
 					new PlantRegrowth(this.player, this.origin.getBlock());
 					this.origin.getBlock().setType(Material.AIR);
-				} else if (isCauldron(this.origin.getBlock()) || isMud(this.origin.getBlock()) || isSponge(this.origin.getBlock())) {
+				} else if (isTransformableBlock(this.origin.getBlock())) {
 					updateSourceBlock(this.origin.getBlock());
 				}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -211,21 +211,7 @@ public class WaterSpoutWave extends WaterAbility {
 					new PlantRegrowth(this.player, this.origin.getBlock());
 					this.origin.getBlock().setType(Material.AIR);
 				} else if (isCauldron(this.origin.getBlock()) || isMud(this.origin.getBlock()) || isSponge(this.origin.getBlock())) {
-					updateSourceBlock(this.origin.getBlock(), block -> {
-						if (isCauldron(block)) {
-							this.origin.getBlock().setType(Material.CAULDRON);
-						} else if (isMud(block)) {
-							if (block.getType() == Material.getMaterial("MUD") || block.getType() == Material.getMaterial("PACKED_MUD")) {
-								block.setType(Material.DIRT);
-							} else {
-								block.setType(Material.getMaterial("MANGROVE_ROOTS"));
-							}
-							playMudbendingSound(block.getLocation());
-						} else if (isSponge(block)) {
-							block.setType(Material.SPONGE);
-							block.getWorld().playSound(block.getLocation(), Sound.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
-						}
-					});
+					updateSourceBlock(this.origin.getBlock());
 				}
 
 				if (TempBlock.isTempBlock(this.origin.getBlock())) {

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
@@ -209,8 +210,22 @@ public class WaterSpoutWave extends WaterAbility {
 				if (isPlant(this.origin.getBlock()) || isSnow(this.origin.getBlock())) {
 					new PlantRegrowth(this.player, this.origin.getBlock());
 					this.origin.getBlock().setType(Material.AIR);
-				} else if (isCauldron(this.origin.getBlock())) {
-					this.origin.getBlock().setType(Material.CAULDRON);
+				} else if (isCauldron(this.origin.getBlock()) || isMud(this.origin.getBlock()) || isSponge(this.origin.getBlock())) {
+					updateSourceBlock(this.origin.getBlock(), block -> {
+						if (isCauldron(block)) {
+							this.origin.getBlock().setType(Material.CAULDRON);
+						} else if (isMud(block)) {
+							if (block.getType() == Material.getMaterial("MUD") || block.getType() == Material.getMaterial("PACKED_MUD")) {
+								block.setType(Material.DIRT);
+							} else {
+								block.setType(Material.getMaterial("MANGROVE_ROOTS"));
+							}
+							playMudbendingSound(block.getLocation());
+						} else if (isSponge(block)) {
+							block.setType(Material.SPONGE);
+							block.getWorld().playSound(block.getLocation(), Sound.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
+						}
+					});
 				}
 
 				if (TempBlock.isTempBlock(this.origin.getBlock())) {

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -210,7 +210,7 @@ public class WaterSpoutWave extends WaterAbility {
 				if (isPlant(this.origin.getBlock()) || isSnow(this.origin.getBlock())) {
 					new PlantRegrowth(this.player, this.origin.getBlock());
 					this.origin.getBlock().setType(Material.AIR);
-				} else if (isTransformableBlock(this.origin.getBlock())) {
+				} else if (isCauldron(this.origin.getBlock()) || isTransformableBlock(this.origin.getBlock())) {
 					updateSourceBlock(this.origin.getBlock());
 				}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -286,8 +286,8 @@ public class IceSpikeBlast extends IceAbility {
 			if (isBendableWaterTempBlock(tb)) {
 				tb.revertBlock();
 			}
-		} else if (isCauldron(this.sourceBlock)) {
-			GeneralMethods.setCauldronData(this.sourceBlock, ((Levelled) this.sourceBlock.getBlockData()).getLevel() - 1);
+		} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+			updateSourceBlock(this.sourceBlock);
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -286,7 +286,7 @@ public class IceSpikeBlast extends IceAbility {
 			if (isBendableWaterTempBlock(tb)) {
 				tb.revertBlock();
 			}
-		} else if (isCauldron(this.sourceBlock) || isMud(this.sourceBlock) || isSponge(this.sourceBlock)) {
+		} else if (isTransformableBlock(this.sourceBlock)) {
 			updateSourceBlock(this.sourceBlock);
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -286,7 +286,7 @@ public class IceSpikeBlast extends IceAbility {
 			if (isBendableWaterTempBlock(tb)) {
 				tb.revertBlock();
 			}
-		} else if (isTransformableBlock(this.sourceBlock)) {
+		} else if (isCauldron(this.sourceBlock) || isTransformableBlock(this.sourceBlock)) {
 			updateSourceBlock(this.sourceBlock);
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -169,7 +169,7 @@ public class WaterArms extends WaterAbility {
 				new PlantRegrowth(this.player, sourceBlock);
 				sourceBlock.setType(Material.AIR);
 				this.fullSource = false;
-			} else if (isCauldron(sourceBlock) || isMud(sourceBlock) || isSponge(sourceBlock)) {
+			} else if (isTransformableBlock(sourceBlock)) {
 				updateSourceBlock(sourceBlock);
 			}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -169,7 +169,7 @@ public class WaterArms extends WaterAbility {
 				new PlantRegrowth(this.player, sourceBlock);
 				sourceBlock.setType(Material.AIR);
 				this.fullSource = false;
-			} else if (isTransformableBlock(sourceBlock)) {
+			} else if (isCauldron(sourceBlock) || isTransformableBlock(sourceBlock)) {
 				updateSourceBlock(sourceBlock);
 			}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -169,8 +169,8 @@ public class WaterArms extends WaterAbility {
 				new PlantRegrowth(this.player, sourceBlock);
 				sourceBlock.setType(Material.AIR);
 				this.fullSource = false;
-			} else if (isCauldron(sourceBlock)) {
-				GeneralMethods.setCauldronData(sourceBlock, ((Levelled) sourceBlock.getBlockData()).getLevel() - 1);
+			} else if (isCauldron(sourceBlock) || isMud(sourceBlock) || isSponge(sourceBlock)) {
+				updateSourceBlock(sourceBlock);
 			}
 
 			ParticleEffect.SMOKE_LARGE.display(sourceBlock.getLocation().clone().add(0.5, 0.5, 0.5), 4, 0, 0, 0);

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
@@ -107,6 +107,7 @@ public class WaterArmsFreeze extends IceAbility {
 					this.waterArms.setRightArmCooldown(false);
 				}
 				this.waterArms.setMaxIceBlasts(this.waterArms.getMaxIceBlasts() - 1);
+				ActionBar.sendActionBar(Element.WATER.getSubColor() + "Ice blasts left: " + this.waterArms.getMaxIceBlasts(), this.player);
 			}
 		}
 
@@ -163,6 +164,7 @@ public class WaterArmsFreeze extends IceAbility {
 					this.waterArms.setRightArmCooldown(false);
 				}
 				this.waterArms.setMaxIceBlasts(this.waterArms.getMaxIceBlasts() - 1);
+				ActionBar.sendActionBar(Element.WATER.getSubColor() + "Ice Blasts Left: " + this.waterArms.getMaxIceBlasts(), this.player);
 			}
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
@@ -1,6 +1,8 @@
 package com.projectkorra.projectkorra.waterbending.multiabilities;
 
+import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
+import com.projectkorra.projectkorra.util.ActionBar;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsFreeze.java
@@ -107,7 +107,7 @@ public class WaterArmsFreeze extends IceAbility {
 					this.waterArms.setRightArmCooldown(false);
 				}
 				this.waterArms.setMaxIceBlasts(this.waterArms.getMaxIceBlasts() - 1);
-				ActionBar.sendActionBar(Element.WATER.getSubColor() + "Ice blasts left: " + this.waterArms.getMaxIceBlasts(), this.player);
+				ActionBar.sendActionBar(Element.WATER.getSubColor() + "Ice Blasts Left: " + this.waterArms.getMaxIceBlasts(), this.player);
 			}
 		}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -2,6 +2,8 @@ package com.projectkorra.projectkorra.waterbending.multiabilities;
 
 import java.util.HashMap;
 
+import com.projectkorra.projectkorra.Element;
+import com.projectkorra.projectkorra.util.ActionBar;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -392,6 +394,9 @@ public class WaterArmsWhip extends WaterAbility {
 			}
 			if (this.hasDamaged) {
 				this.waterArms.setMaxPunches(this.waterArms.getMaxPunches() - 1);
+				ActionBar.sendActionBar(Element.WATER.getSubColor() + "Punches Left: " + this.waterArms.getMaxPunches(), this.player);
+			} else {
+				ActionBar.sendActionBar(Element.WATER.getSubColor() + "Uses Left: " + this.waterArms.getMaxUses(), this.player);
 			}
 
 			this.waterArms.setMaxUses(this.waterArms.getMaxUses() - 1);


### PR DESCRIPTION
Implementing suggestions from Discord.

## Additions
* Added mudbending viability for waterbending and earthbending. ***Suggested by member: `.pan_daniel`***
    - ProjectKorra water abilities that use mud as a source will turn them into dirt (muddy mangrove roots turn to mangrove roots) upon activation.
    - Mudbending sounds, configurable:
        -  Earthbenders hear `BLOCK_MUD_PLACE`; `EarthAbility.playMudbendingSound()` plays this sound. 
        - Waterbenders hear `BLOCK_MUD_STEP`; `WaterAbility.playMudbendingSound()` plays this sound.

* AvatarState sound change. ***Suggested by member `cinchedlibra` and `manuel04_`***
    - Changed sound from `BLOCK_ANVIL_FALL` to `BLOCK_BEACON_POWER_SELECT`.

* Food dropped by mobs is cooked when killed by firebending. ***Suggested by member: `novatitan_`***

* Waterbenders can use wet sponges as a source. They will turn into regular sponges upon use. ***Suggested by member: `mackapackaa`***

* Firebenders can dry up sponges as well as destroy snow blocks with `FireBlast`, `FireShield`, `FireManipulation`, `HeatControl` and `WallOfFire`. ***Suggested by member: `mackapackaa`***

* Number of uses left for each `WaterArms` ability are portrayed in the action bar upon use. ***Suggested by member: `loyr`***

* ~~Users are able to change what transformable water sources can transform into in the config under `Properties.Water.TransformableBlocks`.~~
    - ~~E.g. `MUD>DIRT` will turn the transformable `MUD` source into `DIRT`.~~
    - ~~*Note: non-transformable sources such as `DIAMOND_BLOCK`, for example, or anything that isn't `MUD`, `PACKED_MUD`, `MUDDY_MANGROVE_ROOTS` or `WET_SPONGE` will be ignored.*~~
> Transformables will not be included as of 1.12. Will be further looked into in future releases.

> ~~Will be implementing more suggestions until the next beta releases. This PR can be merged when it does. Until then, I will continue implementing more suggestions and updating this PR.~~ **This PR is congested, will move part 2 into another PR.**