### PR TITLE
Implementing suggestions 2: Surge bubble particles, configuration, Extraction iron golem viability

### DIFF
--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1440,7 +1440,6 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.Extraction.DoubleLootChance", 30);
 			config.addDefault("Abilities.Earth.Extraction.IronGolem.Drops", 1);
 			config.addDefault("Abilities.Earth.Extraction.IronGolem.Damage", 4);
-			config.addDefault("Abilities.Earth.Extraction.IronGolem.DropMaterial", "IRON_NUGGET");
 
 			config.addDefault("Abilities.Earth.LavaFlow.Enabled", true);
 			config.addDefault("Abilities.Earth.LavaFlow.ShiftCooldown", 20000);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1492,6 +1492,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.MetalClips.Range", 10);
 			config.addDefault("Abilities.Earth.MetalClips.Cooldown", 6000);
 			config.addDefault("Abilities.Earth.MetalClips.Duration", 10000);
+			config.addDefault("Abilities.Earth.MetalClips.Shoot.Cooldown", 600);
+			config.addDefault("Abilities.Earth.MetalClips.Shoot.Speed", 1.2);
 			config.addDefault("Abilities.Earth.MetalClips.Magnet.Range", 20);
 			config.addDefault("Abilities.Earth.MetalClips.Magnet.Speed", 0.6);
 			config.addDefault("Abilities.Earth.MetalClips.Magnet.Cooldown", 1000);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1188,6 +1188,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.Surge.Wave.SolidifyLava.Enabled", true);
 			config.addDefault("Abilities.Water.Surge.Wave.SolidifyLava.Duration", 36000);
 			config.addDefault("Abilities.Water.Surge.Wall.Range", 5);
+			config.addDefault("Abilities.Water.Surge.Wall.SelectRange", 5);
 			config.addDefault("Abilities.Water.Surge.Wall.Radius", 2);
 			config.addDefault("Abilities.Water.Surge.Wall.Cooldown", 0);
 			config.addDefault("Abilities.Water.Surge.Wall.Duration", 0);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1438,6 +1438,9 @@ public class ConfigManager {
 			config.addDefault("Abilities.Earth.Extraction.Cooldown", 500);
 			config.addDefault("Abilities.Earth.Extraction.TripleLootChance", 10);
 			config.addDefault("Abilities.Earth.Extraction.DoubleLootChance", 30);
+			config.addDefault("Abilities.Earth.Extraction.IronGolem.Drops", 1);
+			config.addDefault("Abilities.Earth.Extraction.IronGolem.Damage", 4);
+			config.addDefault("Abilities.Earth.Extraction.IronGolem.DropMaterial", "IRON_NUGGET");
 
 			config.addDefault("Abilities.Earth.LavaFlow.Enabled", true);
 			config.addDefault("Abilities.Earth.LavaFlow.ShiftCooldown", 20000);

--- a/core/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
@@ -48,10 +48,7 @@ public class Extraction extends MetalAbility {
 		this.selectRange = getConfig().getInt("Abilities.Earth.Extraction.SelectRange");
 		this.ironGolemDrops = getConfig().getInt("Abilities.Earth.Extraction.IronGolem.Drops");
 		this.ironGolemDamage = getConfig().getDouble("Abilities.Earth.Extraction.IronGolem.Damage");
-		this.ironGolemDropMaterial = Material.getMaterial(getConfig().getString("Abilities.Earth.Extraction.IronGolem.DropMaterial"));
-		if (this.ironGolemDropMaterial == null) {
-			this.ironGolemDropMaterial = Material.IRON_INGOT;
-		}
+		this.ironGolemDropMaterial = Material.IRON_NUGGET;
 
 		this.is117 = GeneralMethods.getMCVersion() >= 1170;
 		this.iron = is117 ? Material.getMaterial("RAW_IRON") : Material.IRON_INGOT;
@@ -106,6 +103,7 @@ public class Extraction extends MetalAbility {
 		case "IRON_ORE":
 			type = Material.STONE;
 			item = new ItemStack(iron, this.getAmount(is117 ? 2 : 1 ));
+			break;
 		case "DEEPSLATE_IRON_ORE":
 			type = deepslate;
 			item = new ItemStack(iron, this.getAmount(2));

--- a/core/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
@@ -111,6 +111,7 @@ public class Extraction extends MetalAbility {
 		case "GOLD_ORE":
 			type = Material.STONE;
 			item = new ItemStack(gold, this.getAmount( is117 ? 2 : 1 ));
+			break;
 		case "DEEPSLATE_GOLD_ORE":
 			type = deepslate;
 			item = new ItemStack(gold, this.getAmount(2));

--- a/core/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/metal/Extraction.java
@@ -130,6 +130,7 @@ public class Extraction extends MetalAbility {
 		case "COPPER_ORE":
 			type = Material.STONE;
 			item = new ItemStack(copper, this.getAmount(2));
+			break;
 		case "DEEPSLATE_COPPER_ORE":
 			type = deepslate;
 			item = new ItemStack(copper, this.getAmount(2));

--- a/core/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/metal/MetalClips.java
@@ -52,6 +52,8 @@ public class MetalClips extends MetalAbility {
 	private long cooldown;
 	@Attribute("Shoot" + Attribute.COOLDOWN)
 	private long shootCooldown;
+	@Attribute("Shoot" + Attribute.SPEED)
+	private double shootSpeed;
 	@Attribute("Crush" + Attribute.COOLDOWN)
 	private long crushCooldown;
 	@Attribute("Magnet" + Attribute.COOLDOWN)
@@ -79,7 +81,8 @@ public class MetalClips extends MetalAbility {
 		this.armorTime = getConfig().getInt("Abilities.Earth.MetalClips.Duration");
 		this.range = getConfig().getDouble("Abilities.Earth.MetalClips.Range");
 		this.cooldown = getConfig().getLong("Abilities.Earth.MetalClips.Cooldown");
-		this.shootCooldown = 600;
+		this.shootCooldown = getConfig().getLong("Abilities.Earth.MetalClips.Shoot.Cooldown");
+		this.shootSpeed = getConfig().getDouble("Abilities.Earth.MetalClips.Shoot.Speed");
 		this.crushCooldown = getConfig().getLong("Abilities.Earth.MetalClips.Crush.Cooldown");
 		this.magnetCooldown = getConfig().getLong("Abilities.Earth.MetalClips.Magnet.Cooldown");
 		this.magnetRange = getConfig().getInt("Abilities.Earth.MetalClips.Magnet.Range");
@@ -156,7 +159,7 @@ public class MetalClips extends MetalAbility {
 			vector = GeneralMethods.getDirection(this.player.getLocation(), GeneralMethods.getTargetedLocation(this.player, this.range));
 		}
 
-		GeneralMethods.setVelocity(this, item, vector.normalize().add(new Vector(0, 0.1, 0).multiply(1.2)));
+		GeneralMethods.setVelocity(this, item, vector.normalize().multiply(this.shootSpeed));
 		this.trackedIngots.add(item);
 		this.player.getInventory().removeItem(is);
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -55,6 +55,8 @@ public class SurgeWall extends WaterAbility {
 	private double radius;
 	@Attribute(Attribute.RANGE)
 	private double range;
+	@Attribute(Attribute.SELECT_RANGE)
+	private double selectRange;
 	private Block sourceBlock;
 	private Location location;
 	private Location firstDestination;
@@ -71,6 +73,7 @@ public class SurgeWall extends WaterAbility {
 		this.cooldown = applyInverseModifiers(getConfig().getLong("Abilities.Water.Surge.Wall.Cooldown"));
 		this.duration = applyModifiers(getConfig().getLong("Abilities.Water.Surge.Wall.Duration"));
 		this.range = applyModifiers(getConfig().getDouble("Abilities.Water.Surge.Wall.Range"));
+		this.selectRange = getConfig().getDouble("Abilities.Water.Surge.Wall.SelectRange");
 		this.radius = applyModifiers(getConfig().getDouble("Abilities.Water.Surge.Wall.Radius"));
 		this.solidifyLava = getConfig().getBoolean("Abilities.Water.Surge.Wall.SolidifyLava.Enabled");
 		this.obsidianDuration = getConfig().getLong("Abilities.Water.Surge.Wall.SolidifyLava.Duration");
@@ -167,7 +170,7 @@ public class SurgeWall extends WaterAbility {
 
 	public boolean prepare() {
 		this.cancelPrevious();
-		final Block block = BlockSource.getWaterSourceBlock(this.player, this.range, ClickType.LEFT_CLICK, true, true, this.bPlayer.canPlantbend());
+		final Block block = BlockSource.getWaterSourceBlock(this.player, this.selectRange, ClickType.LEFT_CLICK, true, true, this.bPlayer.canPlantbend());
 
 		if (block != null && !RegionProtection.isRegionProtected(this, block.getLocation())) {
 			this.sourceBlock = block;

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.region.RegionProtection;
 import org.bukkit.Location;
@@ -291,8 +292,12 @@ public class SurgeWall extends WaterAbility {
 						} else if (WALL_BLOCKS.containsKey(block)) {
 							blocks.add(block);
 						} else if (!blocks.contains(block) && (ElementalAbility.isAir(block.getType()) || FireAbility.isFire(block.getType()) || this.isWaterbendable(block)) && this.isTransparent(block)) {
-							WALL_BLOCKS.put(block, this.player);
-							this.addWallBlock(block);
+							if (!isWater(block) || frozen) {
+								WALL_BLOCKS.put(block, this.player);
+								this.addWallBlock(block);
+							} else if (isWater(block) && !frozen) {
+								ParticleEffect.WATER_BUBBLE.display(block.getLocation().clone().add(.5, .5, .5), 1, ThreadLocalRandom.current().nextDouble(0, 0.5), ThreadLocalRandom.current().nextDouble(0, 0.5), ThreadLocalRandom.current().nextDouble(0, 0.5), 0);
+							}
 							blocks.add(block);
 							this.locations.add(block.getLocation());
 							FireBlast.removeFireBlastsAroundPoint(block.getLocation(), 2);

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -310,6 +311,11 @@ public class SurgeWave extends WaterAbility {
 							final Block block = this.location.clone().add(vec).getBlock();
 
 							if (!blocks.contains(block) && (isAir(block.getType()) || isFire(block.getType())) || this.isWaterbendable(block)) {
+								if (isWater(block)) {
+									if (ThreadLocalRandom.current().nextInt(8) == 0) {
+										ParticleEffect.WATER_BUBBLE.display(block.getLocation().clone().add(.5, .5, .5), 1, ThreadLocalRandom.current().nextDouble(0, 0.5), ThreadLocalRandom.current().nextDouble(0, 0.5), ThreadLocalRandom.current().nextDouble(0, 0.5), 0);
+									}
+								}
 								blocks.add(block);
 								FireBlast.removeFireBlastsAroundPoint(block.getLocation(), 2);
 							}


### PR DESCRIPTION
### Implementing suggestions from Discord: Part Two.

> Part One here: https://github.com/ProjectKorra/ProjectKorra/pull/1329

## Additions

- Surge bubble particles. ***Suggested by member: `.blackxlight`***
    - When `SurgeWave` or `SurgeWall` interacts with water blocks (e.g., if used underwater), bubble particles are displayed--similarly to `Torrent` and `WaterManipulation`.
- `MetalClips`' shoot speed and cooldown can be configurable now. ***Suggested by member: `.blackxlight`***
- `SurgeWall` select range configurability. ***Suggested by member: `prusakovaleksandr`***
- `Extraction` viability on **IRON GOLEMS**. ***Suggested by member: `.blackxlight`***
   - `Extraction` drops **IRON NUGGETS** when used on **IRON GOLEMS**. Players may configure the amount dropped in the config.

> [!NOTE]
> *Will manually resolve merge conflicts from either pull request when one is merged into **master**.*