### PR TITLE
Fixed #1374

### DIFF
--- a/core/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/core/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -904,8 +904,6 @@ public class BendingPlayer extends OfflineBendingPlayer {
 			//Hide the board if they spawn in a world with bending disabled
 			BendingBoardManager.changeWorld(this.player);
 		}, 1L);
-
-		Bukkit.getServer().getPluginManager().callEvent(new BendingPlayerLoadEvent(this));
 	}
 
 

--- a/core/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/core/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -736,7 +736,7 @@ public class GeneralMethods {
 	 * @return The filter
 	 */
 	public static Predicate<Entity> getEntityFilter() {
-		return entity -> !(entity.isValid() || entity.hasMetadata ("BendingImmunity")
+		return entity -> !(!entity.isValid() || entity.hasMetadata ("BendingImmunity")
 				|| (entity instanceof Player && ((Player) entity).getGameMode().equals(GameMode.SPECTATOR))
 				|| (entity instanceof ArmorStand && ((ArmorStand) entity).isMarker()));
 	}

--- a/core/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
+++ b/core/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
@@ -140,7 +140,8 @@ public class OfflineBendingPlayer {
                         newPlayer = new OfflineBendingPlayer(offlinePlayer);
                     }
                     PLAYERS.put(uuid, newPlayer);
-                    Bukkit.getPluginManager().callEvent(new BendingPlayerLoadEvent(newPlayer));
+                    Bukkit.getScheduler().callSyncMethod(ProjectKorra.plugin, ()
+                            -> Bukkit.getPluginManager().callEvent(new BendingPlayerLoadEvent(newPlayer)));
                     future.complete(newPlayer);
                 } else {
                     // The player has at least played before.


### PR DESCRIPTION
- Fixed the BendingPlayerLoadEvent being fired async (#1374)
- Fixed collisions not happening due to a change in the entity predicate filter (#1374)
- Fixed BendingPlayerLoadEvent being fired twice for online players