### PR TITLE
Final 1.12.0

### DIFF
--- a/core/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
+++ b/core/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
@@ -444,11 +444,13 @@ public class OfflineBendingPlayer {
                     OfflineBendingPlayer finalBPlayer4 = bPlayer;
                     Bukkit.getScheduler().runTask(ProjectKorra.plugin, () -> {
                         Bukkit.getPluginManager().callEvent(new BendingPlayerLoadEvent(finalBPlayer4));
+                        LOADING.remove(uuid);
                         future.complete(finalBPlayer4);
                     });
                 }
             } catch (final SQLException | ExecutionException | InterruptedException ex) {
                 ex.printStackTrace();
+                LOADING.remove(uuid);
                 future.cancel(true);
             }
         };
@@ -994,6 +996,7 @@ public class OfflineBendingPlayer {
 
     /**
      * Gets the time that a temporary element expires. If the element is not temporary, it will return -1.
+     * If the element has already expired but the user isn't online, it will return 0.
      * @param element The element to check
      * @return The time the element expires, or -1 if it is not temporary
      */
@@ -1004,6 +1007,7 @@ public class OfflineBendingPlayer {
 
     /**
      * Gets the time that a temporary subelement expires. If the subelement is not temporary, it will return -1.
+     * If the subelement has already expired but the user isn't online, it will return 0.
      * @param sub The subelement to check
      * @return The time the subelement expires, or -1 if it is not temporary
      */
@@ -1334,6 +1338,7 @@ public class OfflineBendingPlayer {
 
         PLAYERS.remove(this.player.getUniqueId());
         ONLINE_PLAYERS.remove(this.player.getUniqueId());
+        LOADING.remove(this.player.getUniqueId());
     }
 
     /**

--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -1468,6 +1468,10 @@ public class PKListener implements Listener {
 			}
 		}
 
+		if (bPlayer == null) {
+			return;
+		}
+
 		Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, //Run 1 tick later so they actually are offline
 				() -> {
 					if (ProjectKorra.isDatabaseCooldownsEnabled()) {

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBurst.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBurst.java
@@ -129,8 +129,11 @@ public class AirBurst extends AirAbility {
 	public static void coneBurst(final Player player) {
 		if (hasAbility(player, AirBurst.class)) {
 			final AirBurst airBurst = getAbility(player, AirBurst.class);
-			airBurst.startConeBurst();
-			airBurst.remove();
+			if (airBurst.isCharged) {
+				airBurst.bPlayer.addCooldown(airBurst);
+				airBurst.startConeBurst();
+				airBurst.remove();
+			}
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/airbending/AirShield.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirShield.java
@@ -70,6 +70,10 @@ public class AirShield extends AirAbility {
 			return;
 		}
 
+		if (!this.bPlayer.canBend(this)) {
+			return;
+		}
+
 		int angle = 0;
 		final int di = (int) (this.maxRadius * 2 / this.streams);
 		for (int i = -(int) this.maxRadius + di; i < (int) this.maxRadius; i += di) {

--- a/core/src/com/projectkorra/projectkorra/airbending/Suffocate.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/Suffocate.java
@@ -107,21 +107,21 @@ public class Suffocate extends AirAbility {
 			}
 		} else {
 			List<Entity> entities = new ArrayList<Entity>();
-			for (int i = 0; i < 6; i++) {
+			for (int i = 0; i < range; i++) {
 				final Location location = GeneralMethods.getTargetedLocation(player, i, getTransparentMaterials());
 				entities = GeneralMethods.getEntitiesAroundPoint(location, .5);
-				if (entities.contains(player)) {
-					entities.remove(player);
-				}
-				if (entities != null && !entities.isEmpty() && !entities.contains(player)) {
+
+				entities.remove(player);
+
+				if (!entities.isEmpty() && !entities.contains(player)) {
 					break;
 				}
 			}
-			if (entities == null || entities.isEmpty()) {
+			if (entities.isEmpty()) {
 				return;
 			}
 			final Entity target = entities.get(0);
-			if (target != null && target instanceof LivingEntity) {
+			if (target instanceof LivingEntity) {
 				this.targets.add((LivingEntity) target);
 			}
 		}

--- a/core/src/com/projectkorra/projectkorra/airbending/Suffocate.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/Suffocate.java
@@ -113,7 +113,7 @@ public class Suffocate extends AirAbility {
 
 				entities.remove(player);
 
-				if (!entities.isEmpty() && !entities.contains(player)) {
+				if (!entities.isEmpty()) {
 					break;
 				}
 			}

--- a/core/src/com/projectkorra/projectkorra/airbending/Tornado.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/Tornado.java
@@ -61,6 +61,10 @@ public class Tornado extends AirAbility {
 		this.random = new Random();
 		this.angles = new ConcurrentHashMap<>();
 
+		if (!this.bPlayer.canBend(this)) {
+			return;
+		}
+
 		int angle = 0;
 		for (int i = 0; i <= this.maxHeight; i += (int) this.maxHeight / this.numberOfStreams) {
 			this.angles.put(i, angle);

--- a/core/src/com/projectkorra/projectkorra/command/TempCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/TempCommand.java
@@ -201,10 +201,10 @@ public class TempCommand extends PKCommand {
 		} else if (sub && bPlayer.getSubElements().contains(element)) {
 			ChatUtil.sendBrandingMessage(sender, ChatColor.RED + this.alreadyHasSubElement.replace("{target}", bPlayer.getName()));
 			return;
-		} else if (!sub && bPlayer.getTempElements().containsKey(element)) {
+		} else if (!sub && bPlayer.getTempElements().containsKey(element) && bPlayer.getTempElementTime(element) > 0) {
 			ChatUtil.sendBrandingMessage(sender, ChatColor.RED + this.alreadyHasTempElement.replace("{target}", bPlayer.getName()));
 			return;
-		} else if (sub && bPlayer.getTempElements().containsKey(element)) {
+		} else if (sub && bPlayer.getTempSubElements().containsKey(element) && bPlayer.getTempElementTime(element) > 0) {
 			ChatUtil.sendBrandingMessage(sender, ChatColor.RED + this.alreadyHasTempSubElement.replace("{target}", bPlayer.getName()));
 			return;
 		}

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -350,7 +350,7 @@ public class ConfigManager {
 			config.addDefault("Commands.Temp.Reduce.SuccessRemove", "Your {element}{bending}&e's expiry time has been reduced and has now expired.");
 			config.addDefault("Commands.Temp.Remove.SuccessOther", "{target}'s {element}{bending} &ehas been removed.");
 			config.addDefault("Commands.Temp.Remove.Success", "Your {element}{bending} &ehas been removed.");
-			config.addDefault("Commands.Temp.Remove.ElementNotFound", "{target} does not have {element} &etemporarily.");
+			config.addDefault("Commands.Temp.Remove.ElementNotFound", "{target} does not have {element} &ctemporarily.");
 			config.addDefault("Commands.Temp.Remove.NoElements", "{target} does not have any temporary elements.");
 			config.addDefault("Commands.Temp.Remove.SuccessAll", "Your temporary elements has been removed.");
 
@@ -1739,10 +1739,14 @@ public class ConfigManager {
 			config.addDefault("LowHealth.BoostHealth.YellowHearts", false);
 			config.addDefault("LowHealth.PreventDeath", false);
 
-			config.addDefault("PotionEffects.Regeneration", 4);
-			config.addDefault("PotionEffects.Speed", 3);
-			config.addDefault("PotionEffects.Resistance", 3);
-			config.addDefault("PotionEffects.Fire_Resistance", 3);
+			//Because the effects are "keys", they are always added back if removed.
+			//We also check "Abilities" instead of PotionEffects in case users remove the entire section
+			if (!config.contains("Abilities")) {
+				config.addDefault("PotionEffects.Regeneration", 4);
+				config.addDefault("PotionEffects.Speed", 3);
+				config.addDefault("PotionEffects.Resistance", 3);
+				config.addDefault("PotionEffects.Fire_Resistance", 3);
+			}
 
 			config.addDefault("Abilities._All.Damage", "x2.0");
 			config.addDefault("Abilities._All.Cooldown", "x0.5");
@@ -1969,16 +1973,16 @@ public class ConfigManager {
 
 		//Migrate potion effects.
 		if (config.getBoolean("Abilities.Avatar.AvatarState.PotionEffects.Regeneration.Enabled")) {
-			avatarState.set("PotionEffects.regeneration", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.Regeneration.Power"));
+			avatarState.set("PotionEffects.Regeneration", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.Regeneration.Power"));
 		}
 		if (config.getBoolean("Abilities.Avatar.AvatarState.PotionEffects.Speed.Enabled")) {
-			avatarState.set("PotionEffects.speed", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.Speed.Power"));
+			avatarState.set("PotionEffects.Speed", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.Speed.Power"));
 		}
 		if (config.getBoolean("Abilities.Avatar.AvatarState.PotionEffects.DamageResistance.Enabled")) {
-			avatarState.set("PotionEffects.resistance", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.DamageResistance.Power"));
+			avatarState.set("PotionEffects.Resistance", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.DamageResistance.Power"));
 		}
 		if (config.getBoolean("Abilities.Avatar.AvatarState.PotionEffects.FireResistance.Enabled")) {
-			avatarState.set("PotionEffects.fire_resistance", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.FireResistance.Power"));
+			avatarState.set("PotionEffects.Fire_Resistance", config.getInt("Abilities.Avatar.AvatarState.PotionEffects.FireResistance.Power"));
 		}
 
 		//Migrate all other ability keys

--- a/core/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -199,7 +199,7 @@ public class Tremorsense extends EarthAbility {
 
 		final Tremorsense this_ = (Tremorsense) getAbility(Tremorsense.class);
 
-		if (bPlayer != null && this_.isEnabled() && bPlayer.canBendPassive(this_) && bPlayer.canUsePassive(this_)) {
+		if (this_ != null && bPlayer != null && this_.isEnabled() && bPlayer.canBendPassive(this_) && bPlayer.canUsePassive(this_)) {
 			return true;
 		}
 

--- a/core/src/com/projectkorra/projectkorra/event/BendingPlayerLoadEvent.java
+++ b/core/src/com/projectkorra/projectkorra/event/BendingPlayerLoadEvent.java
@@ -1,11 +1,19 @@
 package com.projectkorra.projectkorra.event;
 
+import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.OfflineBendingPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 /**
- * Called when a new BendingPlayer is created or loaded from the Database
+ * Called when a new BendingPlayer is created or loaded from the Database.
+ *
+ * This event fires for loading both online AND offline players. Use
+ * {@link #isOnline()} to check if the BendingPlayer object is available.
+ *
+ * If offline data was already cached and a player logs in, this event will fire
+ * again but with {@link #isOnline()} returning true.
  */
 
 public class BendingPlayerLoadEvent extends Event {
@@ -13,7 +21,9 @@ public class BendingPlayerLoadEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 	private final OfflineBendingPlayer bPlayer;
 
+
 	public BendingPlayerLoadEvent(final OfflineBendingPlayer bPlayer) {
+		super(!Bukkit.isPrimaryThread());
 		this.bPlayer = bPlayer;
 	}
 
@@ -27,14 +37,15 @@ public class BendingPlayerLoadEvent extends Event {
 	}
 
 	/**
-	 * @return BendingPlayer created
+	 * @return The OfflineBendingPlayer object that was loaded.
 	 */
 	public OfflineBendingPlayer getBendingPlayer() {
 		return this.bPlayer;
 	}
 
 	/**
-	 * Is the player who's bending was created online?
+	 * Is the player who's bending data was loaded online? If this is true,
+	 * it is safe to cast {@link #getBendingPlayer()} to {@link BendingPlayer}.
 	 * @return true if the player is online
 	 */
 	public boolean isOnline() {

--- a/core/src/com/projectkorra/projectkorra/event/PlayerChangeElementEvent.java
+++ b/core/src/com/projectkorra/projectkorra/event/PlayerChangeElementEvent.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.event;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.OfflineBendingPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -38,6 +39,7 @@ public class PlayerChangeElementEvent extends Event implements Cancellable {
 	 *            permaremoved
 	 */
 	public PlayerChangeElementEvent(final CommandSender sender, final OfflinePlayer target, final Element element, final Result result) {
+		super(!Bukkit.isPrimaryThread());
 		this.sender = sender;
 		this.target = target;
 		this.element = element;

--- a/core/src/com/projectkorra/projectkorra/event/PlayerChangeSubElementEvent.java
+++ b/core/src/com/projectkorra/projectkorra/event/PlayerChangeSubElementEvent.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.event;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.OfflineBendingPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -34,6 +35,7 @@ public class PlayerChangeSubElementEvent extends Event implements Cancellable {
 	 *            permaremoved
 	 */
 	public PlayerChangeSubElementEvent(final CommandSender sender, final OfflinePlayer target, final SubElement sub, final Result result) {
+		super(!Bukkit.isPrimaryThread());
 		this.sender = sender;
 		this.target = target;
 		this.sub = sub;

--- a/core/src/com/projectkorra/projectkorra/firebending/FireBurst.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireBurst.java
@@ -56,7 +56,7 @@ public class FireBurst extends FireAbility {
 
 	public static void coneBurst(final Player player) {
 		final FireBurst burst = getAbility(player, FireBurst.class);
-		if (burst != null) {
+		if (burst != null && burst.charged) {
 			burst.coneBurst();
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/WallOfFire.java
@@ -65,7 +65,7 @@ public class WallOfFire extends FireAbility {
 		this.random = new Random();
 		this.blocks = new ArrayList<>();
 
-		if (hasAbility(player, WallOfFire.class) && !this.bPlayer.isAvatarState()) {
+		if (hasAbility(player, WallOfFire.class)) {
 			return;
 		} else if (this.bPlayer.isOnCooldown(this)) {
 			return;
@@ -86,6 +86,7 @@ public class WallOfFire extends FireAbility {
 			return;
 		}
 
+		this.recalculateAttributes();
 		this.initializeBlocks();
 		this.start();
 	}

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireComboStream.java
@@ -1,6 +1,7 @@
 package com.projectkorra.projectkorra.firebending.combo;
 
 import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.Element.SubElement;
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ability.CoreAbility;
@@ -43,6 +44,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * stream for all their progress methods. If someone else was reliant on that,
  * they can use this ability instead.
  */
+@Deprecated
 public class FireComboStream extends BukkitRunnable {
 	private boolean useNewParticles;
 	private boolean cancelled;
@@ -109,7 +111,9 @@ public class FireComboStream extends BukkitRunnable {
 			}
 		}
 
-		emitFirebendingLight(this.location);
+		if (this.coreAbility.getElement() == Element.FIRE) {
+			emitFirebendingLight(this.location);
+		}
 
 		if (GeneralMethods.checkDiagonalWall(this.location, this.direction)) {
 			this.remove();

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireKick.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireKick.java
@@ -95,8 +95,11 @@ public class FireKick extends FireAbility implements ComboAbility {
 			this.player.getWorld().playSound(this.player.getLocation(), Sound.ENTITY_HORSE_JUMP, 0.5f, 0f);
 			this.player.getWorld().playSound(this.player.getLocation(), Sound.ENTITY_CREEPER_PRIMED, 0.5f, 1f);
 			for (int i = -30; i <= 30; i += 5) {
-				Vector vec = GeneralMethods.getDirection(this.player.getLocation(), this.destination.clone());
-				vec = GeneralMethods.rotateXZ(vec, i);
+				double angle = Math.toRadians(i);
+				final Vector direction = this.player.getEyeLocation().getDirection().clone();
+				Vector xz = GeneralMethods.rotateVectorAroundVector(direction, new Vector(-direction.getZ(), 0, direction.getX()).normalize(), 0);
+				Vector vec = direction.clone().multiply(Math.cos(angle))
+						.add(xz.clone().multiply(Math.sin(angle))).normalize();
 
 				final FireComboStream fs = new FireComboStream(this.player, this, vec, this.player.getLocation(), this.range, this.speed);
 				fs.setSpread(0.2F);

--- a/core/src/com/projectkorra/projectkorra/hooks/PlaceholderAPIHook.java
+++ b/core/src/com/projectkorra/projectkorra/hooks/PlaceholderAPIHook.java
@@ -2,9 +2,11 @@ package com.projectkorra.projectkorra.hooks;
 
 import static java.util.stream.Collectors.joining;
 
+import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.util.TimeUtil;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.md_5.bungee.api.ChatColor;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.BendingPlayer;
@@ -42,20 +44,25 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
 				return "";
 			}
 			return coreAbil.getElement().getColor() + coreAbil.getName();
-		} else if (params.equals("element") || params.equals("elementcolor")) {
+		} else if (params.equals("element") || params.equals("elementcolor") || params.equals("element_title") || params.equals("element_prefix")) {
 			String e = "Nonbender";
 			ChatColor c = ChatColor.WHITE;
+			String title = ConfigManager.languageConfig.get().getString("Chat.Prefixes.Nonbender", c + "[Nonbender]");
 			if (player.hasPermission("bending.avatar") || (bPlayer.hasElement(Element.AIR) && bPlayer.hasElement(Element.EARTH) && bPlayer.hasElement(Element.FIRE) && bPlayer.hasElement(Element.WATER))) {
 				c = Element.AVATAR.getColor();
 				e = Element.AVATAR.getName();
+				title = ConfigManager.languageConfig.get().getString("Chat.Prefixes.Avatar", c + "[Avatar]");
 			} else if (bPlayer.getElements().size() > 0) {
 				c = bPlayer.getElements().get(0).getColor();
 				e = bPlayer.getElements().get(0).getName();
+				title = ConfigManager.languageConfig.get().getString("Chat.Prefixes." + e, c + "[" + e + "]");
 			}
 			if (params.equals("element")) {
 				return e;
-			} else {
+			} else if (params.equals("elementcolor")) {
 				return c.toString();
+			} else {
+				return title;
 			}
 		} else if (params.equals("elements")) {
 			return bPlayer.getElements().stream().map(item -> item.getColor() + item.getName()).collect(joining(" "));
@@ -91,7 +98,7 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
 
 	@Override
 	public boolean canRegister() {
-		return true;
+		return Bukkit.getPluginManager().isPluginEnabled("ProjectKorra");
 	}
 
 	@Override
@@ -112,10 +119,7 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
 	@Override
 	public List<String> getPlaceholders() {
 		return Arrays.asList("slot", "slot1", "slot2", "slot3", "slot4", "slot5", "slot6", "slot7", "slot8", "slot9",
-				"element", "elementcolor", "elements", "subelements", "cooldown_<ability>", "cooldown_slot", "cooldown_slot<1-9>", "cooldown_choose");
-	}
-
-	public void unregister() {
-		PlaceholderAPI.unregisterExpansion(this);
+				"element", "elementcolor", "elements", "subelements", "element_prefix",
+				"cooldown_<ability>", "cooldown_slot", "cooldown_slot<1-9>", "cooldown_choose");
 	}
 }

--- a/core/src/com/projectkorra/projectkorra/util/ChatUtil.java
+++ b/core/src/com/projectkorra/projectkorra/util/ChatUtil.java
@@ -64,7 +64,7 @@ public class ChatUtil {
         final String end = color(ConfigManager.languageConfig.get().getString("Chat.Branding.ChatPrefix.Suffix", " \u00BB "));
         final String prefix = color + start + main + end;
         if (!(receiver instanceof Player)) {
-            receiver.sendMessage(prefix + message);
+            receiver.sendMessage(prefix + message.toLegacyText());
         } else {
             final TextComponent prefixComponent = new TextComponent(prefix);
             final String hover = multiline(color + ConfigManager.languageConfig.get().getString("Chat.Branding.ChatPrefix.Hover", color + "Bending brought to you by ProjectKorra | Fork Roku!\n" + color + "Click for more info."));


### PR DESCRIPTION
## Additions
- Added insurance for getting an OfflineBendingPlayer while it is already loading
- Added PAPI `%projectkorra_element_prefix%` placeholder. Uses the defined prefixes from the language.yml

## Changes
- Updated ProjectKorra's PAPI expansion to use the latest PAPI API
- Tweaked some language config stuff related to temp elements
- BendingPlayerLoadEvent is now thrown when a player joins the server and their data is converted from an OfflineBendingPlayer to BendingPlayer

## Fixes
- Fixed race condition for saving temp elements
- Fixed some PK events not working async
- Fixed ChatUtil outputting md5 component spam when sending to console
- Fixed remaining issues with the temp command
- Fixed AvatarState's default potion effects being unremovable from the config
- Fixed AirBurst cone not applying cooldown
- Fixed clicking AirBurst/FireBurst while charging cancelling the charge sequence
- Fixed sneaking with AirShield/Tornado while on cooldown restarting the cooldown
- Fixed range option not applying for non avatarstate Suffocate
- Fixed NPE when Tremorsense is disabled
- Fixed AirSweep and IceBullet creating firebending light
- Deprecated FireComboStream
- Fixed FireKick not working when looking straight upwards
- Fixed WallOfFire not respecting AvatarState properties
- Fixed WallOfFire being able to be used multiple times in AvatarState

