### PR TITLE
Fix /b ch SubElements for Avatar

### DIFF
--- a/core/src/com/projectkorra/projectkorra/command/ChooseCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/ChooseCommand.java
@@ -187,13 +187,11 @@ public class ChooseCommand extends PKCommand {
 						bPlayer.addElement(e);
 
 						if (online) {
-							for (final SubElement sub : Element.getSubElements(element)) {
+							for (final SubElement sub : Element.getSubElements(e)) {
 								if (((BendingPlayer) bPlayer).hasSubElementPermission(sub)) {
 									PlayerChangeSubElementEvent subEvent = new PlayerChangeSubElementEvent(sender, target, sub, PlayerChangeSubElementEvent.Result.CHOOSE);
-
 									Bukkit.getServer().getPluginManager().callEvent(subEvent);
 									if (subEvent.isCancelled()) continue; //Do nothing if cancelled
-
 									bPlayer.addSubElement(sub);
 								}
 							}


### PR DESCRIPTION
## Fixes
* Bug where /pk ch avatar wouldn't add subelements of elements

## Misc. Changes
* Line 190 | Changed the inner loop for getting subelements of an element.
    > * For the line `for (final SubElement sub : Element.getSubElements(e))`,(previous version: `for (final SubElement sub : Element.getSubElements(element))`, the getSubElements method would take the Element object outside of the for loop instead of the one needed in the outer for loop `for (Element e : new Element[] {Element.AIR, Element.EARTH, Element.FIRE, Element.WATER})`