### PR TITLE
Ice damage not being applied during slow cooldown

### DIFF
--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1061,6 +1061,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Water.IceBlast.CollisionRadius", 1.0);
 			config.addDefault("Abilities.Water.IceBlast.Interval", 20);
 			config.addDefault("Abilities.Water.IceBlast.Cooldown", 1500);
+			config.addDefault("Abilities.Water.IceBlast.SlowCooldown", 5000);
 			config.addDefault("Abilities.Water.IceBlast.AllowSnow", false);
 
 			config.addDefault("Abilities.Water.IceSpike.Enabled", true);

--- a/core/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
@@ -38,6 +38,8 @@ public class IceBlast extends IceAbility {
 	private long time;
 	@Attribute(Attribute.COOLDOWN) @DayNightFactor(invert = true)
 	private long cooldown;
+	@Attribute("Slow" + Attribute.COOLDOWN) @DayNightFactor(invert = true)
+	private long slowCooldown;
 	private long interval;
 	@Attribute(Attribute.RANGE) @DayNightFactor
 	private double range;
@@ -63,6 +65,7 @@ public class IceBlast extends IceAbility {
 		this.range = getConfig().getDouble("Abilities.Water.IceBlast.Range");
 		this.damage = getConfig().getInt("Abilities.Water.IceBlast.Damage");
 		this.cooldown = getConfig().getInt("Abilities.Water.IceBlast.Cooldown");
+		this.slowCooldown = getConfig().getLong("Abilities.Water.IceBlast.SlowCooldown");
 		this.allowSnow = getConfig().getBoolean("Abilities.Water.IceBlast.AllowSnow");
 
 		if (!this.bPlayer.canBend(this) || !this.bPlayer.canIcebend()) {
@@ -159,17 +162,16 @@ public class IceBlast extends IceAbility {
 	}
 
 	private void affect(final LivingEntity entity) {
+		DamageHandler.damageEntity(entity, this.damage, this);
 		if (entity instanceof Player) {
 			if (this.bPlayer.canBeSlowed()) {
 				final PotionEffect effect = new PotionEffect(PotionEffectType.SLOW, 70, 2);
 				new TempPotionEffect(entity, effect);
-				this.bPlayer.slow(10);
-				DamageHandler.damageEntity(entity, this.damage, this);
+				this.bPlayer.slow(this.slowCooldown);
 			}
 		} else {
 			final PotionEffect effect = new PotionEffect(PotionEffectType.SLOW, 70, 2);
 			new TempPotionEffect(entity, effect);
-			DamageHandler.damageEntity(entity, this.damage, this);
 		}
 		AirAbility.breakBreathbendingHold(entity);
 
@@ -487,6 +489,14 @@ public class IceBlast extends IceAbility {
 
 	public void setLocation(final Location location) {
 		this.location = location;
+	}
+	
+	public long getSlowCooldown() {
+		return this.slowCooldown;
+	}
+
+	public void setSlowCooldown(final long slowCooldown) {
+		this.slowCooldown = slowCooldown;
 	}
 
 }

--- a/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -95,21 +95,16 @@ public class IceSpikeBlast extends IceAbility {
 	}
 
 	private void affect(final LivingEntity entity) {
+		DamageHandler.damageEntity(entity, this.damage, this);
 		if (entity instanceof Player) {
-			final BendingPlayer targetBPlayer = BendingPlayer.getBendingPlayer((Player) entity);
-			if (targetBPlayer == null) {
-				return;
-			}
-			if (targetBPlayer.canBeSlowed()) {
+			if (this.bPlayer.canBeSlowed()) {
 				final PotionEffect effect = new PotionEffect(PotionEffectType.SLOW, this.slowDuration, this.slowPotency);
 				new TempPotionEffect(entity, effect);
-				targetBPlayer.slow(this.slowCooldown);
-				DamageHandler.damageEntity(entity, this.damage, this);
+				this.bPlayer.slow(this.slowCooldown);
 			}
 		} else {
 			final PotionEffect effect = new PotionEffect(PotionEffectType.SLOW, this.slowDuration, this.slowPotency);
 			new TempPotionEffect(entity, effect);
-			DamageHandler.damageEntity(entity, this.damage, this);
 		}
 		AirAbility.breakBreathbendingHold(entity);
 	}


### PR DESCRIPTION
## Issue
This bug prevents damage from being applied consistently when using IceSpikeBlast and IceBlast. When a player is hit with IceSpikeBlast or IceBlast during the `bPlayer.slow(slowCooldown)`  the attack wouldnt pass through the `if(bPlayer.canBeSlowed())` check where the damage command for players is located.

## Additions
* Adds a SlowCooldown parameter to the config under "Abilities.Water.IceBlast.SlowCooldown".
* IceBlast uses new SlowCooldown parameter.
    
## Fixes
* Line 98 IceSpikeBlast
    > * Moves damage out of the `canBeSlowed()` check.
* Line 165 IceBlast
    > * Moves damage out of the `canBeSlowed()` check.

## Removals
* Line 99 IceSpikeBlast
    > * Removes recasting of entity to get the bending player. Now uses the same method as IceSpikePillar to get the bending player.