### PR TITLE
Folia Support (1.12.1)

### DIFF
--- a/core-legacy/pom.xml
+++ b/core-legacy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.projectkorra</groupId>
     <artifactId>projectkorra-parent</artifactId>
-    <version>1.12.0</version>
+    <version>1.12.1</version>
   </parent>
 
   <artifactId>core-legacy</artifactId>

--- a/core-modern/pom.xml
+++ b/core-modern/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.projectkorra</groupId>
     <artifactId>projectkorra-parent</artifactId>
-    <version>1.12.0</version>
+    <version>1.12.1</version>
   </parent>
 
   <artifactId>core-modern</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.projectkorra</groupId>
   <artifactId>projectkorra</artifactId>
-  <version>1.12.0</version>
+  <version>1.12.1</version>
   <packaging>jar</packaging>
 
   <name>ProjectKorra</name>
@@ -110,6 +110,12 @@
       <version>1.0.1</version>
     </dependency>
     <!-- Minecraft Timings -->
+    <dependency>
+      <groupId>dev.folia</groupId>
+      <artifactId>folia-api</artifactId>
+      <version>1.20.1-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Spigot API -->
     <dependency>
       <groupId>org.spigotmc</groupId>
@@ -117,6 +123,7 @@
       <version>1.16.5-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+
     <!-- lang3 -->
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -103,13 +103,12 @@
       <artifactId>core-legacy</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- PaperLib -->
     <dependency>
-      <groupId>io.papermc</groupId>
-      <artifactId>paperlib</artifactId>
-      <version>1.0.1</version>
+      <groupId>com.projectkorra</groupId>
+      <artifactId>luminol</artifactId>
+      <version>${project.version}</version>
     </dependency>
-    <!-- Minecraft Timings -->
+    <!-- Folia API -->
     <dependency>
       <groupId>dev.folia</groupId>
       <artifactId>folia-api</artifactId>
@@ -339,10 +338,6 @@
 
           </filters>
           <relocations>
-            <relocation>
-              <pattern>io.papermc.lib</pattern>
-              <shadedPattern>paperlib.projectkorra</shadedPattern>
-            </relocation>
             <relocation>
               <pattern>org.apache.commons</pattern>
               <shadedPattern>commonslang3.projectkorra</shadedPattern>

--- a/core/src/com/projectkorra/projectkorra/BendingManager.java
+++ b/core/src/com/projectkorra/projectkorra/BendingManager.java
@@ -3,11 +3,20 @@ package com.projectkorra.projectkorra;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import com.projectkorra.projectkorra.airbending.util.AirbendingManager;
+import com.projectkorra.projectkorra.chiblocking.util.ChiblockingManager;
+import com.projectkorra.projectkorra.earthbending.util.EarthbendingManager;
 import com.projectkorra.projectkorra.event.WorldTimeEvent;
+import com.projectkorra.projectkorra.firebending.util.FirebendingManager;
 import com.projectkorra.projectkorra.util.ChatUtil;
 import com.projectkorra.projectkorra.util.TempBlock;
 import com.projectkorra.projectkorra.util.TempFallingBlock;
+import com.projectkorra.projectkorra.util.ThreadUtil;
+import com.projectkorra.projectkorra.util.TimeUtil;
+import com.projectkorra.projectkorra.waterbending.util.WaterbendingManager;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -39,6 +48,31 @@ public class BendingManager implements Runnable {
 
 		times.clear();
 
+		TempElementsRunnable tempElementsRunnable = new TempElementsRunnable();
+		if (ProjectKorra.isFolia()) {
+
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new AirbendingManager(ProjectKorra.plugin), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new WaterbendingManager(ProjectKorra.plugin), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new EarthbendingManager(ProjectKorra.plugin), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new FirebendingManager(ProjectKorra.plugin), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new ChiblockingManager(ProjectKorra.plugin), 1, 1);
+
+
+			Bukkit.getAsyncScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> {
+				this.tempBlockRevertTask.run();
+				TempArmor.cleanup();
+				TempFallingBlock.manage();
+				this.handleCooldowns();
+				tempElementsRunnable.run();
+				RevertChecker.revertAirBlocks(); //The revert checker class also needs an instance that is run
+					 							 //every tick, but the class needs rewriting to be Folia safe
+			}, 100, 100, TimeUnit.MILLISECONDS); // Every 2 ticks, approx. Exact tick isn't important
+
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> handleDayNight(), 1, 5); //Every 5 ticks
+		} else {
+			Bukkit.getScheduler().runTaskTimerAsynchronously(ProjectKorra.plugin, tempElementsRunnable, 1, 2);
+		}
+
 		handleDayNight();
 	}
 
@@ -50,7 +84,7 @@ public class BendingManager implements Runnable {
 		for (Map.Entry<UUID, BendingPlayer> entry : BendingPlayer.getPlayers().entrySet()) {
 			BendingPlayer bPlayer = entry.getValue();
 
-			bPlayer.removeOldCooldowns();
+			ThreadUtil.ensureEntity(bPlayer.getPlayer(), bPlayer::removeOldCooldowns);
 		}
 	}
 
@@ -113,17 +147,17 @@ public class BendingManager implements Runnable {
 		this.time = System.currentTimeMillis();
 		ProjectKorra.time_step = this.interval;
 
-		CoreAbility.progressAll();
-		TempPotionEffect.progressAll();
-		this.handleDayNight();
-		RevertChecker.revertAirBlocks();
-		HorizontalVelocityTracker.updateAll();
-		this.handleCooldowns();
-		TempArmor.cleanup();
+		CoreAbility.progressAll(); //Player threads. DONE.
+		TempPotionEffect.progressAll(); //Player threads. DONE.
+		this.handleDayNight(); //Global region
+		RevertChecker.revertAirBlocks(); //Complicated, needs rewriting
+		HorizontalVelocityTracker.updateAll(); //Player threads. DONE
+		this.handleCooldowns(); //Async thread
+		TempArmor.cleanup(); //Async thread
 
-		TempFallingBlock.manage();
+		TempFallingBlock.manage(); //Async.
 
-		tempBlockRevertTask.run();
+		tempBlockRevertTask.run(); //Async thread
 	}
 
 	public static String getSunriseMessage() {
@@ -156,7 +190,8 @@ public class BendingManager implements Runnable {
 
 				if (System.currentTimeMillis() > pair.getRight()) { //Check if the top temp element has expired
 					BendingPlayer.TEMP_ELEMENTS.poll(); //And if it has, remove from the queue, and recalculate temp elements for that player
-					BendingPlayer.getBendingPlayer(pair.getLeft()).recalculateTempElements(false);
+					BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(pair.getLeft());
+					ThreadUtil.ensureEntity(bPlayer.getPlayer(), () -> bPlayer.recalculateTempElements(false));
 				} else {
 					break; //Break the loop if the top element hasn't expired, as all elements below it won't have either
 				}

--- a/core/src/com/projectkorra/projectkorra/BendingManager.java
+++ b/core/src/com/projectkorra/projectkorra/BendingManager.java
@@ -14,9 +14,7 @@ import com.projectkorra.projectkorra.util.ChatUtil;
 import com.projectkorra.projectkorra.util.TempBlock;
 import com.projectkorra.projectkorra.util.TempFallingBlock;
 import com.projectkorra.projectkorra.util.ThreadUtil;
-import com.projectkorra.projectkorra.util.TimeUtil;
 import com.projectkorra.projectkorra.waterbending.util.WaterbendingManager;
-import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -25,13 +23,10 @@ import org.bukkit.entity.Player;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
-import com.projectkorra.projectkorra.earthbending.metal.MetalClips;
 import com.projectkorra.projectkorra.object.HorizontalVelocityTracker;
-import com.projectkorra.projectkorra.util.ActionBar;
 import com.projectkorra.projectkorra.util.RevertChecker;
 import com.projectkorra.projectkorra.util.TempArmor;
 import com.projectkorra.projectkorra.util.TempPotionEffect;
-import com.projectkorra.projectkorra.waterbending.blood.Bloodbending;
 
 public class BendingManager implements Runnable {
 
@@ -63,7 +58,6 @@ public class BendingManager implements Runnable {
 			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> fire.run(), 1, 1);
 			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> chiblocking.run(), 1, 1);
 
-
 			Bukkit.getAsyncScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> {
 				this.tempBlockRevertTask.run();
 				TempArmor.cleanup();
@@ -78,8 +72,6 @@ public class BendingManager implements Runnable {
 		} else {
 			Bukkit.getScheduler().runTaskTimerAsynchronously(ProjectKorra.plugin, tempElementsRunnable, 1, 2);
 		}
-
-		handleDayNight();
 	}
 
 	public static BendingManager getInstance() {

--- a/core/src/com/projectkorra/projectkorra/BendingManager.java
+++ b/core/src/com/projectkorra/projectkorra/BendingManager.java
@@ -51,11 +51,17 @@ public class BendingManager implements Runnable {
 		TempElementsRunnable tempElementsRunnable = new TempElementsRunnable();
 		if (ProjectKorra.isFolia()) {
 
-			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new AirbendingManager(ProjectKorra.plugin), 1, 1);
-			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new WaterbendingManager(ProjectKorra.plugin), 1, 1);
-			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new EarthbendingManager(ProjectKorra.plugin), 1, 1);
-			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new FirebendingManager(ProjectKorra.plugin), 1, 1);
-			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> new ChiblockingManager(ProjectKorra.plugin), 1, 1);
+			AirbendingManager air = new AirbendingManager(ProjectKorra.plugin);
+			ChiblockingManager chiblocking = new ChiblockingManager(ProjectKorra.plugin);
+			EarthbendingManager earth = new EarthbendingManager(ProjectKorra.plugin);
+			FirebendingManager fire = new FirebendingManager(ProjectKorra.plugin);
+			WaterbendingManager water = new WaterbendingManager(ProjectKorra.plugin);
+
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> air.run(), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> water.run(), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> earth.run(), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> fire.run(), 1, 1);
+			Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> chiblocking.run(), 1, 1);
 
 
 			Bukkit.getAsyncScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> {

--- a/core/src/com/projectkorra/projectkorra/BendingPlayer.java
+++ b/core/src/com/projectkorra/projectkorra/BendingPlayer.java
@@ -29,6 +29,7 @@ import com.projectkorra.projectkorra.hooks.CanBindHook;
 import com.projectkorra.projectkorra.object.Preset;
 import com.projectkorra.projectkorra.region.RegionProtection;
 import com.projectkorra.projectkorra.util.ChatUtil;
+import com.projectkorra.projectkorra.util.PlayerThreadMonitor;
 import com.projectkorra.projectkorra.util.ThreadUtil;
 import net.md_5.bungee.api.ChatColor;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -143,6 +144,10 @@ public class BendingPlayer extends OfflineBendingPlayer {
 
 		final List<String> disabledWorlds = getConfig().getStringList("Properties.DisabledWorlds");
 		final Location playerLoc = this.player.getLocation();
+
+		if (ProjectKorra.isFolia() && !Bukkit.isOwnedByCurrentRegion(this.getPlayer())) {
+			return false;
+		}
 
 		//Loop through all hooks and test them
 		for (JavaPlugin plugin : BEND_HOOKS.keySet()) {
@@ -894,10 +899,14 @@ public class BendingPlayer extends OfflineBendingPlayer {
 		PassiveManager.registerPassives(this.player);
 		FirePassive.handle(player);
 
+
+		if (ProjectKorra.isFolia()) {
+			ThreadUtil.ensureEntityTimer(this.player, new PlayerThreadMonitor(this.player), 1L, 1L);
+			return; //TODO Folia doesn't support scoreboards, ignore it
+		}
+
 		//Show the bending board 1 tick later. We do it 1 tick later because postLoad() is called BEFORE the player is loaded into the map,
 		//and the board needs to see the player in the map to initialize
-		if (ProjectKorra.isFolia()) return; //TODO Folia doesn't support scoreboards, ignore it
-
 		ThreadUtil.ensureEntityDelay(player, () -> {
 			BendingBoardManager.getBoard(this.player).ifPresent(BendingBoard::show);
 			//Hide the board if they spawn in a world with bending disabled

--- a/core/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/core/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1374,10 +1374,14 @@ public class GeneralMethods {
 		// WaterAbility.setupWaterTransformableBlocks();
 		EarthTunnel.clearBendableMaterials();
 
-		Bukkit.getScheduler().cancelTasks(ProjectKorra.plugin);
+
 		if (ProjectKorra.isFolia()) {
 			Bukkit.getGlobalRegionScheduler().cancelTasks(ProjectKorra.plugin);
 			Bukkit.getAsyncScheduler().cancelTasks(ProjectKorra.plugin);
+		} else {
+			Bukkit.getScheduler().cancelTasks(ProjectKorra.plugin);
+
+			ProjectKorra.plugin.revertChecker = ProjectKorra.plugin.getServer().getScheduler().runTaskTimerAsynchronously(ProjectKorra.plugin, new RevertChecker(ProjectKorra.plugin), 0, 200);
 		}
 
 		new BendingManager();
@@ -1389,7 +1393,6 @@ public class GeneralMethods {
 		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new EarthbendingManager(ProjectKorra.plugin), 0, 1);
 		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new FirebendingManager(ProjectKorra.plugin), 0, 1);
 		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new ChiblockingManager(ProjectKorra.plugin), 0, 1);
-		ProjectKorra.plugin.revertChecker = ProjectKorra.plugin.getServer().getScheduler().runTaskTimerAsynchronously(ProjectKorra.plugin, new RevertChecker(ProjectKorra.plugin), 0, 200);
 
 		EarthTunnel.setupBendableMaterials();
 		Bloodbending.loadBloodlessFromConfig();

--- a/core/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/core/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -1375,13 +1375,20 @@ public class GeneralMethods {
 		EarthTunnel.clearBendableMaterials();
 
 		Bukkit.getScheduler().cancelTasks(ProjectKorra.plugin);
-		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new BendingManager(), 0, 1);
-		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new AirbendingManager(ProjectKorra.plugin), 0, 1);
-		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new WaterbendingManager(ProjectKorra.plugin), 0, 1);
-		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new EarthbendingManager(ProjectKorra.plugin), 0, 1);
-		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new FirebendingManager(ProjectKorra.plugin), 0, 1);
-		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new ChiblockingManager(ProjectKorra.plugin), 0, 1);
-		ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new BendingManager.TempElementsRunnable(), 20, 20);
+		if (ProjectKorra.isFolia()) {
+			Bukkit.getGlobalRegionScheduler().cancelTasks(ProjectKorra.plugin);
+			Bukkit.getAsyncScheduler().cancelTasks(ProjectKorra.plugin);
+		}
+
+		new BendingManager();
+
+		//FOLIA TODO
+		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new BendingManager(), 0, 1);
+		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new AirbendingManager(ProjectKorra.plugin), 0, 1);
+		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new WaterbendingManager(ProjectKorra.plugin), 0, 1);
+		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new EarthbendingManager(ProjectKorra.plugin), 0, 1);
+		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new FirebendingManager(ProjectKorra.plugin), 0, 1);
+		//ProjectKorra.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(ProjectKorra.plugin, new ChiblockingManager(ProjectKorra.plugin), 0, 1);
 		ProjectKorra.plugin.revertChecker = ProjectKorra.plugin.getServer().getScheduler().runTaskTimerAsynchronously(ProjectKorra.plugin, new RevertChecker(ProjectKorra.plugin), 0, 200);
 
 		EarthTunnel.setupBendableMaterials();
@@ -1790,17 +1797,17 @@ public class GeneralMethods {
 	}
 
 	public static void stopBending() {
-		CoreAbility.removeAll();
-		EarthAbility.stopBending();
-		WaterAbility.stopBending();
-		FireAbility.stopBending();
+		CoreAbility.removeAll(); //Now Folia safe
+		EarthAbility.stopBending(); //Should be okay?
+		WaterAbility.stopBending(); //Should be fine now
+		FireAbility.stopBending(); //Does nothing lmao
 
-		TempBlock.removeAll();
-		TempArmor.revertAll();
-		TempArmorStand.removeAll();
-		MovementHandler.resetAll();
-		MultiAbilityManager.removeAll();
-		TempFallingBlock.removeAllFallingBlocks();
+		TempBlock.removeAll(); //Now Folia safe
+		TempArmor.revertAll(); //Now folia safe
+		TempArmorStand.removeAll(); //Now folia safe
+		MovementHandler.resetAll(); //Now folia safe
+		MultiAbilityManager.removeAll(); //Doesn't need thread safety
+		TempFallingBlock.removeAllFallingBlocks(); //Folia safe
 	}
 
 	public static void stopPlugin() {

--- a/core/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
+++ b/core/src/com/projectkorra/projectkorra/OfflineBendingPlayer.java
@@ -12,6 +12,7 @@ import com.projectkorra.projectkorra.event.PlayerChangeSubElementEvent;
 import com.projectkorra.projectkorra.storage.DBConnection;
 import com.projectkorra.projectkorra.util.ChatUtil;
 import com.projectkorra.projectkorra.util.Cooldown;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.lang3.tuple.Pair;
@@ -43,7 +44,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -93,7 +93,7 @@ public class OfflineBendingPlayer {
     private int currentSlot;
     private long lastAccessed;
     private long uncacheTime = 30_000; //This is the default time to unload after when the data is accessed by code, NOT when logging out
-    private BukkitTask uncache;
+    private Object uncache;
 
     public OfflineBendingPlayer(@NotNull OfflinePlayer player) {
         this.player = player;
@@ -146,25 +146,20 @@ public class OfflineBendingPlayer {
             try {
                 if (!rs2.next()) { // Data doesn't exist, we want a completely new player.
                     DBConnection.sql.modifyQuery("INSERT INTO pk_players (uuid, player, slot1, slot2, slot3, slot4, slot5, slot6, slot7, slot8, slot9) VALUES ('" + uuid.toString() + "', '" + offlinePlayer.getName() + "', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null', 'null')");
-                    Bukkit.getScheduler().runTask(ProjectKorra.plugin, () -> ProjectKorra.log.info("Created new BendingPlayer for " + offlinePlayer.getName()));
+                    ProjectKorra.log.info("Created new BendingPlayer for " + offlinePlayer.getName());
                     OfflineBendingPlayer newPlayer;
                     if (offlinePlayer.isOnline()) {
                         newPlayer = new BendingPlayer((Player)offlinePlayer);
                         //Call postLoad() on the main thread and wait for it to complete
-                        Bukkit.getScheduler().callSyncMethod(ProjectKorra.plugin, () -> {
+                        ThreadUtil.runSync(() -> {
                             ((BendingPlayer)newPlayer).postLoad();
-                            return true;
-                        }).get();
-                        ONLINE_PLAYERS.put(uuid, (BendingPlayer) newPlayer);
+                            ONLINE_PLAYERS.put(uuid, (BendingPlayer) newPlayer);
+                        });
                     } else {
                         newPlayer = new OfflineBendingPlayer(offlinePlayer);
                     }
                     PLAYERS.put(uuid, newPlayer);
-                    Bukkit.getScheduler().callSyncMethod(ProjectKorra.plugin, ()
-                            -> {
-                        Bukkit.getPluginManager().callEvent(new BendingPlayerLoadEvent(newPlayer));
-                        return true;
-                    });
+                    ThreadUtil.runSync(() -> Bukkit.getPluginManager().callEvent(new BendingPlayerLoadEvent(newPlayer)));
                     future.complete(newPlayer);
                     LOADING.remove(uuid);
                 } else {
@@ -235,17 +230,9 @@ public class OfflineBendingPlayer {
                             };
 
                             if (onStartup) { //If we are doing this on startup, addon elements aren't loaded yet. So do this async
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        if (func.test(addonClone)) {
-                                            this.cancel();
-                                        }
-                                    }
-                                }.runTaskTimer(ProjectKorra.plugin, 0, 5);
+                                ThreadUtil.runAsyncLater(() -> func.test(addonClone),500L);
                             } else func.test(addonClone); //Addon elements should be loaded so
                         }
-
                     }
 
                     //Load subelements
@@ -339,14 +326,7 @@ public class OfflineBendingPlayer {
                                 }
                             };
                             if (onStartup) { //If we are doing this on startup, addon elements aren't loaded yet. So do this async
-                                new BukkitRunnable() {
-                                    @Override
-                                    public void run() {
-                                        if (func.test(addonClone)) {
-                                            this.cancel();
-                                        }
-                                    }
-                                }.runTaskTimer(ProjectKorra.plugin, 0, 5);
+                                ThreadUtil.runAsyncLater(() -> func.test(addonClone), 500L);
                             } else func.test(addonClone); //Addon elements should be loaded by now
                         }
                     }
@@ -383,14 +363,7 @@ public class OfflineBendingPlayer {
                         }
                     };
                     if (onStartup) { //If we are doing this on startup, addon elements aren't loaded yet. So do this async
-                        new BukkitRunnable() {
-                            @Override
-                            public void run() {
-                                if (func.test(abilitiesClone)) {
-                                    this.cancel();
-                                }
-                            }
-                        }.runTaskTimer(ProjectKorra.plugin, 0, 5);
+                        ThreadUtil.runAsyncLater(() -> func.test(abilitiesClone), 500L);
                     } else func.test(abilitiesClone); //Addon elements should be loaded by now
 
                     //Load permaRemove
@@ -433,29 +406,28 @@ public class OfflineBendingPlayer {
                     //Call postLoad() on the main thread and wait for it to complete
                     if (bPlayer instanceof BendingPlayer) {
                         BendingPlayer finalBPlayer3 = (BendingPlayer) bPlayer;
-                        Bukkit.getScheduler().callSyncMethod(ProjectKorra.plugin, () -> {
+                        ThreadUtil.ensureEntity(finalBPlayer3.getPlayer(), () -> {;
                             finalBPlayer3.postLoad();
-                            return true;
-                        }).get();
+                        });
                     } else {
                         bPlayer.uncacheAfter(30_000);
                     }
 
                     OfflineBendingPlayer finalBPlayer4 = bPlayer;
-                    Bukkit.getScheduler().runTask(ProjectKorra.plugin, () -> {
+                    ThreadUtil.runSync(() -> {
                         Bukkit.getPluginManager().callEvent(new BendingPlayerLoadEvent(finalBPlayer4));
                         LOADING.remove(uuid);
                         future.complete(finalBPlayer4);
                     });
                 }
-            } catch (final SQLException | ExecutionException | InterruptedException ex) {
+            } catch (final SQLException ex) {
                 ex.printStackTrace();
                 LOADING.remove(uuid);
                 future.cancel(true);
             }
         };
 
-        Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, runnable);
+        ThreadUtil.runAsync(runnable);
 
         return future;
     }
@@ -464,7 +436,7 @@ public class OfflineBendingPlayer {
      * Saves the subelements of a BendingPlayer to the database.
      */
     public void saveSubElements() {
-        Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+        ThreadUtil.runAsyncLater(() -> {
             final StringBuilder subs = new StringBuilder();
             if (this.hasSubElement(Element.METAL)) {
                 subs.append("m");
@@ -526,7 +498,7 @@ public class OfflineBendingPlayer {
      * Saves the elements of a BendingPlayer to the database.
      */
     public void saveElements() {
-        Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+        ThreadUtil.runAsyncLater(() -> {
             final StringBuilder elements = new StringBuilder();
             if (this.hasElement(Element.AIR)) {
                 elements.append("a");
@@ -567,7 +539,7 @@ public class OfflineBendingPlayer {
      * Saves all temporary elements to the database
      */
     public void saveTempElements() {
-        Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+        ThreadUtil.runAsyncLater(() -> {
 
             try {
                 DBConnection.sql.getConnection().setAutoCommit(false);
@@ -907,7 +879,7 @@ public class OfflineBendingPlayer {
     }
 
     public void saveCooldowns(boolean async) {
-        if (async) Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, this::saveCooldownsForce);
+        if (async) ThreadUtil.runAsync(this::saveCooldownsForce);
         else this.saveCooldownsForce();
     }
 
@@ -1282,15 +1254,14 @@ public class OfflineBendingPlayer {
         bendingPlayer.loading = false;
 
         if (offlineBendingPlayer.uncache != null) {
-            offlineBendingPlayer.uncache.cancel();
+            ThreadUtil.cancelTimerTask(offlineBendingPlayer.uncache);
         }
 
         PLAYERS.put(player.getUniqueId(), bendingPlayer);
         ONLINE_PLAYERS.put(player.getUniqueId(), bendingPlayer);
 
-        Bukkit.getScheduler().callSyncMethod(ProjectKorra.plugin, () -> {
+        ThreadUtil.ensureEntity(player, () -> {
             Bukkit.getPluginManager().callEvent(new BendingPlayerLoadEvent(bendingPlayer));
-            return true;
         });
 
         return bendingPlayer;
@@ -1331,8 +1302,8 @@ public class OfflineBendingPlayer {
         long remaining = (this.lastAccessed + this.uncacheTime) - System.currentTimeMillis();
 
         if (remaining >= 500) { //If there is at least half a second to go, delay the uncache
-            if (this.uncache != null) this.uncache.cancel(); //Cancel existing task
-            this.uncache = Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, this::uncache, remaining / 50);
+            if (this.uncache != null) ThreadUtil.cancelTimerTask(this.uncache); //Cancel existing task
+            this.uncache = ThreadUtil.runSyncLater(this::uncache, remaining / 50);
             return;
         }
 

--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -120,6 +120,7 @@ import com.projectkorra.projectkorra.util.StatisticsMethods;
 import com.projectkorra.projectkorra.util.TempArmor;
 import com.projectkorra.projectkorra.util.TempBlock;
 import com.projectkorra.projectkorra.util.TempFallingBlock;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import com.projectkorra.projectkorra.waterbending.OctopusForm;
 import com.projectkorra.projectkorra.waterbending.SurgeWall;
 import com.projectkorra.projectkorra.waterbending.SurgeWave;
@@ -210,7 +211,6 @@ import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 public class PKListener implements Listener {
@@ -870,12 +870,7 @@ public class PKListener implements Listener {
 				final Player player = (Player) event.getEntity();
 				BENDING_PLAYER_DEATH.put(player, Pair.of(ability.getElement().getColor() + ability.getName(), event.getAttacker()));
 
-				new BukkitRunnable() {
-					@Override
-					public void run() {
-						BENDING_PLAYER_DEATH.remove(player);
-					}
-				}.runTaskLater(ProjectKorra.plugin, 20);
+				ThreadUtil.runAsyncLater(() -> BENDING_PLAYER_DEATH.remove(player), 20);
 			}
 			if (event.getAttacker() != null && ProjectKorra.isStatisticsEnabled()) {
 				StatisticsMethods.addStatisticAbility(event.getAttacker().getUniqueId(), CoreAbility.getAbility(event.getAbility().getName()), com.projectkorra.projectkorra.util.Statistic.PLAYER_KILLS, 1);
@@ -1187,7 +1182,7 @@ public class PKListener implements Listener {
 			final UUID uuid = player.getUniqueId();
 
 			if (RIGHT_CLICK_INTERACT.add(uuid)) { //Add if it isn't already in there. And if it isn't in there...
-				Bukkit.getScheduler().runTaskLater(this.plugin, () -> RIGHT_CLICK_INTERACT.remove(uuid), 2L);
+				ThreadUtil.runSyncLater(() -> RIGHT_CLICK_INTERACT.remove(uuid), 2L);
 			}
 
 			if (event.getHand() == EquipmentSlot.HAND) {
@@ -1264,7 +1259,7 @@ public class PKListener implements Listener {
 					fma.requestCarry(target);
 					final UUID uuid = player.getUniqueId();
 					if (RIGHT_CLICK_INTERACT.add(uuid)) { //Add if it isn't already in there. And if it isn't in there...
-						Bukkit.getScheduler().runTaskLater(this.plugin, () -> RIGHT_CLICK_INTERACT.remove(uuid), 2L);
+						ThreadUtil.runSyncLater(() -> RIGHT_CLICK_INTERACT.remove(uuid), 2L);
 					}
 				} else if (FlightMultiAbility.getFlyingPlayers().contains(target.getUniqueId())) {
 					FlightMultiAbility.acceptCarryRequest(player, target);
@@ -1299,7 +1294,7 @@ public class PKListener implements Listener {
 		}
 
 		if (ConfigManager.languageConfig.get().getBoolean("Chat.Branding.JoinMessage.Enabled")) {
-			Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+			ThreadUtil.ensureEntityDelay(player, () -> {
 				ChatColor color = ChatColor.of(ConfigManager.languageConfig.get().getString("Chat.Branding.Color").toUpperCase());
 				color = color == null ? ChatColor.GOLD : color;
 				final String topBorder = ConfigManager.languageConfig.get().getString("Chat.Branding.Borders.TopBorder");
@@ -1472,7 +1467,7 @@ public class PKListener implements Listener {
 			return;
 		}
 
-		Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, //Run 1 tick later so they actually are offline
+		ThreadUtil.runAsyncLater( //Run 1 tick later so they actually are offline
 				() -> {
 					if (ProjectKorra.isDatabaseCooldownsEnabled()) {
 						bPlayer.saveCooldowns();
@@ -1705,7 +1700,7 @@ public class PKListener implements Listener {
 			}
 		}
 
-		Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> Illumination.slotChange(player), 1L);
+		ThreadUtil.ensureEntityDelay(player, () -> Illumination.slotChange(player), 1L);
 	}
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -2195,14 +2190,7 @@ public class PKListener implements Listener {
 		final Player player = (Player) event.getPlayer();
 		if (player == null) return;
 		if (event.isMultiAbility()) {
-			new BukkitRunnable() {
-
-				@Override
-				public void run() {
-					BendingBoardManager.updateAllSlots(player);
-				}
-				
-			}.runTaskLater(ProjectKorra.plugin, 1);
+			ThreadUtil.ensureEntityDelay(player, () -> BendingBoardManager.updateAllSlots(player), 1);
 		} else {
 			if (event.isBinding()) {
 				BendingBoardManager.updateBoard(player, event.getAbility(), false, event.getSlot());

--- a/core/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -172,6 +172,17 @@ public abstract class CoreAbility implements Ability {
 		if (this.player == null || !this.isEnabled()) {
 			return;
 		}
+
+		if (ProjectKorra.isFolia() && !Bukkit.isOwnedByCurrentRegion(this.player)) {
+			ProjectKorra.log.warning("Tried to start ability " + this.getName() + " (" + this.getClass().getSimpleName() +
+					".class) on a player that is not owned by the current region. This is not allowed in Folia. Please report " +
+					"this to the ProjectKorra team.");
+			for (int i = 0; i < 6 && i < Thread.currentThread().getStackTrace().length; i++) {
+				ProjectKorra.log.warning(Thread.currentThread().getStackTrace()[i].toString());
+			}
+			return;
+		}
+
 		final AbilityStartEvent event = new AbilityStartEvent(this);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 		if (event.isCancelled()) {
@@ -204,6 +215,8 @@ public abstract class CoreAbility implements Ability {
 		if (ProjectKorra.isFolia()) {
 			//In Folia, we don't call CoreAbility#progressAll(), so instead we make a repeating task
 			//that runs every tick and calls progressSelf()
+
+			//ProjectKorra.log.info("[Debug] " + this.getName() + " was started on Thread " + Thread.currentThread().getName() + " (#" + Thread.currentThread().getId() + ")");
 
 			this.foliaTask = Bukkit.getRegionScheduler().runAtFixedRate(ProjectKorra.plugin, player.getLocation(), (task) -> {
 				this.currentTickFolia++;
@@ -281,8 +294,12 @@ public abstract class CoreAbility implements Ability {
 				return;
 			}
 
-			if (!this.getPlayer().isOnline()) { // This has to be before isDead as isDead
-				this.remove(); 					// will return true if they are offline.
+			if (ProjectKorra.isFolia() && !Bukkit.isOwnedByCurrentRegion(this.player)) {
+				//player.sendMessage(ChatColor.RED +"[Debug] " + this.getName() + " was killed because you changed regions");
+				this.remove();
+				return;
+			} else if (!this.getPlayer().isOnline()) { 	// This has to be before isDead as isDead
+				this.remove(); 							// will return true if they are offline.
 				return;
 			} else if (this.getPlayer().isDead()) {
 				return;

--- a/core/src/com/projectkorra/projectkorra/ability/CoreAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/CoreAbility.java
@@ -223,7 +223,7 @@ public abstract class CoreAbility implements Ability {
 	 */
 	@Override
 	public void remove() {
-		if (this.player == null) {
+		if (this.player == null || !this.isStarted()) {
 			return;
 		}
 

--- a/core/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.projectkorra.projectkorra.region.RegionProtection;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -581,7 +582,7 @@ public abstract class EarthAbility extends ElementalAbility {
 
 	public static void removeAllEarthbendedBlocks() {
 		for (final Block block : MOVED_EARTH.keySet()) {
-			revertBlock(block);
+			ThreadUtil.ensureLocation(block.getLocation(), () -> revertBlock(block));
 		}
 		for (final Integer i : TEMP_AIR_LOCATIONS.keySet()) {
 			revertAirBlock(i, true);
@@ -622,7 +623,7 @@ public abstract class EarthAbility extends ElementalAbility {
 			}
 			return;
 		} else {
-			info.getState().update(true, false);
+			ThreadUtil.ensureLocation(block.getLocation(), () -> info.getState().update(true, false));
 			TEMP_AIR_LOCATIONS.remove(i);
 		}
 	}
@@ -710,7 +711,7 @@ public abstract class EarthAbility extends ElementalAbility {
 	}
 
 	public static void stopBending() {
-		DensityShift.removeAll();
+		DensityShift.removeAll(); //Now thread safe
 
 		if (isEarthRevertOn()) {
 			removeAllEarthbendedBlocks();

--- a/core/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/ElementalAbility.java
@@ -113,37 +113,37 @@ public abstract class ElementalAbility extends CoreAbility {
 	}
 
 	public static boolean isDay(final World world) {
-		final long time = world.getTime();
 		if (world.getEnvironment() == Environment.NETHER || world.getEnvironment() == Environment.THE_END) {
 			return true;
 		}
+		final long time = world.getTime();
 
 		return time >= 23750 || time <= 12250;
 	}
 
 	public static boolean isDawn(final World world) {
-		final long time = world.getTime();
 		if (world.getEnvironment() == Environment.NETHER || world.getEnvironment() == Environment.THE_END) {
 			return false;
 		}
+		final long time = world.getTime();
 
 		return time > 23250 && time < 23750;
 	}
 
 	public static boolean isDusk(final World world) {
-		final long time = world.getTime();
 		if (world.getEnvironment() == Environment.NETHER || world.getEnvironment() == Environment.THE_END) {
 			return false;
 		}
+		final long time = world.getTime();
 
 		return time > 12250 && time < 12750;
 	}
 
 	public static boolean isNight(final World world) {
-		final long time = world.getTime();
 		if (world.getEnvironment() == Environment.NETHER || world.getEnvironment() == Environment.THE_END) {
 			return false;
 		}
+		final long time = world.getTime();
 
 		return time >= 12750 && time <= 23250;
 	}

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -531,8 +531,8 @@ public abstract class WaterAbility extends ElementalAbility {
 	}
 
 	public static void stopBending() {
-		SurgeWall.removeAllCleanup();
-		SurgeWave.removeAllCleanup();
-		WaterArms.removeAllCleanup();
+		SurgeWall.removeAllCleanup(); //Folia compatible
+		SurgeWave.removeAllCleanup(); //Folia compatible
+		WaterArms.removeAllCleanup(); //Folia compatible
 	}
 }

--- a/core/src/com/projectkorra/projectkorra/ability/util/AbilityLoader.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/AbilityLoader.java
@@ -72,7 +72,7 @@ public class AbilityLoader<T> {
 		while (entries.hasMoreElements()) {
 
 			final JarEntry entry = entries.nextElement();
-			if (!entry.getName().endsWith(".class") || entry.getName().contains("$")) {
+			if (!entry.getName().endsWith(".class")) {
 				continue;
 			}
 

--- a/core/src/com/projectkorra/projectkorra/ability/util/CollisionManager.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/CollisionManager.java
@@ -207,6 +207,8 @@ public class CollisionManager {
 	 */
 	public void startCollisionDetection() {
 		this.stopCollisionDetection();
+		if (ProjectKorra.isFolia()) return; //TODO CollisionManager needs to be figured out, so skip for now
+
 		this.detectionRunnable = new BukkitRunnable() {
 			@Override
 			public void run() {

--- a/core/src/com/projectkorra/projectkorra/ability/util/ComboManager.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/ComboManager.java
@@ -41,7 +41,7 @@ public class ComboManager {
 			COMBO_ABILITIES.put("EarthDomeOthers", new ComboAbilityInfo("EarthDomeOthers", earthDomeOthers, EarthDomeOthers.class));
 		}*/
 
-		ThreadUtil.runAsyncLater(ComboManager::registerCombos, 1L);
+		ThreadUtil.runSyncLater(ComboManager::registerCombos, 1L);
 		startCleanupTask();
 	}
 
@@ -66,7 +66,7 @@ public class ComboManager {
 			return;
 		}
 
-		ThreadUtil.runSyncLater(() -> {
+		ThreadUtil.ensureLocation(player.getLocation(), () -> {
 			if (comboAbil.getComboType() instanceof Class) {
 				final Class<?> clazz = (Class<?>) comboAbil.getComboType();
 				try {
@@ -80,7 +80,7 @@ public class ComboManager {
 					return;
 				}
 			}
-		}, 1L);
+		});
 	}
 
 	/**

--- a/core/src/com/projectkorra/projectkorra/ability/util/FoliaCollisionManager.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/FoliaCollisionManager.java
@@ -1,0 +1,220 @@
+package com.projectkorra.projectkorra.ability.util;
+
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.event.AbilityCollisionEvent;
+import com.projectkorra.projectkorra.util.ThreadUtil;
+import com.projectkorra.projectkorra.versions.LuminolIntermediate;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Although this is named "Folia" collision manager, this currently requires Luminol
+ * due to incomplete API in Folia.
+ */
+public class FoliaCollisionManager {
+
+    private static Map<Long, Set<CoreAbility>> regionMap = new HashMap<>();
+    private static Map<Long, CollisionTask> collisionTasks = new ConcurrentHashMap<>();
+    private static Map<Long, Map<Class<? extends CoreAbility>, Set<CoreAbility>>> INSTANCES_BY_CLASS = new ConcurrentHashMap<>();
+
+    public static void startTracking(CoreAbility ability) {
+        Location location = ability.getLocation();
+        if (location == null) {
+            location = ability.getPlayer().getLocation();
+        }
+        Object region = LuminolIntermediate.getRegion(location);
+        if (region == null) {
+            return;
+        }
+
+        long id = LuminolIntermediate.getRegionId(region);
+
+        regionMap.computeIfAbsent(id, k -> new HashSet<>()).add(ability);
+        INSTANCES_BY_CLASS.computeIfAbsent(id, k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(ability.getClass(), k -> new HashSet<>()).add(ability);
+
+        if (!collisionTasks.containsKey(id)) {
+            CollisionTask task = new CollisionTask(region);
+            collisionTasks.put(id, task);
+            ThreadUtil.ensureLocationDelay(location, task, 1);
+        }
+
+        //
+
+    }
+
+    public static void stopTracking(CoreAbility ability) {
+        Location location = ability.getLocation();
+        if (location == null) {
+            location = ability.getPlayer().getLocation();
+        }
+
+        Object region = LuminolIntermediate.getRegion(location);
+        if (region == null) {
+            return;
+        }
+
+        long id = LuminolIntermediate.getRegionId(region);
+
+        Set<CoreAbility> abilities = regionMap.get(id);
+        if (abilities != null) {
+            abilities.remove(ability);
+            if (abilities.isEmpty()) {
+                regionMap.remove(id);
+                collisionTasks.remove(id);
+            }
+        }
+        Map<Class<? extends CoreAbility>, Set<CoreAbility>> instancesByClass = INSTANCES_BY_CLASS.get(id);
+        if (instancesByClass != null) {
+            Set<CoreAbility> classAbilities = instancesByClass.get(ability.getClass());
+            if (classAbilities != null) {
+                classAbilities.remove(ability);
+                if (classAbilities.isEmpty()) {
+                    instancesByClass.remove(ability.getClass());
+                    if (instancesByClass.isEmpty()) {
+                        INSTANCES_BY_CLASS.remove(id);
+                    }
+                }
+            }
+        }
+    }
+
+    public static class CollisionTask implements Runnable {
+
+        private Object region;
+        private long id;
+
+        public CollisionTask(Object region) {
+            this.region = region;
+            this.id = LuminolIntermediate.getRegionId(region);
+        }
+
+        @Override
+        public void run() {
+            if (!regionMap.containsKey(id) || regionMap.get(id).isEmpty() || !LuminolIntermediate.isRegionActive(region)) {
+                regionMap.remove(id);
+                //ProjectKorra.log.info("Removing collision task for region " + region);
+                return;
+            }
+
+            checkCollisions(id);
+
+            CoreAbility first = regionMap.get(id).iterator().next();
+            Location location = first.getLocation();
+            if (location == null) location = first.getPlayer().getLocation();
+
+            ThreadUtil.ensureLocationDelay(location, this, 1);
+        }
+    }
+
+    private static void checkCollisions(long regionId) {
+        if (regionMap.get(regionId).size() < 2) {
+            return;
+        }
+
+        final HashMap<CoreAbility, List<Location>> locationsCache = new HashMap<>();
+        for (final Collision collision : ProjectKorra.getCollisionManager().getCollisions()) {
+            final Collection<? extends CoreAbility> instancesFirst = INSTANCES_BY_CLASS.get(regionId).get(collision.getAbilityFirst().getClass());
+            if (instancesFirst == null || instancesFirst.isEmpty()) {
+                continue;
+            }
+            final Collection<? extends CoreAbility> instancesSecond = INSTANCES_BY_CLASS.get(regionId).get(collision.getAbilitySecond().getClass());
+            if (instancesSecond == null || instancesSecond.isEmpty()) {
+                continue;
+            }
+            final HashSet<CoreAbility> alreadyCollided = new HashSet<CoreAbility>();
+            final double certainNoCollisionDistSquared = Math.pow(ProjectKorra.getCollisionManager().getCertainNoCollisionDistance(), 2);
+
+            for (final CoreAbility abilityFirst : instancesFirst) {
+                if (abilityFirst.getPlayer() == null || alreadyCollided.contains(abilityFirst) || !abilityFirst.isCollidable()) {
+                    continue;
+                }
+
+                if (!locationsCache.containsKey(abilityFirst)) {
+                    locationsCache.put(abilityFirst, abilityFirst.getLocations());
+                }
+                final List<Location> locationsFirst = locationsCache.get(abilityFirst);
+                if (locationsFirst.isEmpty()) {
+                    continue;
+                }
+
+                for (final CoreAbility abilitySecond : instancesSecond) {
+                    if (abilitySecond.getPlayer() == null || alreadyCollided.contains(abilitySecond) || !abilitySecond.isCollidable()) {
+                        continue;
+                    } else if (abilityFirst.getPlayer().equals(abilitySecond.getPlayer())) {
+                        continue;
+                    }
+
+                    if (!locationsCache.containsKey(abilitySecond)) {
+                        locationsCache.put(abilitySecond, abilitySecond.getLocations());
+                    }
+                    final List<Location> locationsSecond = locationsCache.get(abilitySecond);
+                    if (locationsSecond.isEmpty()) {
+                        continue;
+                    }
+
+                    boolean collided = false;
+                    boolean certainNoCollision = false; // Used for efficiency.
+                    Location locationFirst = null;
+                    Location locationSecond = null;
+                    final double requiredDist = abilityFirst.getCollisionRadius() + abilitySecond.getCollisionRadius();
+                    final double requiredDistSquared = Math.pow(requiredDist, 2);
+
+                    for (int i = 0; i < locationsFirst.size(); i++) {
+                        locationFirst = locationsFirst.get(i);
+                        if (locationFirst == null) {
+                            continue;
+                        }
+                        for (int j = 0; j < locationsSecond.size(); j++) {
+                            locationSecond = locationsSecond.get(j);
+                            if (locationSecond == null) {
+                                continue;
+                            }
+
+                            if (locationFirst.getWorld() != locationSecond.getWorld()) {
+                                continue;
+                            }
+                            final double distSquared = locationFirst.distanceSquared(locationSecond);
+                            if (distSquared <= requiredDistSquared) {
+                                collided = true;
+                                break;
+                            } else if (distSquared >= certainNoCollisionDistSquared) {
+                                certainNoCollision = true;
+                                break;
+                            }
+                        }
+                        if (collided || certainNoCollision) {
+                            break;
+                        }
+                    }
+
+                    if (collided) {
+                        final Collision forwardCollision = new Collision(abilityFirst, abilitySecond, collision.isRemovingFirst(), collision.isRemovingSecond(), locationFirst, locationSecond);
+                        final Collision reverseCollision = new Collision(abilitySecond, abilityFirst, collision.isRemovingSecond(), collision.isRemovingFirst(), locationSecond, locationFirst);
+                        final AbilityCollisionEvent event = new AbilityCollisionEvent(forwardCollision);
+                        Bukkit.getServer().getPluginManager().callEvent(event);
+                        if (event.isCancelled()) {
+                            continue;
+                        }
+                        abilityFirst.handleCollision(forwardCollision);
+                        abilitySecond.handleCollision(reverseCollision);
+                        if (!ProjectKorra.getCollisionManager().isRemoveMultipleInstances()) {
+                            alreadyCollided.add(abilityFirst);
+                            alreadyCollided.add(abilitySecond);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/src/com/projectkorra/projectkorra/ability/util/FoliaThreadChecker.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/FoliaThreadChecker.java
@@ -1,18 +1,20 @@
-package com.projectkorra.projectkorra.util;
+package com.projectkorra.projectkorra.ability.util;
 
 import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.util.PassiveManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-
-public class PlayerThreadMonitor implements Runnable {
+/**
+ * This is a runnable that fixes and restarts passives when a player
+ * changes regions in Folia.
+ */
+public class FoliaThreadChecker implements Runnable {
 
     private Player player;
     private Location oldLocation;
 
-    public PlayerThreadMonitor(Player player) {
+    public FoliaThreadChecker(Player player) {
         this.player = player;
     }
 

--- a/core/src/com/projectkorra/projectkorra/ability/util/PassiveManager.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/PassiveManager.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.projectkorra.projectkorra.configuration.ConfigManager;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.entity.Player;
 
 import com.projectkorra.projectkorra.BendingPlayer;
@@ -44,15 +45,18 @@ public class PassiveManager {
 					continue;
 				}
 
-				try {
-					final Class<? extends CoreAbility> clazz = PASSIVE_CLASSES.get(ability);
-					final Constructor<?> constructor = clazz.getConstructor(Player.class);
-					final Object object = constructor.newInstance(player);
-					((CoreAbility) object).start();
-				} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
-					e.printStackTrace();
-				}
+				ThreadUtil.ensureLocation(player.getLocation(), () -> startPassive(player, ability.getClass()));
 			}
+		}
+	}
+
+	public static void startPassive(Player player, Class<? extends CoreAbility> ability) {
+		try {
+			final Constructor<?> constructor = ability.getConstructor(Player.class);
+			final Object object = constructor.newInstance(player);
+			((CoreAbility) object).start();
+		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+			e.printStackTrace();
 		}
 	}
 
@@ -101,6 +105,8 @@ public class PassiveManager {
 		}
 		return passives;
 	}
+
+
 
 	public static Map<String, CoreAbility> getPassives() {
 		return PASSIVES;

--- a/core/src/com/projectkorra/projectkorra/ability/util/RepeatingTask.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/RepeatingTask.java
@@ -1,0 +1,70 @@
+package com.projectkorra.projectkorra.ability.util;
+
+import com.projectkorra.projectkorra.Element;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.ability.ElementalAbility;
+import org.bukkit.Location;
+
+public abstract class RepeatingTask extends ElementalAbility {
+
+    private final CoreAbility parentAbility;
+
+    public RepeatingTask(CoreAbility parentAbility) {
+        super(parentAbility.getPlayer());
+        this.parentAbility = parentAbility;
+    }
+
+    public CoreAbility getParentAbility() {
+        return parentAbility;
+    }
+
+    @Override
+    public Element getElement() {
+        return parentAbility.getElement();
+    }
+
+    @Override
+    public long getCooldown() {
+        return 0;
+    }
+
+    @Override
+    public boolean isHiddenAbility() {
+        return true;
+    }
+
+    @Override
+    public boolean isIgniteAbility() {
+        return parentAbility.isIgniteAbility();
+    }
+
+    @Override
+    public boolean isHarmlessAbility() {
+        return parentAbility.isHarmlessAbility();
+    }
+
+    @Override
+    public boolean isExplosiveAbility() {
+        return parentAbility.isExplosiveAbility();
+    }
+
+    @Override
+    public String getName() {
+        return parentAbility.getName() + "Task";
+    }
+
+    @Override
+    public Location getLocation() {
+        return parentAbility.getLocation();
+    }
+
+    @Override
+    public boolean isSneakAbility() {
+        return parentAbility.isSneakAbility();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/core/src/com/projectkorra/projectkorra/ability/util/RepeatingTask.java
+++ b/core/src/com/projectkorra/projectkorra/ability/util/RepeatingTask.java
@@ -20,7 +20,7 @@ public abstract class RepeatingTask extends ElementalAbility {
 
     @Override
     public Element getElement() {
-        return parentAbility.getElement();
+        return parentAbility == null ? Element.AVATAR : parentAbility.getElement();
     }
 
     @Override
@@ -35,32 +35,32 @@ public abstract class RepeatingTask extends ElementalAbility {
 
     @Override
     public boolean isIgniteAbility() {
-        return parentAbility.isIgniteAbility();
+        return false;
     }
 
     @Override
     public boolean isHarmlessAbility() {
-        return parentAbility.isHarmlessAbility();
+        return false;
     }
 
     @Override
     public boolean isExplosiveAbility() {
-        return parentAbility.isExplosiveAbility();
+        return false;
     }
 
     @Override
     public String getName() {
-        return parentAbility.getName() + "Task";
+        return parentAbility == null ? "RepeatingTask" : parentAbility.getName() + "Task";
     }
 
     @Override
     public Location getLocation() {
-        return parentAbility.getLocation();
+        return parentAbility == null ? null : parentAbility.getLocation();
     }
 
     @Override
     public boolean isSneakAbility() {
-        return parentAbility.isSneakAbility();
+        return false;
     }
 
     @Override

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBlast.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBlast.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.projectkorra.projectkorra.region.RegionProtection;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -22,7 +23,6 @@ import org.bukkit.block.data.type.TrapDoor;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.BlockIterator;
 import org.bukkit.util.Vector;
 
@@ -187,7 +187,7 @@ public class AirBlast extends AirAbility {
 
 	public static void progressOrigins() {
 		for (final Player player : ORIGINS.keySet()) {
-			playOriginEffect(player);
+			ThreadUtil.ensureLocation(player.getLocation(), () -> playOriginEffect(player));
 		}
 	}
 
@@ -444,17 +444,12 @@ public class AirBlast extends AirAbility {
 					testblock.setBlockData(button);
 					this.affectedLevers.add(testblock);
 
-					new BukkitRunnable() {
-
-						@Override
-						public void run() {
-							button.setPowered(false);
-							testblock.setBlockData(button);
-							AirBlast.this.affectedLevers.remove(testblock);
-							testblock.getWorld().playSound(testblock.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_OFF, 0.5f, 0);
-						}
-
-					}.runTaskLater(ProjectKorra.plugin, 15);
+					ThreadUtil.ensureLocationDelay(testblock.getLocation(), () -> {
+						button.setPowered(false);
+						testblock.setBlockData(button);
+						AirBlast.this.affectedLevers.remove(testblock);
+						testblock.getWorld().playSound(testblock.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_OFF, 0.5f, 0);
+					}, 15);
 				}
 
 				testblock.getWorld().playSound(testblock.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 0.5f, 0);

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBurst.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBurst.java
@@ -3,10 +3,10 @@ package com.projectkorra.projectkorra.airbending;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.ProjectKorra;
@@ -173,12 +173,7 @@ public class AirBurst extends AirAbility {
 			if (i % 4 != 0) {
 				toggleTime = (int) (i % (100 / this.particlePercentage)) + 3;
 			}
-			new BukkitRunnable() {
-				@Override
-				public void run() {
-					blast.setShowParticles(true);
-				}
-			}.runTaskLater(ProjectKorra.plugin, toggleTime);
+			ThreadUtil.ensureLocationDelay(blast.getLocation(), () -> blast.setShowParticles(true), toggleTime);
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirSwipe.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -13,7 +14,6 @@ import org.bukkit.block.data.Levelled;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.BlockIterator;
 import org.bukkit.util.Vector;
 
@@ -222,33 +222,30 @@ public class AirSwipe extends AirAbility {
 		for (int i = 0; i < entities.size(); i++) {
 			final Entity entity = entities.get(i);
 			final AirSwipe abil = this;
-			new BukkitRunnable() {
-				@Override
-				public void run() {
-					if (GeneralMethods.isRegionProtectedFromBuild(AirSwipe.this, entity.getLocation())) {
-						return;
+			ThreadUtil.ensureLocationDelay(entity.getLocation(), () -> {
+				if (GeneralMethods.isRegionProtectedFromBuild(AirSwipe.this, entity.getLocation())) {
+					return;
+				}
+				if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && entity instanceof LivingEntity) {
+					if (entity instanceof Player) {
+						if (Commands.invincible.contains(((Player) entity).getName())) {
+							return;
+						}
 					}
-					if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && entity instanceof LivingEntity) {
-						if (entity instanceof Player) {
-							if (Commands.invincible.contains(((Player) entity).getName())) {
-								return;
-							}
-						}
-						if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
-							GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
-						}
-						if (!AirSwipe.this.affectedEntities.contains(entity)) {
-							if (AirSwipe.this.damage != 0) {
-								DamageHandler.damageEntity(entity, AirSwipe.this.damage, abil);
-							}
-							AirSwipe.this.affectedEntities.add(entity);
-						}
-						breakBreathbendingHold(entity);
-					} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
+					if (entities.size() < MAX_AFFECTABLE_ENTITIES) {
 						GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 					}
+					if (!AirSwipe.this.affectedEntities.contains(entity)) {
+						if (AirSwipe.this.damage != 0) {
+							DamageHandler.damageEntity(entity, AirSwipe.this.damage, abil);
+						}
+						AirSwipe.this.affectedEntities.add(entity);
+					}
+					breakBreathbendingHold(entity);
+				} else if (entity.getEntityId() != AirSwipe.this.player.getEntityId() && !(entity instanceof LivingEntity)) {
+					GeneralMethods.setVelocity(AirSwipe.this, entity, fDirection.multiply(AirSwipe.this.pushFactor));
 				}
-			}.runTaskLater(ProjectKorra.plugin, i / MAX_AFFECTABLE_ENTITIES);
+			}, i / MAX_AFFECTABLE_ENTITIES);
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/airbending/Suffocate.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/Suffocate.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.airbending;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
@@ -10,7 +11,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.GeneralMethods;
 import com.projectkorra.projectkorra.ProjectKorra;
@@ -59,7 +59,8 @@ public class Suffocate extends AirAbility {
 	private double blindRepeat;
 	private double animationSpeed;
 	private Suffocate ability;
-	private ArrayList<BukkitRunnable> tasks;
+	private ArrayList<Object> tasks;
+	private ArrayList<SuffocateSpiral> spirals;
 	private ArrayList<LivingEntity> targets;
 
 	public Suffocate(final Player player) {
@@ -92,6 +93,7 @@ public class Suffocate extends AirAbility {
 		this.blindRepeat = getConfig().getDouble("Abilities.Air.Suffocate.BlindInterval");
 		this.targets = new ArrayList<>();
 		this.tasks = new ArrayList<>();
+		this.spirals = new ArrayList<>();
 
 		if (this.particleCount < 1) {
 			this.particleCount = 1;
@@ -185,31 +187,14 @@ public class Suffocate extends AirAbility {
 		} else if (!this.started) {
 			this.started = true;
 			for (final LivingEntity target : this.targets) {
-				final BukkitRunnable br1 = new BukkitRunnable() {
-					@Override
-					public void run() {
-						DamageHandler.damageEntity(target, Suffocate.this.damage, Suffocate.this.ability);
-					}
-				};
-				final BukkitRunnable br2 = new BukkitRunnable() {
-					@Override
-					public void run() {
-						target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, (int) (Suffocate.this.slowRepeat * 20), (int) Suffocate.this.slow));
-					}
-				};
-				final BukkitRunnable br3 = new BukkitRunnable() {
-					@Override
-					public void run() {
-						target.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, (int) (Suffocate.this.blindRepeat * 20), (int) Suffocate.this.blind));
-					}
-				};
+				final Runnable br1 = () -> DamageHandler.damageEntity(target, Suffocate.this.damage, Suffocate.this.ability);
+				final Runnable br2 = () -> target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, (int) (Suffocate.this.slowRepeat * 20), (int) Suffocate.this.slow));
+				final Runnable br3 = () -> target.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, (int) (Suffocate.this.blindRepeat * 20), (int) Suffocate.this.blind));
 
-				this.tasks.add(br1);
-				this.tasks.add(br2);
-				this.tasks.add(br3);
-				br1.runTaskTimer(ProjectKorra.plugin, (long) (this.damageDelay * 20), (long) (this.damageRepeat * 20));
-				br2.runTaskTimer(ProjectKorra.plugin, (long) (this.slowDelay * 20), (long) (this.slowRepeat * 20 / 0.25));
-				br3.runTaskTimer(ProjectKorra.plugin, (long) (this.blindDelay * 20), (long) (this.blindRepeat * 20));
+
+				this.tasks.add(ThreadUtil.ensureEntityTimer(target, br1, (long) (this.damageDelay * 20), (long) (this.damageRepeat * 20)));
+				this.tasks.add(ThreadUtil.ensureEntityTimer(target, br2, (long) (this.slowDelay * 20), (long) (this.slowRepeat * 20 / 0.25)));
+				this.tasks.add(ThreadUtil.ensureEntityTimer(target, br3, (long) (this.blindDelay * 20), (long) (this.blindRepeat * 20)));
 			}
 		}
 
@@ -296,24 +281,24 @@ public class Suffocate extends AirAbility {
 		final long t3 = (long) (5000 * this.animationSpeed);
 		final long t4 = (long) (6000 * this.animationSpeed);
 		if (dt < t1) {
-			new SuffocateSpiral(target, steps, this.radius, delay, 0, 0.25 - (0.25 * dt / t1), 0, SpiralType.HORIZONTAL1);
-			new SuffocateSpiral(target, steps, this.radius, delay, 0, 0.25 - (0.25 * dt / t1), 0, SpiralType.HORIZONTAL2);
+			new SuffocateSpiral(this, target, steps, this.radius, delay, 0, 0.25 - (0.25 * dt / t1), 0, SpiralType.HORIZONTAL1);
+			new SuffocateSpiral(this, target, steps, this.radius, delay, 0, 0.25 - (0.25 * dt / t1), 0, SpiralType.HORIZONTAL2);
 		} else if (dt < t2) {
-			new SuffocateSpiral(target, steps, this.radius, delay, 0, 0, 0, SpiralType.HORIZONTAL1);
-			new SuffocateSpiral(target, steps * 2, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL1);
-			new SuffocateSpiral(target, steps * 2, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL2);
+			new SuffocateSpiral(this, target, steps, this.radius, delay, 0, 0, 0, SpiralType.HORIZONTAL1);
+			new SuffocateSpiral(this, target, steps * 2, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL1);
+			new SuffocateSpiral(this, target, steps * 2, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL2);
 		} else if (dt < t3) {
-			new SuffocateSpiral(target, steps, this.radius, delay, 0, 0, 0, SpiralType.HORIZONTAL1);
-			new SuffocateSpiral(target, steps, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL1);
-			new SuffocateSpiral(target, steps, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL2);
+			new SuffocateSpiral(this, target, steps, this.radius, delay, 0, 0, 0, SpiralType.HORIZONTAL1);
+			new SuffocateSpiral(this, target, steps, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL1);
+			new SuffocateSpiral(this, target, steps, this.radius, delay, 0, 0, 0, SpiralType.VERTICAL2);
 		} else if (dt < t4) {
-			new SuffocateSpiral(target, steps, this.radius - Math.min(this.radius * 3 / 4, (this.radius * 3.0 / 4 * ((double) (dt - t3) / (double) (t4 - t3)))), delay, 0, 0, 0, SpiralType.HORIZONTAL1);
-			new SuffocateSpiral(target, steps, this.radius - Math.min(this.radius * 3 / 4, (this.radius * 3.0 / 4 * ((double) (dt - t3) / (double) (t4 - t3)))), delay, 0, 0, 0, SpiralType.VERTICAL1);
-			new SuffocateSpiral(target, steps, this.radius - Math.min(this.radius * 3 / 4, (this.radius * 3.0 / 4 * ((double) (dt - t3) / (double) (t4 - t3)))), delay, 0, 0, 0, SpiralType.VERTICAL2);
+			new SuffocateSpiral(this, target, steps, this.radius - Math.min(this.radius * 3 / 4, (this.radius * 3.0 / 4 * ((double) (dt - t3) / (double) (t4 - t3)))), delay, 0, 0, 0, SpiralType.HORIZONTAL1);
+			new SuffocateSpiral(this, target, steps, this.radius - Math.min(this.radius * 3 / 4, (this.radius * 3.0 / 4 * ((double) (dt - t3) / (double) (t4 - t3)))), delay, 0, 0, 0, SpiralType.VERTICAL1);
+			new SuffocateSpiral(this, target, steps, this.radius - Math.min(this.radius * 3 / 4, (this.radius * 3.0 / 4 * ((double) (dt - t3) / (double) (t4 - t3)))), delay, 0, 0, 0, SpiralType.VERTICAL2);
 		} else {
-			new SuffocateSpiral(target, steps, this.radius - (this.radius * 3.0 / 4.0), delay, 0, 0, 0, SpiralType.HORIZONTAL1);
-			new SuffocateSpiral(target, steps, this.radius - (this.radius * 3.0 / 4.0), delay, 0, 0, 0, SpiralType.VERTICAL1);
-			new SuffocateSpiral(target, steps, this.radius - (this.radius * 3.0 / 4.0), delay, 0, 0, 0, SpiralType.VERTICAL2);
+			new SuffocateSpiral(this, target, steps, this.radius - (this.radius * 3.0 / 4.0), delay, 0, 0, 0, SpiralType.HORIZONTAL1);
+			new SuffocateSpiral(this, target, steps, this.radius - (this.radius * 3.0 / 4.0), delay, 0, 0, 0, SpiralType.VERTICAL1);
+			new SuffocateSpiral(this, target, steps, this.radius - (this.radius * 3.0 / 4.0), delay, 0, 0, 0, SpiralType.VERTICAL2);
 		}
 	}
 
@@ -330,7 +315,7 @@ public class Suffocate extends AirAbility {
 		super.remove();
 		this.bPlayer.addCooldown(this);
 		for (int i = 0; i < this.tasks.size(); i++) {
-			this.tasks.get(i).cancel();
+			ThreadUtil.cancelTimerTask(this.tasks.get(i));
 			this.tasks.remove(i);
 			i--;
 		}
@@ -341,7 +326,7 @@ public class Suffocate extends AirAbility {
 	 * entity. The direction of the spiral is determined by SpiralType, and each
 	 * type is calculated independently from one another.
 	 */
-	public class SuffocateSpiral extends BukkitRunnable {
+	public class SuffocateSpiral extends AirAbility {
 		private Location startLoc;
 		private final Location loc;
 		private LivingEntity target;
@@ -361,7 +346,8 @@ public class Suffocate extends AirAbility {
 		 * @param dz z offset
 		 * @param type Spiral animation direction
 		 */
-		public SuffocateSpiral(final LivingEntity lent, final int totalSteps, final double radius, final long interval, final double dx, final double dy, final double dz, final SpiralType type) {
+		public SuffocateSpiral(final Suffocate suffocate, final LivingEntity lent, final int totalSteps, final double radius, final long interval, final double dx, final double dy, final double dz, final SpiralType type) {
+			super(suffocate.player);
 			this.target = lent;
 			this.totalSteps = totalSteps;
 			this.radius = radius;
@@ -371,8 +357,8 @@ public class Suffocate extends AirAbility {
 			this.type = type;
 			this.loc = this.target.getEyeLocation();
 			this.i = 0;
-			this.runTaskTimer(ProjectKorra.plugin, 0L, interval);
-			Suffocate.this.tasks.add(this);
+			this.start();
+			Suffocate.this.spirals.add(this);
 		}
 
 		/**
@@ -385,7 +371,8 @@ public class Suffocate extends AirAbility {
 		 * @param dz z offset
 		 * @param type Spiral animation direction
 		 */
-		public SuffocateSpiral(final Location startLoc, final int totalSteps, final double radius, final long interval, final double dx, final double dy, final double dz, final SpiralType type) {
+		public SuffocateSpiral(final Suffocate suffocate, final Location startLoc, final int totalSteps, final double radius, final long interval, final double dx, final double dy, final double dz, final SpiralType type) {
+			super(suffocate.player);
 			this.startLoc = startLoc;
 			this.totalSteps = totalSteps;
 			this.radius = radius;
@@ -395,15 +382,15 @@ public class Suffocate extends AirAbility {
 			this.type = type;
 			this.loc = startLoc.clone();
 			this.i = 0;
-			this.runTaskTimer(ProjectKorra.plugin, 0L, interval);
-			Suffocate.this.tasks.add(this);
+			this.start();
+			Suffocate.this.spirals.add(this);
 		}
 
 		/**
 		 * Starts the initial animation, and removes itself when it is finished.
 		 */
 		@Override
-		public void run() {
+		public void progress() {
 			Location tempLoc;
 			if (this.target != null) {
 				tempLoc = this.target.getEyeLocation();
@@ -440,9 +427,44 @@ public class Suffocate extends AirAbility {
 
 			getAirbendingParticles().display(this.loc, 0, 0, 0, 0, 1);
 			if (this.i == this.totalSteps + 1) {
-				this.cancel();
+				this.remove();
 			}
 			this.i++;
+		}
+
+		@Override
+		public String getName() {
+			return "SuffocateSpiral";
+		}
+
+		@Override
+		public boolean isHiddenAbility() {
+			return true;
+		}
+
+		@Override
+		public boolean isSneakAbility() {
+			return false;
+		}
+
+		@Override
+		public boolean isIgniteAbility() {
+			return false;
+		}
+
+		@Override
+		public boolean isHarmlessAbility() {
+			return false;
+		}
+
+		@Override
+		public long getCooldown() {
+			return 0;
+		}
+
+		@Override
+		public Location getLocation() {
+			return loc;
 		}
 	}
 
@@ -628,7 +650,7 @@ public class Suffocate extends AirAbility {
 		this.animationSpeed = animationSpeed;
 	}
 
-	public ArrayList<BukkitRunnable> getTasks() {
+	public ArrayList<Object> getTasks() {
 		return this.tasks;
 	}
 

--- a/core/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/combo/AirStream.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 
 import com.projectkorra.projectkorra.ability.util.ComboUtil;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -37,13 +37,11 @@ public class AirStream extends AirAbility implements ComboAbility {
 	private Location destination;
 	private Vector direction;
 	private ArrayList<Entity> affectedEntities;
-	private ArrayList<BukkitRunnable> tasks;
 
 	public AirStream(final Player player) {
 		super(player);
 
 		this.affectedEntities = new ArrayList<>();
-		this.tasks = new ArrayList<>();
 
 		if (!this.bPlayer.canBendIgnoreBindsCooldowns(this)) {
 			return;
@@ -129,20 +127,16 @@ public class AirStream extends AirAbility implements ComboAbility {
 		}
 
 		for (int i = 0; i < 10; i++) {
-			final BukkitRunnable br = new BukkitRunnable() {
-				final Location loc = AirStream.this.currentLoc.clone();
-				final Vector dir = AirStream.this.direction.clone();
-
-				@Override
-				public void run() {
-					for (int angle = -180; angle <= 180; angle += 45) {
-						final Vector orthog = GeneralMethods.getOrthogonalVector(this.dir.clone(), angle, 0.5);
-						playAirbendingParticles(this.loc.clone().add(orthog), 1, 0F, 0F, 0F);
-					}
+			final Location loc = AirStream.this.currentLoc.clone();
+			final Vector dir = AirStream.this.direction.clone();
+			final Runnable runnable = () -> {
+				if (AirStream.this.isRemoved()) return;
+				for (int angle = -180; angle <= 180; angle += 45) {
+					final Vector orthog = GeneralMethods.getOrthogonalVector(dir.clone(), angle, 0.5);
+					playAirbendingParticles(loc.clone().add(orthog), 1, 0F, 0F, 0F);
 				}
 			};
-			br.runTaskLater(ProjectKorra.plugin, i * 2);
-			this.tasks.add(br);
+			ThreadUtil.ensureLocationDelay(loc, runnable, i * 2);
 		}
 
 		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.currentLoc, 2.8)) {
@@ -162,14 +156,6 @@ public class AirStream extends AirAbility implements ComboAbility {
 			final Vector force = GeneralMethods.getDirection(entity.getLocation(), this.currentLoc);
 			GeneralMethods.setVelocity(this, entity, force.clone().normalize().multiply(this.speed));
 			entity.setFallDistance(0F);
-		}
-	}
-
-	@Override
-	public void remove() {
-		super.remove();
-		for (final BukkitRunnable task : this.tasks) {
-			task.cancel();
 		}
 	}
 
@@ -277,14 +263,6 @@ public class AirStream extends AirAbility implements ComboAbility {
 
 	public ArrayList<Entity> getAffectedEntities() {
 		return this.affectedEntities;
-	}
-
-	public ArrayList<BukkitRunnable> getTasks() {
-		return this.tasks;
-	}
-
-	public void setTasks(final ArrayList<BukkitRunnable> tasks) {
-		this.tasks = tasks;
 	}
 
 	public void setCooldown(final long cooldown) {

--- a/core/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/combo/AirSweep.java
@@ -10,7 +10,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -21,8 +20,7 @@ import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
 import com.projectkorra.projectkorra.attribute.Attribute;
 import com.projectkorra.projectkorra.command.Commands;
-import com.projectkorra.projectkorra.firebending.combo.FireComboStream;
-import com.projectkorra.projectkorra.util.ClickType;
+import com.projectkorra.projectkorra.firebending.combo.ComboStream;
 import com.projectkorra.projectkorra.util.DamageHandler;
 
 public class AirSweep extends AirAbility implements ComboAbility {
@@ -43,7 +41,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 	private Location destination;
 	private Vector direction;
 	private ArrayList<Entity> affectedEntities;
-	private ArrayList<BukkitRunnable> tasks;
+	private ArrayList<ComboStream> tasks;
 	private double radius;
 
 	public AirSweep(final Player player) {
@@ -84,13 +82,13 @@ public class AirSweep extends AirAbility implements ComboAbility {
 	@Override
 	public void handleCollision(final Collision collision) {
 		if (collision.isRemovingFirst()) {
-			final ArrayList<BukkitRunnable> newTasks = new ArrayList<>();
+			final ArrayList<ComboStream> newTasks = new ArrayList<>();
 			final double collisionDistanceSquared = Math.pow(this.getCollisionRadius() + collision.getAbilitySecond().getCollisionRadius(), 2);
 			// Remove all of the streams that are by this specific ourLocation.
 			// Don't just do a single stream at a time or this algorithm becomes O(n^2) with Collision's detection algorithm.
-			for (final BukkitRunnable task : this.getTasks()) {
-				if (task instanceof FireComboStream) {
-					final FireComboStream stream = (FireComboStream) task;
+			for (final ComboStream task : this.getTasks()) {
+				if (task instanceof ComboStream) {
+					final ComboStream stream = (ComboStream) task;
 					if (stream.getLocation().distanceSquared(collision.getLocationSecond()) > collisionDistanceSquared) {
 						newTasks.add(stream);
 					} else {
@@ -107,9 +105,9 @@ public class AirSweep extends AirAbility implements ComboAbility {
 	@Override
 	public List<Location> getLocations() {
 		final ArrayList<Location> locations = new ArrayList<>();
-		for (final BukkitRunnable task : this.getTasks()) {
-			if (task instanceof FireComboStream) {
-				final FireComboStream stream = (FireComboStream) task;
+		for (final ComboStream task : this.getTasks()) {
+			if (task instanceof ComboStream) {
+				final ComboStream stream = (ComboStream) task;
 				locations.add(stream.getLocation());
 			}
 		}
@@ -145,13 +143,13 @@ public class AirSweep extends AirAbility implements ComboAbility {
 				}
 				final Vector vec = GeneralMethods.getDirection(hand, endLoc);
 
-				final FireComboStream fs = new FireComboStream(this.player, this, vec, hand, this.range, this.speed);
+				final ComboStream fs = new ComboStream(this.player, this, vec, hand, this.range, this.speed);
 				fs.setDensity(1);
 				fs.setSpread(0F);
 				fs.setUseNewParticles(true);
 				fs.setParticleEffect(getAirbendingParticles());
 				fs.setCollides(false);
-				fs.runTaskTimer(ProjectKorra.plugin, (long) (i / 2.5), 1L);
+				fs.start();
 				this.tasks.add(fs);
 			}
 		}
@@ -160,7 +158,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 
 	public void manageAirVectors() {
 		for (int i = 0; i < this.tasks.size(); i++) {
-			if (((FireComboStream) this.tasks.get(i)).isCancelled()) {
+			if (((ComboStream) this.tasks.get(i)).isRemoved()) {
 				this.tasks.remove(i);
 				i--;
 			}
@@ -170,7 +168,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 			return;
 		}
 		for (int i = 0; i < this.tasks.size(); i++) {
-			final FireComboStream fstream = (FireComboStream) this.tasks.get(i);
+			final ComboStream fstream = (ComboStream) this.tasks.get(i);
 			final Location loc = fstream.getLocation();
 
 			if (GeneralMethods.isRegionProtectedFromBuild(this, loc)) {
@@ -214,7 +212,7 @@ public class AirSweep extends AirAbility implements ComboAbility {
 	@Override
 	public void remove() {
 		super.remove();
-		for (final BukkitRunnable task : this.tasks) {
+		for (final ComboStream task : this.tasks) {
 			task.cancel();
 		}
 	}
@@ -325,11 +323,11 @@ public class AirSweep extends AirAbility implements ComboAbility {
 		return this.affectedEntities;
 	}
 
-	public ArrayList<BukkitRunnable> getTasks() {
+	public ArrayList<ComboStream> getTasks() {
 		return this.tasks;
 	}
 
-	public void setTasks(final ArrayList<BukkitRunnable> tasks) {
+	public void setTasks(final ArrayList<ComboStream> tasks) {
 		this.tasks = tasks;
 	}
 }

--- a/core/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/flight/FlightMultiAbility.java
@@ -8,13 +8,13 @@ import java.util.Set;
 import java.util.UUID;
 
 import com.projectkorra.projectkorra.util.ChatUtil;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.Element;
@@ -59,6 +59,7 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 	@Attribute(Attribute.COOLDOWN)
 	private long cooldown;
 	private Vector prevDir;
+	private Object messageTask;
 
 	public FlightMultiAbility(final Player player) {
 		super(player);
@@ -176,15 +177,12 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 			} else {
 				if (requestTime.get(this.player.getUniqueId()) + 15000 > System.currentTimeMillis()) {
 					final long start = System.currentTimeMillis();
-					new BukkitRunnable() {
-						@Override
-						public void run() {
-							ChatUtil.sendActionBar(ChatColor.WHITE + FlightMultiAbility.this.player.getName() + ChatColor.GREEN + " has requested to carry you, right-click them to accept!", p2);
-							if (System.currentTimeMillis() >= start + 300) {
-								this.cancel();
-							}
+					messageTask = ThreadUtil.ensureEntityTimer(player, () -> {
+						ChatUtil.sendActionBar(ChatColor.WHITE + FlightMultiAbility.this.player.getName() + ChatColor.GREEN + " has requested to carry you, right-click them to accept!", p2);
+						if (System.currentTimeMillis() >= start + 300) {
+							ThreadUtil.cancelTimerTask(messageTask);
 						}
-					}.runTaskTimer(ProjectKorra.plugin, 0, 1);
+					}, 0, 1);
 				} else {
 					requestedMap.remove(this.player.getUniqueId());
 					requestTime.remove(this.player.getUniqueId());
@@ -350,29 +348,26 @@ public class FlightMultiAbility extends FlightAbility implements MultiAbility {
 		}
 
 		final long start = System.currentTimeMillis();
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				ChatUtil.sendActionBar(ChatColor.AQUA + "Flight speed: " + FlightMultiAbility.this.speed(), FlightMultiAbility.this.player);
-				if (System.currentTimeMillis() >= start + 1000) {
-					this.cancel();
-				}
+		messageTask = ThreadUtil.ensureEntityTimer(this.player, () -> {
+			ChatUtil.sendActionBar(ChatColor.AQUA + "Flight speed: " + FlightMultiAbility.this.speed(), FlightMultiAbility.this.player);
+			if (System.currentTimeMillis() >= start + 1000) {
+				ThreadUtil.cancelTimerTask(messageTask);
 			}
-		}.runTaskTimer(ProjectKorra.plugin, 0, 1);
+		}, 0, 1);
 	}
 
 	public void cancel(final String reason) {
 		if (!MovementHandler.isStopped(this.player) && !this.bPlayer.isChiBlocked()) {
 			final long start = System.currentTimeMillis();
-			new BukkitRunnable() {
+			messageTask = ThreadUtil.ensureEntityTimer(this.player, new Runnable() {
 				@Override
 				public void run() {
 					ChatUtil.sendActionBar(ChatColor.RED + "* Flight cancelled due to " + reason + " *", FlightMultiAbility.this.player);
 					if (System.currentTimeMillis() >= start + 1000) {
-						this.cancel();
+						ThreadUtil.cancelTimerTask(messageTask);
 					}
 				}
-			}.runTaskTimer(ProjectKorra.plugin, 0, 1);
+			}, 0, 1);
 		}
 
 		this.remove();

--- a/core/src/com/projectkorra/projectkorra/avatar/AvatarState.java
+++ b/core/src/com/projectkorra/projectkorra/avatar/AvatarState.java
@@ -10,6 +10,7 @@ import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.attribute.AttributeCache;
 import com.projectkorra.projectkorra.attribute.AttributeModification;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -139,7 +140,7 @@ public class AvatarState extends AvatarAbility {
 
 				if (boostHealth) {
 					//Delay by 1 tick so the event doesn't override our changes
-					Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+					ThreadUtil.ensureEntityDelay(player.getPlayer(), () -> {
 						if (yellowHearts) {
 							if (willDie) player.getPlayer().setHealth(0.5);
 							player.getPlayer().setAbsorptionAmount(amount);

--- a/core/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
+++ b/core/src/com/projectkorra/projectkorra/board/BendingBoardManager.java
@@ -22,6 +22,7 @@ import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.storage.DBConnection;
 
 import com.projectkorra.projectkorra.util.ChatUtil;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -57,7 +58,7 @@ public final class BendingBoardManager {
 	}
 
 	private static void initialize() {
-		enabled = ConfigManager.getConfig().getBoolean("Properties.BendingBoard");
+		enabled = ConfigManager.getConfig().getBoolean("Properties.BendingBoard") && !ProjectKorra.isFolia();
 		
 		disabledWorlds.clear();
 		disabledWorlds.addAll(ConfigManager.getConfig().getStringList("Properties.DisabledWorlds"));
@@ -209,7 +210,7 @@ public final class BendingBoardManager {
 	 * Load into memory the list of players who have toggled the bending board off.
 	 */
 	public static void loadDisabledPlayers() {
-		Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, () -> {
+		ThreadUtil.runAsync(() -> {
 			Set<UUID> disabled = new HashSet<>();
 			try {
 				final ResultSet rs = DBConnection.sql.readQuery("SELECT uuid FROM pk_board WHERE enabled = 0");
@@ -231,7 +232,7 @@ public final class BendingBoardManager {
 		scoreboardPlayers.remove(player);
 		final UUID uuid = player.getUniqueId();
 		final String updateQuery = "UPDATE pk_board SET enabled = " + (disabledPlayers.contains(uuid) ? 0 : 1) + " WHERE uuid = ?";
-		Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, () -> {
+		ThreadUtil.runAsync(() -> {
 			try {
 				PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement("SELECT enabled FROM pk_board WHERE uuid = ? LIMIT 1");
 				ps.setString(1, uuid.toString());

--- a/core/src/com/projectkorra/projectkorra/command/CooldownCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/CooldownCommand.java
@@ -10,6 +10,7 @@ import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.event.PlayerCooldownChangeEvent;
 import com.projectkorra.projectkorra.util.ChatUtil;
 import com.projectkorra.projectkorra.util.Cooldown;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import com.projectkorra.projectkorra.util.TimeUtil;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -37,7 +38,7 @@ public class CooldownCommand extends PKCommand {
 
         COOLDOWNS.add("ChooseElement");
 
-        Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+        ThreadUtil.runSyncLater(() -> {
             for (CoreAbility ability : CoreAbility.getAbilities()) {
                 if (ability.isHiddenAbility() || ability instanceof PassiveAbility || !ability.isEnabled()) continue;
 

--- a/core/src/com/projectkorra/projectkorra/command/PKCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/PKCommand.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.util.ChatUtil;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -311,9 +312,10 @@ public abstract class PKCommand implements SubCommand {
 		//If the player is online, return them instantly so it doesn't happen next tick
 		if (Bukkit.getPlayer(name) != null) return CompletableFuture.completedFuture(Bukkit.getPlayer(name));
 
-		Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, () -> {
+		ThreadUtil.runAsync(() -> {
 			OfflinePlayer player = Bukkit.getOfflinePlayer(name);
-			Bukkit.getScheduler().runTask(ProjectKorra.plugin, () -> future.complete(player)); //Complete in a sync thread
+			//TODO FOLIA: THIS MAY NOT RETURN ON THE SAME THREAD IT WAS CALLED FROM. BEWARE.
+			ThreadUtil.runSync(() -> future.complete(player)); //Complete in a sync thread
 		});
 
 		return future;

--- a/core/src/com/projectkorra/projectkorra/command/StatsCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/StatsCommand.java
@@ -11,11 +11,11 @@ import java.util.Set;
 import java.util.UUID;
 
 import com.projectkorra.projectkorra.util.ChatUtil;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.ProjectKorra;
@@ -95,15 +95,16 @@ public class StatsCommand extends PKCommand {
 			} catch (IndexOutOfBoundsException | NumberFormatException e) {}
 			final Object o = object;
 			final int p = page;
-			new BukkitRunnable() {
-				@Override
-				public void run() {
-					final List<String> messages = StatsCommand.this.getLeaderboard(sender, o, statistic, p);
-					for (final String message : messages) {
-						sender.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
-					}
+			Runnable runnable = () -> {
+				final List<String> messages = StatsCommand.this.getLeaderboard(sender, o, statistic, p);
+				for (final String message : messages) {
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
 				}
-			}.runTaskAsynchronously(ProjectKorra.plugin);
+			};
+
+			if (sender instanceof Player) ThreadUtil.ensureEntity((Player) sender, runnable);
+			else runnable.run();
+
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/command/TempCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/TempCommand.java
@@ -7,6 +7,7 @@ import com.projectkorra.projectkorra.OfflineBendingPlayer;
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 import com.projectkorra.projectkorra.util.ChatUtil;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import com.projectkorra.projectkorra.util.TimeUtil;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
@@ -165,17 +166,17 @@ public class TempCommand extends PKCommand {
 
 		if (Arrays.asList(addAliases).contains(args.get(0).toLowerCase())) {
 			if (!hasPermission(sender, "add")) return;
-			BendingPlayer.getOrLoadOfflineAsync(player).thenAccept(bPlayer -> Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+			BendingPlayer.getOrLoadOfflineAsync(player).thenAccept(bPlayer -> ThreadUtil.runAsyncLater(() -> {
 				addElement(element, bPlayer, sender, time);
 			}, 1L));
 		} else if (Arrays.asList(extendAliases).contains(args.get(0).toLowerCase())) {
 			if (!hasPermission(sender, "extend")) return;
-			BendingPlayer.getOrLoadOfflineAsync(player).thenAccept(bPlayer -> Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () -> {
+			BendingPlayer.getOrLoadOfflineAsync(player).thenAccept(bPlayer -> ThreadUtil.runAsyncLater(() -> {
 				extendElement(element, bPlayer, sender, time);
 			}, 1L));
 		} else if (Arrays.asList(reduceAliases).contains(args.get(0).toLowerCase())) {
 			if (!hasPermission(sender, "reduce")) return;
-			BendingPlayer.getOrLoadOfflineAsync(player).thenAccept(bPlayer -> Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () ->{
+			BendingPlayer.getOrLoadOfflineAsync(player).thenAccept(bPlayer -> ThreadUtil.runAsyncLater(() ->{
 				reduceElement(element, bPlayer, sender, time, false);
 			}, 1L));
 		}

--- a/core/src/com/projectkorra/projectkorra/command/ToggleCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/ToggleCommand.java
@@ -12,6 +12,7 @@ import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.PassiveAbility;
 import com.projectkorra.projectkorra.util.ChatUtil;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -57,7 +58,7 @@ public class ToggleCommand extends PKCommand {
 		this.toggleAllPassivesOnSelf =  c.getString("Commands.Toggle.ToggledPassivesOn");
 
 		//1 tick later because commands are created before abilities are
-		Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, () ->
+		ThreadUtil.runAsyncLater(() ->
 				cachedPassiveElements = CoreAbility.getAbilities().stream().filter(ab -> ab instanceof PassiveAbility)
 						.map(Ability::getElement).collect(Collectors.toSet())
 		, 1L);

--- a/core/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import com.projectkorra.projectkorra.region.RegionProtection;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Color;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -18,7 +19,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -301,24 +301,21 @@ public class EarthArmor extends EarthAbility {
 
 	public void updateAbsorbtion() {
 		final EarthArmor abil = this;
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				abil.goldHearts = EarthArmor.this.player.getAbsorptionAmount();
-				if (abil.formed && abil.goldHearts < 0.9F) {
-					abil.bPlayer.addCooldown(abil);
+		ThreadUtil.ensureLocationDelay(abil.player.getLocation(), () -> {
+			abil.goldHearts = EarthArmor.this.player.getAbsorptionAmount();
+			if (abil.formed && abil.goldHearts < 0.9F) {
+				abil.bPlayer.addCooldown(abil);
 
-					abil.player.getLocation().getWorld().playSound(abil.player.getLocation(), Sound.BLOCK_STONE_BREAK, 2, 1);
-					abil.player.getLocation().getWorld().playSound(abil.player.getLocation(), Sound.BLOCK_STONE_BREAK, 2, 1);
-					abil.player.getLocation().getWorld().playSound(abil.player.getLocation(), Sound.BLOCK_STONE_BREAK, 2, 1);
+				abil.player.getLocation().getWorld().playSound(abil.player.getLocation(), Sound.BLOCK_STONE_BREAK, 2, 1);
+				abil.player.getLocation().getWorld().playSound(abil.player.getLocation(), Sound.BLOCK_STONE_BREAK, 2, 1);
+				abil.player.getLocation().getWorld().playSound(abil.player.getLocation(), Sound.BLOCK_STONE_BREAK, 2, 1);
 
-					ParticleEffect.BLOCK_CRACK.display(abil.player.getEyeLocation(), 8, 0.1, 0.1, 0.1, abil.headMaterial.createBlockData());
-					ParticleEffect.BLOCK_CRACK.display(abil.player.getLocation(), 8, 0.1F, 0.1F, 0.1F, abil.legsMaterial.createBlockData());
+				ParticleEffect.BLOCK_CRACK.display(abil.player.getEyeLocation(), 8, 0.1, 0.1, 0.1, abil.headMaterial.createBlockData());
+				ParticleEffect.BLOCK_CRACK.display(abil.player.getLocation(), 8, 0.1F, 0.1F, 0.1F, abil.legsMaterial.createBlockData());
 
-					abil.remove();
-				}
+				abil.remove();
 			}
-		}.runTaskLater(ProjectKorra.plugin, 1L);
+		}, 1L);
 
 	}
 

--- a/core/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/EarthSmash.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import io.papermc.lib.PaperLib;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -135,7 +136,7 @@ public class EarthSmash extends EarthAbility {
 		} else if (type == ClickType.RIGHT_CLICK && player.isSneaking()) {
 			final EarthSmash grabbedSmash = this.aimingAtSmashCheck(player, State.GRABBED);
 			if (grabbedSmash != null) {
-				player.teleport(grabbedSmash.location.clone().add(0, 2, 0));
+				PaperLib.teleportAsync(player, grabbedSmash.location.clone().add(0, 2, 0));
 				grabbedSmash.state = State.FLYING;
 				grabbedSmash.player = player;
 				grabbedSmash.setFields();

--- a/core/src/com/projectkorra/projectkorra/earthbending/Ripple.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/Ripple.java
@@ -302,6 +302,7 @@ public class Ripple extends EarthAbility {
 		return false;
 	}
 
+	@Deprecated
 	public static void progressAllCleanup() {
 		BLOCKS.clear();
 	}

--- a/core/src/com/projectkorra/projectkorra/earthbending/Shockwave.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/Shockwave.java
@@ -81,6 +81,7 @@ public class Shockwave extends EarthAbility {
 		}
 	}
 
+	@Deprecated
 	public static void progressAll() {
 		Ripple.progressAllCleanup();
 	}

--- a/core/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/Tremorsense.java
@@ -1,6 +1,7 @@
 package com.projectkorra.projectkorra.earthbending;
 
 import com.projectkorra.projectkorra.region.RegionProtection;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -189,7 +190,7 @@ public class Tremorsense extends EarthAbility {
 		for (final Player player : server.getOnlinePlayers()) {
 
 			if (canTremorSense(player) && !hasAbility(player, Tremorsense.class)) {
-				new Tremorsense(player, false);
+				ThreadUtil.ensureLocation(player.getLocation(), () -> new Tremorsense(player, false));
 			}
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/earthbending/passive/DensityShift.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/passive/DensityShift.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.earthbending.passive;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -85,7 +86,7 @@ public class DensityShift extends EarthAbility implements PassiveAbility {
 	public static void revertAllSand() {
 		for (final TempBlock block : SAND_BLOCKS) {
 			block.setRevertTask(null);
-			block.revertBlock();
+			ThreadUtil.ensureLocation(block.getLocation(), block::revertBlock);
 		}
 		SAND_BLOCKS.clear();
 	}

--- a/core/src/com/projectkorra/projectkorra/earthbending/util/EarthbendingManager.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/util/EarthbendingManager.java
@@ -7,6 +7,7 @@ import com.projectkorra.projectkorra.earthbending.Shockwave;
 import com.projectkorra.projectkorra.earthbending.Tremorsense;
 import com.projectkorra.projectkorra.util.RevertChecker;
 
+@Deprecated
 public class EarthbendingManager implements Runnable {
 	public ProjectKorra plugin;
 
@@ -16,8 +17,8 @@ public class EarthbendingManager implements Runnable {
 
 	@Override
 	public void run() {
-		RevertChecker.revertEarthBlocks();
-		Shockwave.progressAll();
-		Tremorsense.manage(Bukkit.getServer());
+		RevertChecker.revertEarthBlocks(); //Folia safe now
+		Shockwave.progressAll(); //Nothing
+		Tremorsense.manage(Bukkit.getServer()); //Folia safe now
 	}
 }

--- a/core/src/com/projectkorra/projectkorra/event/BendingPlayerLoadEvent.java
+++ b/core/src/com/projectkorra/projectkorra/event/BendingPlayerLoadEvent.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.event;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.OfflineBendingPlayer;
+import com.projectkorra.projectkorra.ProjectKorra;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -23,7 +24,7 @@ public class BendingPlayerLoadEvent extends Event {
 
 
 	public BendingPlayerLoadEvent(final OfflineBendingPlayer bPlayer) {
-		super(!Bukkit.isPrimaryThread());
+		super(!Bukkit.isPrimaryThread() && !ProjectKorra.isFolia());
 		this.bPlayer = bPlayer;
 	}
 

--- a/core/src/com/projectkorra/projectkorra/event/PlayerChangeElementEvent.java
+++ b/core/src/com/projectkorra/projectkorra/event/PlayerChangeElementEvent.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.event;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.OfflineBendingPlayer;
+import com.projectkorra.projectkorra.ProjectKorra;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -39,7 +40,7 @@ public class PlayerChangeElementEvent extends Event implements Cancellable {
 	 *            permaremoved
 	 */
 	public PlayerChangeElementEvent(final CommandSender sender, final OfflinePlayer target, final Element element, final Result result) {
-		super(!Bukkit.isPrimaryThread());
+		super(!Bukkit.isPrimaryThread() && !ProjectKorra.isFolia());
 		this.sender = sender;
 		this.target = target;
 		this.element = element;

--- a/core/src/com/projectkorra/projectkorra/event/PlayerChangeSubElementEvent.java
+++ b/core/src/com/projectkorra/projectkorra/event/PlayerChangeSubElementEvent.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.event;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.OfflineBendingPlayer;
+import com.projectkorra.projectkorra.ProjectKorra;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -35,7 +36,7 @@ public class PlayerChangeSubElementEvent extends Event implements Cancellable {
 	 *            permaremoved
 	 */
 	public PlayerChangeSubElementEvent(final CommandSender sender, final OfflinePlayer target, final SubElement sub, final Result result) {
-		super(!Bukkit.isPrimaryThread());
+		super(!Bukkit.isPrimaryThread() && !ProjectKorra.isFolia());
 		this.sender = sender;
 		this.target = target;
 		this.sub = sub;

--- a/core/src/com/projectkorra/projectkorra/firebending/FireBurst.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/FireBurst.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -103,12 +103,7 @@ public class FireBurst extends FireAbility {
 		for (int i = 0; i < this.blasts.size(); i++) {
 			final FireBlast fblast = this.blasts.get(i);
 			final int toggleTime = (int) (i % (100.0 / this.particlesPercentage));
-			new BukkitRunnable() {
-				@Override
-				public void run() {
-					fblast.setShowParticles(true);
-				}
-			}.runTaskLater(ProjectKorra.plugin, toggleTime);
+			ThreadUtil.ensureLocationDelay(fblast.getLocation(), () -> fblast.setShowParticles(true), toggleTime);
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/ComboStream.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/ComboStream.java
@@ -24,18 +24,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
-
-import com.projectkorra.projectkorra.BendingPlayer;
-import com.projectkorra.projectkorra.Element.SubElement;
-import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ability.CoreAbility;
-import com.projectkorra.projectkorra.ability.ElementalAbility;
-import com.projectkorra.projectkorra.command.Commands;
-import com.projectkorra.projectkorra.firebending.util.FireDamageTimer;
-import com.projectkorra.projectkorra.util.DamageHandler;
-import com.projectkorra.projectkorra.util.ParticleEffect;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -44,10 +33,8 @@ import java.util.concurrent.ThreadLocalRandom;
  * stream for all their progress methods. If someone else was reliant on that,
  * they can use this ability instead.
  */
-@Deprecated
-public class FireComboStream extends BukkitRunnable {
+public class ComboStream extends ElementalAbility {
 	private boolean useNewParticles;
-	private boolean cancelled;
 	private boolean collides;
 	private boolean singlePoint;
 	private int density;
@@ -68,9 +55,9 @@ public class FireComboStream extends BukkitRunnable {
 	private final Location initialLocation;
 	private final Location location;
 
-	public FireComboStream(final Player player, final CoreAbility coreAbility, final Vector direction, final Location location, final double distance, final double speed) {
-		this.useNewParticles = false;
-		this.cancelled = false;
+	public ComboStream(final Player player, final CoreAbility coreAbility, final Vector direction, final Location location, final double distance, final double speed) {
+        super(player);
+        this.useNewParticles = false;
 		this.collides = true;
 		this.singlePoint = false;
 		this.density = 1;
@@ -90,7 +77,7 @@ public class FireComboStream extends BukkitRunnable {
 	}
 
 	@Override
-	public void run() {
+	public void progress() {
 		final Block block = this.location.getBlock();
 
 		if (RegionProtection.isRegionProtected(this.player, this.location, coreAbility)) {
@@ -195,9 +182,48 @@ public class FireComboStream extends BukkitRunnable {
 		}
 	}
 
-	@Override
 	public void cancel() {
 		this.remove();
+	}
+
+	@Override
+	public boolean isHiddenAbility() {
+		return true;
+	}
+
+	@Override
+	public boolean isSneakAbility() {
+		return false;
+	}
+
+	@Override
+	public boolean isHarmlessAbility() {
+		return false;
+	}
+
+	@Override
+	public boolean isIgniteAbility() {
+		return false;
+	}
+
+	@Override
+	public long getCooldown() {
+		return 0;
+	}
+
+	@Override
+	public Element getElement() {
+		return coreAbility == null ? Element.AVATAR : coreAbility.getElement();
+	}
+
+	@Override
+	public boolean isExplosiveAbility() {
+		return false;
+	}
+
+	@Override
+	public String getName() {
+		return this.coreAbility == null ? "ComboStream" : "ComboStream_" + this.coreAbility.getName();
 	}
 
 	public Vector getDirection() {
@@ -208,18 +234,13 @@ public class FireComboStream extends BukkitRunnable {
 		return this.location;
 	}
 
-	@Override
-	public boolean isCancelled() {
-		return this.cancelled;
-	}
-
-	public void remove() {
-		super.cancel();
-		this.cancelled = true;
-	}
-
 	public CoreAbility getAbility() {
 		return this.coreAbility;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
 	}
 
 	public void setCheckCollisionDelay(final int delay) {

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireKick.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireKick.java
@@ -10,7 +10,6 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -20,7 +19,6 @@ import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.util.Collision;
 import com.projectkorra.projectkorra.ability.util.ComboManager.AbilityInformation;
 import com.projectkorra.projectkorra.attribute.Attribute;
-import com.projectkorra.projectkorra.util.ClickType;
 
 public class FireKick extends FireAbility implements ComboAbility {
 
@@ -35,7 +33,7 @@ public class FireKick extends FireAbility implements ComboAbility {
 	private Location location;
 	private Location destination;
 	private ArrayList<LivingEntity> affectedEntities;
-	private ArrayList<BukkitRunnable> tasks;
+	private ArrayList<ComboStream> tasks;
 
 	public FireKick(final Player player) {
 		super(player);
@@ -68,13 +66,12 @@ public class FireKick extends FireAbility implements ComboAbility {
 	@Override
 	public void progress() {
 		for (int i = 0; i < this.tasks.size(); i++) {
-			final BukkitRunnable br = this.tasks.get(i);
-			if (br instanceof FireComboStream) {
-				final FireComboStream fs = (FireComboStream) br;
-				if (fs.isCancelled()) {
-					this.tasks.remove(fs);
-				}
+			final ComboStream br = this.tasks.get(i);
+
+			if (br.isRemoved()) {
+				this.tasks.remove(br);
 			}
+
 		}
 
 		if (!this.bPlayer.canBendIgnoreBindsCooldowns(this)) {
@@ -101,7 +98,7 @@ public class FireKick extends FireAbility implements ComboAbility {
 				Vector vec = direction.clone().multiply(Math.cos(angle))
 						.add(xz.clone().multiply(Math.sin(angle))).normalize();
 
-				final FireComboStream fs = new FireComboStream(this.player, this, vec, this.player.getLocation(), this.range, this.speed);
+				final ComboStream fs = new ComboStream(this.player, this, vec, this.player.getLocation(), this.range, this.speed);
 				fs.setSpread(0.2F);
 				fs.setDensity(5);
 				fs.setUseNewParticles(true);
@@ -109,7 +106,7 @@ public class FireKick extends FireAbility implements ComboAbility {
 				if (this.tasks.size() % 3 != 0) {
 					fs.setCollides(false);
 				}
-				fs.runTaskTimer(ProjectKorra.plugin, 0, 1L);
+				fs.start();
 				this.tasks.add(fs);
 				this.player.getWorld().playSound(this.player.getLocation(), Sound.ITEM_FLINTANDSTEEL_USE, 0.5f, 1f);
 			}
@@ -123,7 +120,7 @@ public class FireKick extends FireAbility implements ComboAbility {
 	@Override
 	public void remove() {
 		super.remove();
-		for (final BukkitRunnable task : this.tasks) {
+		for (final ComboStream task : this.tasks) {
 			task.cancel();
 		}
 	}
@@ -131,13 +128,13 @@ public class FireKick extends FireAbility implements ComboAbility {
 	@Override
 	public void handleCollision(final Collision collision) {
 		if (collision.isRemovingFirst()) {
-			final ArrayList<BukkitRunnable> newTasks = new ArrayList<>();
+			final ArrayList<ComboStream> newTasks = new ArrayList<>();
 			final double collisionDistanceSquared = Math.pow(this.getCollisionRadius() + collision.getAbilitySecond().getCollisionRadius(), 2);
 			// Remove all of the streams that are by this specific ourLocation.
 			// Don't just do a single stream at a time or this algorithm becomes O(n^2) with Collision's detection algorithm.
-			for (final BukkitRunnable task : this.getTasks()) {
-				if (task instanceof FireComboStream) {
-					final FireComboStream stream = (FireComboStream) task;
+			for (final ComboStream task : this.getTasks()) {
+				if (task != null) {
+					final ComboStream stream = (ComboStream) task;
 					if (stream.getLocation().distanceSquared(collision.getLocationSecond()) > collisionDistanceSquared) {
 						newTasks.add(stream);
 					} else {
@@ -154,9 +151,9 @@ public class FireKick extends FireAbility implements ComboAbility {
 	@Override
 	public List<Location> getLocations() {
 		final ArrayList<Location> locations = new ArrayList<>();
-		for (final BukkitRunnable task : this.getTasks()) {
-			if (task instanceof FireComboStream) {
-				final FireComboStream stream = (FireComboStream) task;
+		for (final ComboStream task : this.getTasks()) {
+			if (task instanceof ComboStream) {
+				final ComboStream stream = (ComboStream) task;
 				locations.add(stream.getLocation());
 			}
 		}
@@ -197,11 +194,11 @@ public class FireKick extends FireAbility implements ComboAbility {
 		return this.affectedEntities;
 	}
 
-	public ArrayList<BukkitRunnable> getTasks() {
+	public ArrayList<ComboStream> getTasks() {
 		return this.tasks;
 	}
 
-	public void setTasks(final ArrayList<BukkitRunnable> tasks) {
+	public void setTasks(final ArrayList<ComboStream> tasks) {
 		this.tasks = tasks;
 	}
 }

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/JetBlast.java
@@ -25,7 +25,7 @@ public class JetBlast extends FireAbility implements ComboAbility {
 	private long cooldown;
 	@Attribute(Attribute.SPEED) @DayNightFactor
 	private double speed;
-	private ArrayList<FireComboStream> tasks;
+	private ArrayList<ComboStream> tasks;
 	@Attribute(Attribute.DURATION) @DayNightFactor
 	private long duration;
 
@@ -75,12 +75,12 @@ public class JetBlast extends FireAbility implements ComboAbility {
 		}
 
 		Vector streamDir = this.player.getVelocity().multiply(-1);
-		final FireComboStream fs = new FireComboStream(this.player, this, streamDir, this.player.getLocation(), 3, 0.5);
+		final ComboStream fs = new ComboStream(this.player, this, streamDir, this.player.getLocation(), 3, 0.5);
 		fs.setDensity(1);
 		fs.setSpread(0.9F);
 		fs.setUseNewParticles(true);
 		fs.setCollides(false);
-		fs.runTaskTimer(ProjectKorra.plugin, 0, 1L);
+		fs.start();
 		this.tasks.add(fs);
 	}
 
@@ -90,7 +90,7 @@ public class JetBlast extends FireAbility implements ComboAbility {
 			this.fireJet.remove();
 		}
 
-		for (final FireComboStream task : this.tasks) {
+		for (final ComboStream task : this.tasks) {
 			task.remove();
 		}
 		super.remove();

--- a/core/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/JetBlaze.java
@@ -30,7 +30,7 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 	@Attribute(Attribute.FIRE_TICK)
 	private double fireTicks;
 	private ArrayList<LivingEntity> affectedEntities;
-	private ArrayList<FireComboStream> tasks;
+	private ArrayList<ComboStream> tasks;
 	@Attribute(Attribute.DURATION)
 	private long duration;
 
@@ -77,7 +77,7 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 		}
 
 		Vector streamDir = this.player.getVelocity().multiply(-1);
-		final FireComboStream fs = new FireComboStream(this.player, this, streamDir, this.player.getLocation(), 5, 1);
+		final ComboStream fs = new ComboStream(this.player, this, streamDir, this.player.getLocation(), 5, 1);
 		fs.setDensity(8);
 		fs.setSpread(1.0F);
 		fs.setUseNewParticles(true);
@@ -85,7 +85,7 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 		fs.setParticleEffect(ParticleEffect.SMOKE_LARGE);
 		fs.setDamage(this.damage);
 		fs.setFireTicks(this.fireTicks);
-		fs.runTaskTimer(ProjectKorra.plugin, 0, 1L);
+		fs.start();
 		this.tasks.add(fs);
 		this.player.getWorld().playSound(this.player.getLocation(), Sound.ENTITY_CREEPER_PRIMED, 1, 0F);
 	}
@@ -96,7 +96,7 @@ public class JetBlaze extends FireAbility implements ComboAbility {
 			this.fireJet.remove();
 		}
 
-		for (final FireComboStream task : this.tasks) {
+		for (final ComboStream task : this.tasks) {
 			task.remove();
 		}
 		super.remove();

--- a/core/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combustion/Combustion.java
@@ -153,11 +153,10 @@ public class Combustion extends CombustionAbility {
 			}
 		}
 
-		for (final Entity entity : this.location.getWorld().getEntities()) {
-			if (entity instanceof LivingEntity) {
-				if (entity.getLocation().distanceSquared(this.location) <= 4 && !entity.equals(this.player)) {
+
+		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, 4)) {
+			if (!entity.equals(this.player)) {
 					this.createExplosion(this.location, this.explosivePower, this.breakBlocks);
-				}
 			}
 		}
 		this.advanceLocation();

--- a/core/src/com/projectkorra/projectkorra/firebending/util/FireDamageTimer.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/util/FireDamageTimer.java
@@ -3,6 +3,7 @@ package com.projectkorra.projectkorra.firebending.util;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.Ability;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -89,6 +90,8 @@ public class FireDamageTimer {
 	}
 
 	public static void handleFlames() {
+		if (ProjectKorra.isFolia()) return; //TODO REWRITE THIS CLASS TO BE INSTANCE BASED
+
 		for (final Entity entity : INSTANCES.keySet()) {
 			if (entity.getFireTicks() <= 0) {
 				INSTANCES.remove(entity);

--- a/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
+++ b/core/src/com/projectkorra/projectkorra/object/HorizontalVelocityTracker.java
@@ -63,6 +63,18 @@ public class HorizontalVelocityTracker {
 		this.abil = ability;
 		this.update();
 		instances.put(this.entity, this);
+
+		if (ProjectKorra.isFolia()) { //On Folia, there is no global scheduler task, so we need to create one for each entity.
+			this.entity.getScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> {
+				if (!e.isDead() && instances.get(e) != null) {
+					this.update();
+				} else {
+					instances.remove(e);
+					task.cancel();
+				}
+
+			}, () -> {}, 1, 1);
+		}
 	}
 
 	public void update() {
@@ -115,6 +127,10 @@ public class HorizontalVelocityTracker {
 		}
 	}
 
+	/**
+	 * Updates all HorizontalVelocityTrackers. This is called every tick.
+	 * <b>Cannot be called by Folia.</b>
+	 */
 	public static void updateAll() {
 		for (final Entity e : instances.keySet()) {
 			if (e != null && !e.isDead() && instances.get(e) != null) {

--- a/core/src/com/projectkorra/projectkorra/object/Preset.java
+++ b/core/src/com/projectkorra/projectkorra/object/Preset.java
@@ -11,9 +11,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.BendingPlayer;
 import com.projectkorra.projectkorra.ProjectKorra;
@@ -80,37 +80,34 @@ public class Preset {
 	 * @param player The Player who's Presets should be loaded
 	 */
 	public static void loadPresets(final Player player) {
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				final UUID uuid = player.getUniqueId();
-				if (uuid == null) {
-					return;
-				}
-				try {
-					final PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement(loadQuery);
-					ps.setString(1, uuid.toString());
-					final ResultSet rs = ps.executeQuery();
-					if (rs.next()) { // Presets exist.
-						int i = 0;
-						do {
-							final HashMap<Integer, String> moves = new HashMap<Integer, String>();
-							for (int total = 1; total <= 9; total++) {
-								final String slot = rs.getString("slot" + total);
-								if (slot != null) {
-									moves.put(total, slot);
-								}
-							}
-							new Preset(uuid, rs.getString("name"), moves);
-							i++;
-						} while (rs.next());
-						ProjectKorra.log.info("Loaded " + i + " presets for " + player.getName());
-					}
-				} catch (final SQLException ex) {
-					ex.printStackTrace();
-				}
+		ThreadUtil.runAsync(() -> {
+			final UUID uuid = player.getUniqueId();
+			if (uuid == null) {
+				return;
 			}
-		}.runTaskAsynchronously(ProjectKorra.plugin);
+			try {
+				final PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement(loadQuery);
+				ps.setString(1, uuid.toString());
+				final ResultSet rs = ps.executeQuery();
+				if (rs.next()) { // Presets exist.
+					int i = 0;
+					do {
+						final HashMap<Integer, String> moves = new HashMap<Integer, String>();
+						for (int total = 1; total <= 9; total++) {
+							final String slot = rs.getString("slot" + total);
+							if (slot != null) {
+								moves.put(total, slot);
+							}
+						}
+						new Preset(uuid, rs.getString("name"), moves);
+						i++;
+					} while (rs.next());
+					ProjectKorra.log.info("Loaded " + i + " presets for " + player.getName());
+				}
+			} catch (final SQLException ex) {
+				ex.printStackTrace();
+			}
+		});
 	}
 
 	/**
@@ -269,22 +266,19 @@ public class Preset {
 	public CompletableFuture<Boolean> delete() {
 		Preset instance = this;
 		CompletableFuture<Boolean> future = new CompletableFuture<>();
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				try {
-					final PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement(deleteQuery);
-					ps.setString(1, uuid.toString());
-					ps.setString(2, name);
-					ps.execute();
-					presets.get(uuid).remove(instance);
-					future.complete(true);
-				} catch (final SQLException e) {
-					e.printStackTrace();
-					future.complete(false);
-				}
+		ThreadUtil.runAsync(() -> {
+			try {
+				final PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement(deleteQuery);
+				ps.setString(1, uuid.toString());
+				ps.setString(2, name);
+				ps.execute();
+				presets.get(uuid).remove(instance);
+				future.complete(true);
+			} catch (final SQLException e) {
+				e.printStackTrace();
+				future.complete(false);
 			}
-		}.runTaskAsynchronously(ProjectKorra.plugin);
+		});
 		return future;
 	}
 
@@ -302,24 +296,22 @@ public class Preset {
 	 */
 	public CompletableFuture<Boolean> save(final Player player) {
 		CompletableFuture<Boolean> future = new CompletableFuture<>();
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				try {
-					PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement(insertQuery);
-					ps.setString(1, uuid.toString());
-					ps.setString(2, name);
-					for (int i = 1; i <= 9; i++) {
-						ps.setString(2 + i, abilities.get(i));
-					}
-					ps.execute();
-					future.complete(true);
-				} catch (final SQLException e) {
-					e.printStackTrace();
-					future.complete(false);
+		ThreadUtil.runAsync(() -> {
+			try {
+				PreparedStatement ps = DBConnection.sql.getConnection().prepareStatement(insertQuery);
+				ps.setString(1, uuid.toString());
+				ps.setString(2, name);
+				for (int i = 1; i <= 9; i++) {
+					ps.setString(2 + i, abilities.get(i));
 				}
+				ps.execute();
+				future.complete(true);
+			} catch (final SQLException e) {
+				e.printStackTrace();
+				future.complete(false);
 			}
-		}.runTaskAsynchronously(ProjectKorra.plugin);
+
+		});
 		return future;
 	}
 

--- a/core/src/com/projectkorra/projectkorra/region/RegionProtection.java
+++ b/core/src/com/projectkorra/projectkorra/region/RegionProtection.java
@@ -4,6 +4,7 @@ import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.hooks.RegionProtectionHook;
 import com.projectkorra.projectkorra.util.BlockCacheElement;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -171,7 +172,7 @@ public class RegionProtection {
      * @param period The time, in milliseconds, to clean the cache
      */
     public static void startCleanCacheTask(double period) {
-        Bukkit.getScheduler().runTaskTimer(ProjectKorra.plugin, () -> {
+        ThreadUtil.runSyncTimer(() -> {
             final long currentTime = System.currentTimeMillis();
             for (final String playerName : BLOCK_CACHE.keySet()) {
                 final Map<Block, BlockCacheElement> map = BLOCK_CACHE.get(playerName);

--- a/core/src/com/projectkorra/projectkorra/storage/Database.java
+++ b/core/src/com/projectkorra/projectkorra/storage/Database.java
@@ -7,9 +7,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.logging.Logger;
 
-import org.bukkit.scheduler.BukkitRunnable;
-
 import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 
 public abstract class Database {
 
@@ -97,12 +96,7 @@ public abstract class Database {
 	 */
 	public void modifyQuery(final String query, final boolean async) {
 		if (async) {
-			new BukkitRunnable() {
-				@Override
-				public void run() {
-					Database.this.doQuery(query);
-				}
-			}.runTaskAsynchronously(ProjectKorra.plugin);
+			ThreadUtil.runAsync(() -> Database.this.doQuery(query));
 		} else {
 			this.doQuery(query);
 		}

--- a/core/src/com/projectkorra/projectkorra/util/FlightHandler.java
+++ b/core/src/com/projectkorra/projectkorra/util/FlightHandler.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.Manager;
 import com.projectkorra.projectkorra.ProjectKorra;
@@ -161,21 +160,19 @@ public class FlightHandler extends Manager {
 	}
 
 	public void startCleanup() {
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				final long currentTime = System.currentTimeMillis();
-				while (!FlightHandler.this.CLEANUP.isEmpty()) {
-					final FlightAbility ability = FlightHandler.this.CLEANUP.peek();
-					if (currentTime >= ability.startTime + ability.duration) {
-						FlightHandler.this.CLEANUP.poll();
-						FlightHandler.this.removeInstance(ability.player, ability.identifier);
-					} else {
-						break;
-					}
+		ThreadUtil.runAsyncTimer(() -> {
+
+			final long currentTime = System.currentTimeMillis();
+			while (!FlightHandler.this.CLEANUP.isEmpty()) {
+				final FlightAbility ability = FlightHandler.this.CLEANUP.peek();
+				if (currentTime >= ability.startTime + ability.duration) {
+					FlightHandler.this.CLEANUP.poll();
+					FlightHandler.this.removeInstance(ability.player, ability.identifier);
+				} else {
+					break;
 				}
 			}
-		}.runTaskTimer(ProjectKorra.plugin, 0, 1);
+		}, 0, 1);
 	}
 
 	public static class Flight {

--- a/core/src/com/projectkorra/projectkorra/util/LightManager.java
+++ b/core/src/com/projectkorra/projectkorra/util/LightManager.java
@@ -136,9 +136,10 @@ public class LightManager {
             public void run() {
                 currentBrightness--;
                 if (currentBrightness > 0) {
-                    sendLightChange(lightData.location, currentBrightness, lightData.observers);
+                    ThreadUtil.ensureLocation(lightData.location,
+                            () -> sendLightChange(lightData.location, currentBrightness, lightData.observers));
                 } else {
-                    revertLight(lightData);
+                    ThreadUtil.ensureLocation(lightData.location, () -> revertLight(lightData));
                     taskHolder.future.cancel(false);
                 }
             }
@@ -170,7 +171,7 @@ public class LightManager {
         while ((blockChange = blockChangeQueue.poll()) != null) {
             Player player = blockChange.getPlayer();
             BlockChange finalBlockChange = blockChange;
-            ThreadUtil.runAsync(() -> {
+            ThreadUtil.ensureLocation(finalBlockChange.location, () -> {
                 player.sendBlockChange(finalBlockChange.getLocation(), finalBlockChange.getBlockData());
             });
         }

--- a/core/src/com/projectkorra/projectkorra/util/LightManager.java
+++ b/core/src/com/projectkorra/projectkorra/util/LightManager.java
@@ -170,7 +170,7 @@ public class LightManager {
         while ((blockChange = blockChangeQueue.poll()) != null) {
             Player player = blockChange.getPlayer();
             BlockChange finalBlockChange = blockChange;
-            Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, () -> {
+            ThreadUtil.runAsync(() -> {
                 player.sendBlockChange(finalBlockChange.getLocation(), finalBlockChange.getBlockData());
             });
         }

--- a/core/src/com/projectkorra/projectkorra/util/MovementHandler.java
+++ b/core/src/com/projectkorra/projectkorra/util/MovementHandler.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.CoreAbility;
@@ -24,8 +23,8 @@ public class MovementHandler {
 	public static Set<MovementHandler> handlers = new HashSet<>();
 
 	private final LivingEntity entity;
-	private BukkitRunnable runnable, msg;
-	private ResetTask reset = null;
+	private Object task;
+	private Runnable reset = null;
 	private final CoreAbility ability;
 
 	public MovementHandler(final LivingEntity entity, final CoreAbility ability) {
@@ -49,39 +48,23 @@ public class MovementHandler {
 		if (this.entity instanceof Player) {
 			final long start = System.currentTimeMillis();
 			final Player player = (Player) this.entity;
-			this.runnable = new BukkitRunnable() {
-
-				@Override
-				public void run() {
-					ChatUtil.sendActionBar(message, player);
-					if (System.currentTimeMillis() >= start + duration / 20 * 1000) {
-						MovementHandler.this.reset();
-					}
-				}
-
-			};
-			this.runnable.runTaskTimer(ProjectKorra.plugin, 0, 1);
-		} else {
-			this.runnable = new BukkitRunnable() {
-
-				@Override
-				public void run() {
+			this.task = ThreadUtil.ensureEntityTimer(this.entity, () -> {
+				ChatUtil.sendActionBar(message, player);
+				if (System.currentTimeMillis() >= start + duration * 50) {
 					MovementHandler.this.reset();
 				}
-
-			};
-			new BukkitRunnable() {
-
-				@Override
-				public void run() {
-					if (MovementHandler.this.entity.isOnGround()) {
-						MovementHandler.this.entity.setAI(false);
-						this.cancel();
-						MovementHandler.this.runnable.runTaskLater(ProjectKorra.plugin, duration);
-					}
+			}, 0, 1);
+		} else {
+			this.task = ThreadUtil.ensureEntityTimer(this.entity, () -> {
+				//This will be a repeating task until the entity hits the ground. Once
+				//they hit the ground, the task repeating task will be cancelled and the entity will
+				//be stopped for the duration.
+				if (MovementHandler.this.entity.isOnGround()) {
+					MovementHandler.this.entity.setAI(false);
+					ThreadUtil.cancelTimerTask(MovementHandler.this.task);
+					ThreadUtil.ensureEntityDelay(MovementHandler.this.entity, MovementHandler.this::reset, duration);
 				}
-
-			}.runTaskTimer(ProjectKorra.plugin, 0, 1);
+			}, 0, 1);
 		}
 	}
 
@@ -96,44 +79,28 @@ public class MovementHandler {
 		this.entity.setMetadata("movement:stop", new FixedMetadataValue(ProjectKorra.plugin, this.ability));
 		if (this.entity instanceof Player) {
 			final Player player = (Player) this.entity;
-			this.msg = new BukkitRunnable() {
-
-				@Override
-				public void run() {
-					ChatUtil.sendActionBar(message, player);
-				}
-
-			};
-			this.msg.runTaskTimer(ProjectKorra.plugin, 0, 1);
+			this.task = ThreadUtil.ensureEntityTimer(this.entity,
+					() -> ChatUtil.sendActionBar(message, player)
+			, 0, 1);
 		} else {
-			new BukkitRunnable() {
-
-				@Override
-				public void run() {
-					if (MovementHandler.this.entity.isOnGround()) {
-						MovementHandler.this.entity.setAI(false);
-						this.cancel();
-					}
+			this.task = ThreadUtil.ensureEntityTimer(this.entity, () -> {
+				//This will be a repeating task until the entity hits the ground. Once
+				//they hit the ground, the task repeating task will be cancelled and the entity will
+				//be stopped for the duration.
+				if (MovementHandler.this.entity.isOnGround()) {
+					MovementHandler.this.entity.setAI(false);
+					ThreadUtil.cancelTimerTask(MovementHandler.this.task);
 				}
-
-			}.runTaskTimer(ProjectKorra.plugin, 0, 1);
+			}, 0, 1);
 		}
-		this.runnable = null;
 	}
 
 	/**
-	 * Resets any stopped movements and runs the {@link ResetTask} if able.
+	 * Resets any stopped movements and runs the {@link Runnable} if able.
 	 */
 	public void reset() {
-		if (this.runnable != null) {
-			try {
-				this.runnable.cancel();
-			} catch (final IllegalStateException e) { //if a player hasn't landed on the ground yet this runnable wont be scheduled, and will give an error on server shutdown
-				this.runnable = null;
-			}
-		}
-		if (this.msg != null) {
-			this.msg.cancel();
+		if (this.task != null) {
+			ThreadUtil.cancelTimerTask(this.task);
 		}
 		if (!(this.entity instanceof Player)) {
 			this.entity.setAI(true);
@@ -154,19 +121,8 @@ public class MovementHandler {
 		return this.entity;
 	}
 
-	public void setResetTask(final ResetTask reset) {
+	public void setResetTask(final Runnable reset) {
 		this.reset = reset;
-	}
-
-	/**
-	 * Functional interface, called when the entity is allowed to move again,
-	 * therefore "reseting" it's AI
-	 *
-	 * @author Simplicitee
-	 *
-	 */
-	public interface ResetTask {
-		public void run();
 	}
 
 	/**
@@ -180,11 +136,11 @@ public class MovementHandler {
 	}
 
 	/**
-	 * Resets all instances of MovementHandler
+	 * Resets all instances of MovementHandler. Thread safe.
 	 */
 	public static void resetAll() {
 		for (final MovementHandler handler : handlers) {
-			handler.reset();
+			ThreadUtil.ensureEntity(handler.entity, handler::reset);
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/util/PaperLib.java
+++ b/core/src/com/projectkorra/projectkorra/util/PaperLib.java
@@ -1,0 +1,142 @@
+package com.projectkorra.projectkorra.util;
+
+import com.projectkorra.projectkorra.ProjectKorra;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * PaperLib is a utility class that provides asynchronous methods for chunk
+ * loading and teleportation, depending on the server environment (Spigot,
+ * Paper, or Folia).
+ * <br><br>
+ * Instead of using Paper's official (but outdated) PaperLib, this class is
+ * an updated version that works with the latest versions of Paper as well as Folia.
+ * However, a lot of the methods in PaperLib that aren't required by ProjectKorra were
+ * not ported over.
+ */
+public class PaperLib {
+
+    private static Environment ENVIRONMENT;
+
+    static {
+        if (ProjectKorra.isFolia()) {
+            ENVIRONMENT = new Folia();
+        } else if (ProjectKorra.isPaper()) {
+            ENVIRONMENT = new Paper();
+        } else {
+            ENVIRONMENT = new Spigot();
+        }
+    }
+
+    /**
+     * Asynchronously gets the chunk at the specified location.
+     *
+     * @param location The location to get the chunk at.
+     * @return A CompletableFuture that will complete with the chunk at the
+     *         specified location.
+     */
+    public static CompletableFuture<Chunk> getChunkAtAsync(Location location) {
+        return ENVIRONMENT.getChunkAtAsync(location);
+    }
+
+    /**
+     * Asynchronously gets the chunk at the specified block.
+     *
+     * @param block The block to get the chunk at.
+     * @return A CompletableFuture that will complete with the chunk at the
+     *         specified block.
+     */
+    public static CompletableFuture<Chunk> getChunkAtAsync(Block block) {
+        return ENVIRONMENT.getChunkAtAsync(block);
+    }
+
+    /**
+     * Asynchronously teleports the specified entity to the specified location.
+     *
+     * @param entity   The entity to teleport.
+     * @param location The location to teleport the entity to.
+     * @return A CompletableFuture that will complete with true if the teleport
+     *         was successful, false otherwise.
+     */
+    public static CompletableFuture<Boolean> teleportAsync(Entity entity, Location location) {
+        return ENVIRONMENT.teleportAsync(entity, location);
+    }
+
+    /**
+     * Asynchronously teleports the specified entity to the specified location
+     * with the specified teleport cause.
+     *
+     * @param entity The entity to teleport.
+     * @param location The location to teleport the entity to.
+     * @param cause The cause of the teleportation.
+     * @return A CompletableFuture that will complete with true if the teleport
+     *         was successful, false otherwise.
+     */
+    public static CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+        return ENVIRONMENT.teleportAsync(entity, location, cause);
+    }
+
+    private interface Environment {
+        default CompletableFuture<Chunk> getChunkAtAsync(Location location) {
+            return getChunkAtAsync(location.getBlock());
+        }
+
+        CompletableFuture<Chunk> getChunkAtAsync(Block block);
+
+        default CompletableFuture<Boolean> teleportAsync(Entity entity, Location location) {
+            return teleportAsync(entity, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+        }
+
+        CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause);
+    }
+
+    static class Spigot implements Environment {
+
+        @Override
+        public CompletableFuture<Chunk> getChunkAtAsync(Block block) {
+            return CompletableFuture.completedFuture(block.getChunk());
+        }
+
+        @Override
+        public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+            entity.teleport(location, cause);
+            return CompletableFuture.completedFuture(true);
+        }
+    }
+
+    static class Paper implements Environment {
+
+        @Override
+        public CompletableFuture<Chunk> getChunkAtAsync(Block block) {
+            return block.getWorld().getChunkAtAsync(block);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+            return entity.teleportAsync(location, cause);
+        }
+    }
+
+    static class Folia implements Environment {
+
+        @Override
+        public CompletableFuture<Chunk> getChunkAtAsync(Block block) {
+            CompletableFuture<Chunk> future = new CompletableFuture<>();
+            ThreadUtil.ensureLocation(block.getLocation(), () -> {
+                Chunk chunk = block.getWorld().getChunkAt(block);
+                future.complete(chunk);
+            });
+            return future;
+        }
+
+        @Override
+        public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+            return entity.teleportAsync(location, cause);
+        }
+    }
+}

--- a/core/src/com/projectkorra/projectkorra/util/PlayerThreadMonitor.java
+++ b/core/src/com/projectkorra/projectkorra/util/PlayerThreadMonitor.java
@@ -1,0 +1,38 @@
+package com.projectkorra.projectkorra.util;
+
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.util.PassiveManager;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+
+public class PlayerThreadMonitor implements Runnable {
+
+    private Player player;
+    private Location oldLocation;
+
+    public PlayerThreadMonitor(Player player) {
+        this.player = player;
+    }
+
+    @Override
+    public void run() {
+
+        if (!player.isOnline()) {
+            ProjectKorra.log.info("Player is no longer online! Player: " + player.getName());
+            return;
+        }
+
+        if (this.oldLocation != null && !Bukkit.isOwnedByCurrentRegion(oldLocation)) {
+            ProjectKorra.log.info(player.getName() + " changed regions. Restarting passives.");
+            onChangeRegion();
+        }
+
+        this.oldLocation = player.getLocation();
+    }
+
+    public void onChangeRegion() {
+        PassiveManager.registerPassives(this.player);
+    }
+}

--- a/core/src/com/projectkorra/projectkorra/util/RevertChecker.java
+++ b/core/src/com/projectkorra/projectkorra/util/RevertChecker.java
@@ -17,8 +17,6 @@ import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.EarthAbility;
 import com.projectkorra.projectkorra.configuration.ConfigManager;
 
-import io.papermc.lib.PaperLib;
-
 public class RevertChecker implements Runnable {
 
 	private final ProjectKorra plugin;
@@ -44,7 +42,7 @@ public class RevertChecker implements Runnable {
 
 	public static void revertEarthBlocks() {
 		for (final Block block : earthRevertQueue.keySet()) {
-			PaperLib.getChunkAtAsync(block.getLocation()).thenAccept(result -> ThreadUtil.ensureLocation(block.getLocation(), () -> EarthAbility.revertBlock(block)));
+			PaperLib.getChunkAtAsync(block.getLocation()).thenAccept(result -> EarthAbility.revertBlock(block));
 			earthRevertQueue.remove(block);
 		}
 	}
@@ -74,9 +72,6 @@ public class RevertChecker implements Runnable {
 		if (config.getBoolean("Properties.Earth.RevertEarthbending")) {
 
 			try {
-				this.returnFuture = this.plugin.getServer().getScheduler().callSyncMethod(this.plugin, new getOccupiedChunks(this.plugin.getServer()));
-				final Set<Map<String, Integer>> chunks = this.returnFuture.get();
-
 				final Map<Block, Information> earth = new HashMap<>(EarthAbility.getMovedEarth());
 
 				for (final Block block : earth.keySet()) {
@@ -86,11 +81,7 @@ public class RevertChecker implements Runnable {
 
 					final Information info = earth.get(block);
 
-					final Map<String, Integer> chunkcoord = new HashMap<>();
-					chunkcoord.put("x", block.getX() >> 4);
-					chunkcoord.put("z", block.getZ() >> 4);
-
-					if (this.time > (info.getTime() + config.getLong("Properties.Earth.RevertCheckTime")) && !(chunks.contains(chunkcoord) && safeRevert)) {
+					if (this.time > (info.getTime() + config.getLong("Properties.Earth.RevertCheckTime"))) {
 						this.addToRevertQueue(block);
 					}
 				}
@@ -103,13 +94,8 @@ public class RevertChecker implements Runnable {
 					}
 
 					final Information info = air.get(i);
-					final Block block = info.getBlock();
 
-					final Map<String, Integer> chunkcoord = new HashMap<>();
-					chunkcoord.put("x", block.getX() >> 4);
-					chunkcoord.put("z", block.getZ() >> 4);
-
-					if (this.time > (info.getTime() + config.getLong("Properties.Earth.RevertCheckTime")) && !(chunks.contains(chunkcoord) && safeRevert)) {
+					if (this.time > (info.getTime() + config.getLong("Properties.Earth.RevertCheckTime"))) {
 						this.addToAirRevertQueue(i);
 					}
 				}
@@ -118,29 +104,4 @@ public class RevertChecker implements Runnable {
 			}
 		}
 	}
-
-	private class getOccupiedChunks implements Callable<Set<Map<String, Integer>>> {
-		private final Server server;
-
-		public getOccupiedChunks(final Server server) {
-			this.server = server;
-		}
-
-		@Override
-		public Set<Map<String, Integer>> call() {
-			final Set<Map<String, Integer>> chunks = new HashSet<>();
-
-			for (final Player player : this.server.getOnlinePlayers()) {
-				final Map<String, Integer> chunkcoord = new HashMap<>();
-				chunkcoord.put("x", player.getLocation().getBlockX() >> 4);
-				chunkcoord.put("z", player.getLocation().getBlockZ() >> 4);
-
-				chunks.add(chunkcoord);
-			}
-
-			return chunks;
-
-		}
-	}
-
 }

--- a/core/src/com/projectkorra/projectkorra/util/RevertChecker.java
+++ b/core/src/com/projectkorra/projectkorra/util/RevertChecker.java
@@ -36,14 +36,15 @@ public class RevertChecker implements Runnable {
 
 	public static void revertAirBlocks() {
 		for (final int ID : airRevertQueue.keySet()) {
-			PaperLib.getChunkAtAsync(EarthAbility.getTempAirLocations().get(ID).getState().getBlock().getLocation()).thenAccept(result -> EarthAbility.revertAirBlock(ID));
+			PaperLib.getChunkAtAsync(EarthAbility.getTempAirLocations().get(ID).getState().getBlock().getLocation())
+					.thenAccept(result -> EarthAbility.revertAirBlock(ID));
 			RevertChecker.airRevertQueue.remove(ID);
 		}
 	}
 
 	public static void revertEarthBlocks() {
 		for (final Block block : earthRevertQueue.keySet()) {
-			PaperLib.getChunkAtAsync(block.getLocation()).thenAccept(result -> EarthAbility.revertBlock(block));
+			PaperLib.getChunkAtAsync(block.getLocation()).thenAccept(result -> ThreadUtil.ensureLocation(block.getLocation(), () -> EarthAbility.revertBlock(block)));
 			earthRevertQueue.remove(block);
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/util/TempArmor.java
+++ b/core/src/com/projectkorra/projectkorra/util/TempArmor.java
@@ -260,7 +260,7 @@ public class TempArmor {
 			while (!queue.isEmpty()) {
 				final TempArmor tarmor = queue.peek();
 				if (System.currentTimeMillis() >= tarmor.getStartTime() + tarmor.getDuration()) {
-					tarmor.revert();
+					ThreadUtil.ensureEntity(tarmor.getEntity(), tarmor::revert);
 				} else {
 					break;
 				}
@@ -276,7 +276,7 @@ public class TempArmor {
 		for (final LivingEntity entity : INSTANCES.keySet()) {
 			while (!INSTANCES.get(entity).isEmpty()) {
 				final TempArmor armor = INSTANCES.get(entity).poll();
-				armor.revert();
+				ThreadUtil.ensureEntity(armor.getEntity(), armor::revert);
 			}
 		}
 	}

--- a/core/src/com/projectkorra/projectkorra/util/TempArmorStand.java
+++ b/core/src/com/projectkorra/projectkorra/util/TempArmorStand.java
@@ -36,7 +36,7 @@ public class TempArmorStand {
 	 */
 	public static void removeAll() {
 		for (final TempArmorStand temp : tempStands) {
-			temp.getArmorStand().remove();
+			ThreadUtil.ensureEntity(temp.getArmorStand(), () -> temp.getArmorStand().remove());
 		}
 		tempStands.clear();
 	}

--- a/core/src/com/projectkorra/projectkorra/util/TempBlock.java
+++ b/core/src/com/projectkorra/projectkorra/util/TempBlock.java
@@ -1,10 +1,8 @@
 package com.projectkorra.projectkorra.util;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +11,6 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.projectkorra.projectkorra.ability.Ability;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
@@ -30,9 +27,6 @@ import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.Snowable;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ProjectKorra;
-
-import io.papermc.lib.PaperLib;
 
 public class TempBlock {
 

--- a/core/src/com/projectkorra/projectkorra/util/TempFallingBlock.java
+++ b/core/src/com/projectkorra/projectkorra/util/TempFallingBlock.java
@@ -8,12 +8,19 @@ import org.bukkit.entity.FallingBlock;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+/**
+ * TempFallingBlock is a utility class that allows for the creation and management of temporary falling blocks in Minecraft.
+ * It provides methods to create, manage, and remove falling blocks, as well as to check if a falling block is a TempFallingBlock.
+ */
 public class TempFallingBlock {
     public static ConcurrentHashMap<FallingBlock, TempFallingBlock> instances = new ConcurrentHashMap<>();
+    public static ConcurrentHashMap<CoreAbility, Set<TempFallingBlock>> instancesByAbility = new ConcurrentHashMap<>();
 
     private FallingBlock fallingblock;
     private CoreAbility ability;
@@ -33,6 +40,11 @@ public class TempFallingBlock {
         this.creation = System.currentTimeMillis();
         this.expire = expire;
         instances.put(fallingblock, this);
+        if (!instancesByAbility.containsKey(ability)) {
+            instancesByAbility.put(ability, new HashSet<>());
+        }
+        instancesByAbility.get(ability).add(this);
+
     }
 
     public static void manage() {
@@ -54,43 +66,71 @@ public class TempFallingBlock {
         return null;
     }
 
+    /**
+     * Check if the falling block is a TempFallingBlock.
+     * @param fallingblock The falling block to check.
+     * @return True if the falling block is a TempFallingBlock, false otherwise.
+     */
     public static boolean isTempFallingBlock(FallingBlock fallingblock) {
         return instances.containsKey(fallingblock);
     }
 
+    /**
+     * Remove a TempFallingBlock from the world.
+     * @param fallingblock The falling block to remove.
+     */
     public static void removeFallingBlock(FallingBlock fallingblock) {
         if (isTempFallingBlock(fallingblock)) {
-            fallingblock.remove();
+            TempFallingBlock tempFallingBlock = instances.get(fallingblock);
+            ThreadUtil.ensureEntity(fallingblock, fallingblock::remove);
             instances.remove(fallingblock);
-        }
-    }
-
-    public static void removeAllFallingBlocks() {
-        for (FallingBlock fallingblock : instances.keySet()) {
-            fallingblock.remove();
-            instances.remove(fallingblock);
-        }
-    }
-
-    public static List<TempFallingBlock> getFromAbility(CoreAbility ability) {
-        List<TempFallingBlock> tfbs = new ArrayList<TempFallingBlock>();
-        for (TempFallingBlock tfb : instances.values()) {
-            if (tfb.getAbility().equals(ability)) {
-                tfbs.add(tfb);
+            instancesByAbility.get(tempFallingBlock.ability).remove(tempFallingBlock);
+            if (instancesByAbility.get(tempFallingBlock.ability).isEmpty()) {
+                instancesByAbility.remove(tempFallingBlock.ability);
             }
         }
-        return tfbs;
     }
 
+    /**
+     * Remove all TempFallingBlocks from the world.
+     */
+    public static void removeAllFallingBlocks() {
+        for (FallingBlock fallingblock : instances.keySet()) {
+            ThreadUtil.ensureEntity(fallingblock, fallingblock::remove);
+        }
+        instances.clear();
+        instancesByAbility.clear();
+    }
+
+    /**
+     * Get all TempFallingBlocks associated with a specific ability.
+     * @param ability The ability to get TempFallingBlocks for.
+     * @return A set of TempFallingBlocks associated with the ability.
+     */
+    public static Set<TempFallingBlock> getFromAbility(CoreAbility ability) {
+        return instancesByAbility.getOrDefault(ability, new HashSet<>());
+    }
+
+    /**
+     * Remove this TempFallingBlock from the world.
+     */
     public void remove() {
-        fallingblock.remove();
+        ThreadUtil.ensureEntity(fallingblock, fallingblock::remove);
         instances.remove(fallingblock);
     }
 
+    /**
+     * Get the falling block associated with this TempFallingBlock.
+     * @return The falling block.
+     */
     public FallingBlock getFallingBlock() {
         return fallingblock;
     }
 
+    /**
+     * Get the ability associated with this TempFallingBlock.
+     * @return The ability.
+     */
     public CoreAbility getAbility() {
         return ability;
     }
@@ -119,16 +159,30 @@ public class TempFallingBlock {
         return expire;
     }
 
+    /**
+     * This method is called automatically when the falling block tries to be
+     * placed in the world. It will call the onPlace consumer if it is set.
+     */
     public void tryPlace() {
         if (onPlace != null) {
             onPlace.accept(this);
         }
     }
 
+    /**
+     * Get the onPlace callback for this TempFallingBlock. This will be called
+     * when the falling block tries to be placed in the world.
+     * @return The onPlace consumer, or null.
+     */
     public Consumer<TempFallingBlock> getOnPlace() {
         return onPlace;
     }
 
+    /**
+     * Set the onPlace callback for this TempFallingBlock. This will be called
+     * when the falling block tries to be placed in the world.
+     * @param onPlace The consumer to set.
+     */
     public void setOnPlace(Consumer<TempFallingBlock> onPlace) {
         this.onPlace = onPlace;
     }

--- a/core/src/com/projectkorra/projectkorra/util/TempPotionEffect.java
+++ b/core/src/com/projectkorra/projectkorra/util/TempPotionEffect.java
@@ -3,6 +3,8 @@ package com.projectkorra.projectkorra.util;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.projectkorra.projectkorra.ProjectKorra;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.potion.PotionEffect;
 
@@ -14,6 +16,7 @@ public class TempPotionEffect {
 	private int ID = Integer.MIN_VALUE;
 	private final Map<Integer, PotionInfo> infos = new ConcurrentHashMap<Integer, PotionInfo>();
 	private final LivingEntity entity;
+	private Object foliaTask;
 
 	public TempPotionEffect(final LivingEntity entity, final PotionEffect effect) {
 		this(entity, effect, System.currentTimeMillis());
@@ -28,6 +31,12 @@ public class TempPotionEffect {
 		} else {
 			this.infos.put(this.ID++, new PotionInfo(starttime, effect));
 			instances.put(entity, this);
+		}
+
+		if (ProjectKorra.isFolia()) {
+			this.foliaTask = entity.getScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> {
+				this.progress();
+			}, ()-> {}, 1, 1);
 		}
 	}
 
@@ -78,6 +87,9 @@ public class TempPotionEffect {
 		}
 		if (this.infos.isEmpty() && instances.containsKey(this.entity)) {
 			instances.remove(this.entity);
+			if (ProjectKorra.isFolia()) {
+				((ScheduledTask)this.foliaTask).cancel();
+			}
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/util/ThreadUtil.java
+++ b/core/src/com/projectkorra/projectkorra/util/ThreadUtil.java
@@ -1,0 +1,258 @@
+package com.projectkorra.projectkorra.util;
+
+import com.projectkorra.projectkorra.ProjectKorra;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class for ensuring that a task is run on the correct thread.
+ * Ensures compatibility between Folia and non-Folia servers. */
+public class ThreadUtil {
+
+    /**
+     * Runs a task on the same thread as an entity. On Spigot, this is the main
+     * thread. On Folia, this is the thread that the entity is on.<br><br>
+     *
+     * <b>NOTE:</b> On Folia, this will run the task <i>next</i> tick as it
+     * is impossible to immediately run a task on the same thread as an entity.
+     * This is because the task has to find what region the entity is in and
+     * wait for the next tick in that thread to begin.
+     * @param entity The entity to run the task on.
+     * @param runnable The task to run.
+     */
+    public static void ensureEntity(Entity entity, Runnable runnable) {
+        if (ProjectKorra.isFolia()) {
+            entity.getScheduler().execute(ProjectKorra.plugin, runnable, null, 1L);
+        } else {
+            if (Bukkit.isPrimaryThread()) {
+                runnable.run();
+                return;
+            }
+            Bukkit.getScheduler().runTask(ProjectKorra.plugin, runnable);
+        }
+    }
+
+    /**
+     * Runs a task on the same thread as an entity after a delay. On Spigot, this is the main
+     * thread. On Folia, this is the thread that the entity is on.
+     * @param entity The entity to run the task on.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     */
+    public static void ensureEntityDelay(Entity entity, Runnable runnable, long delay) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            entity.getScheduler().execute(ProjectKorra.plugin, runnable, null, delay);
+        } else {
+            Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, runnable, delay);
+        }
+    }
+
+    /**
+     * Runs a task on the same thread as an entity after a delay and repeats it until cancelled.
+     * On Spigot, this is the main thread. On Folia, this is the thread that the entity is on.
+     * @param entity The entity to run the task on.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     * @param repeat The delay in ticks between each repeat of the task.
+     */
+    public static Object ensureEntityTimer(Entity entity, Runnable runnable, long delay, long repeat) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            return entity.getScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> runnable.run(), null, delay, repeat);
+        } else {
+            return Bukkit.getScheduler().runTaskTimer(ProjectKorra.plugin, runnable, delay, repeat);
+        }
+    }
+
+    /**
+     * Runs a task on the same thread as a location. On Spigot, this is the main
+     * thread. On Folia, this is the thread that the location is in.
+     * @param location The location to run the task on.
+     * @param runnable The task to run.
+     */
+    public static void ensureLocation(Location location, Runnable runnable) {
+        if (ProjectKorra.isFolia()) {
+            RegionScheduler scheduler = Bukkit.getRegionScheduler();
+            scheduler.execute(ProjectKorra.plugin, location, runnable);
+        } else {
+            if (Bukkit.isPrimaryThread()) {
+                runnable.run();
+                return;
+            }
+            Bukkit.getScheduler().runTask(ProjectKorra.plugin, runnable);
+        }
+    }
+
+    /**
+     * Runs a task on the same thread as a location after a delay. On Spigot, this is the main
+     * thread. On Folia, this is the thread that the location is in.
+     * @param location The location to run the task on.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     */
+    public static void ensureLocationDelay(Location location, Runnable runnable, long delay) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            RegionScheduler scheduler = Bukkit.getRegionScheduler();
+            scheduler.runDelayed(ProjectKorra.plugin, location, (task) -> runnable.run(), delay);
+        } else {
+            Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, runnable, delay);
+        }
+    }
+
+    /**
+     * Runs a task on the same thread as a location after a delay and repeats it until cancelled.
+     * On Spigot, this is the main thread. On Folia, this is the thread that the location is in.
+     * @param location The location to run the task on.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     * @param repeat The delay in ticks between each repeat of the task.
+     * @return The task object that can be used to cancel the task. Is a
+     * {@link io.papermc.paper.threadedregions.scheduler.ScheduledTask} on Folia and a
+     * {@link org.bukkit.scheduler.BukkitTask} on Spigot.
+     */
+    public static Object ensureLocationTimer(Location location, Runnable runnable, long delay, long repeat) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            RegionScheduler scheduler = Bukkit.getRegionScheduler();
+            return scheduler.runAtFixedRate(ProjectKorra.plugin, location, (task) -> runnable.run(), delay, repeat);
+        } else {
+            return Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, runnable, delay);
+        }
+    }
+
+    /**
+     * Runs a task asynchronously.
+     * @param runnable The task to run.
+     */
+    public static void runAsync(Runnable runnable) {
+        if (ProjectKorra.isFolia()) {
+            Bukkit.getAsyncScheduler().runNow(ProjectKorra.plugin, (task) -> runnable.run());
+        } else {
+            Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, runnable);
+        }
+    }
+
+    /**
+     * Runs a task asynchronously after a delay.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     */
+    public static void runAsyncLater(Runnable runnable, long delay) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            Bukkit.getAsyncScheduler().runDelayed(ProjectKorra.plugin, (task) -> runnable.run(), delay * 50, TimeUnit.MILLISECONDS);
+        } else {
+            Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, runnable, delay);
+        }
+    }
+
+    /**
+     * Runs a task asynchronously after a delay and repeats it until cancelled.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     * @param repeat The delay in ticks between each repeat of the task.
+     */
+    public static Object runAsyncTimer(Runnable runnable, long delay, long repeat) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            return Bukkit.getAsyncScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> runnable.run(), delay * 50, repeat * 50, TimeUnit.MILLISECONDS);
+        } else {
+            return Bukkit.getScheduler().runTaskTimerAsynchronously(ProjectKorra.plugin, runnable, delay, repeat);
+        }
+    }
+
+    /**
+     * Runs a task synchronously. On Spigot, this is on the main thread. On Folia,
+     * this is on the global region thread.
+     * @param runnable The task to run.
+     */
+    public static void runSync(Runnable runnable) {
+        if (ProjectKorra.isFolia()) {
+            Bukkit.getGlobalRegionScheduler().run(ProjectKorra.plugin, (task) -> runnable.run());
+        } else {
+            Bukkit.getScheduler().runTask(ProjectKorra.plugin, runnable);
+        }
+    }
+
+    /**
+     * Runs a task synchronously after a delay. On Spigot, this is on the main thread.
+     * On Folia, this is on the global region thread.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     * @return The task object that can be used to cancel the task. Is a
+     * {@link io.papermc.paper.threadedregions.scheduler.ScheduledTask} on Folia and a
+     * {@link org.bukkit.scheduler.BukkitTask} on Spigot.
+     */
+    public static Object runSyncLater(Runnable runnable, long delay) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            return Bukkit.getGlobalRegionScheduler().runDelayed(ProjectKorra.plugin, (task) -> runnable.run(), delay);
+        } else {
+            return  Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, runnable, delay);
+        }
+    }
+
+    /**
+     * Runs a task synchronously after a delay and repeats it until cancelled.
+     * On Spigot, this is on the main thread. On Folia, this is on the global region thread.
+     * @param runnable The task to run.
+     * @param delay The delay in ticks before running the task.
+     * @param repeat The delay in ticks between each repeat of the task.
+     */
+    public static Object runSyncTimer(Runnable runnable, long delay, long repeat) {
+        delay = Math.max(1, delay);
+        if (ProjectKorra.isFolia()) {
+            return Bukkit.getGlobalRegionScheduler().runAtFixedRate(ProjectKorra.plugin, (task) -> runnable.run(), delay, repeat);
+        } else {
+            return Bukkit.getScheduler().runTaskTimer(ProjectKorra.plugin, runnable, delay, repeat);
+        }
+    }
+
+    /**
+     * Cancels a task that was created with {@link #ensureLocationTimer(Location, Runnable, long, long)}
+     * or {@link #ensureEntityTimer(Entity, Runnable, long, long)}.
+     * @param task The task to cancel. This is the object returned from
+     * {@link #ensureLocationTimer(Location, Runnable, long, long)} or
+     *             {@link #ensureEntityTimer(Entity, Runnable, long, long)}.
+     * @return True if the task was cancelled successfully, false otherwise.
+     */
+    public static boolean cancelTimerTask(Object task) {
+        if (task == null) return false;
+
+        if (ProjectKorra.isFolia()) {
+            if (task instanceof io.papermc.paper.threadedregions.scheduler.ScheduledTask) {
+                ((io.papermc.paper.threadedregions.scheduler.ScheduledTask) task).cancel();
+                return true;
+            }
+        } else {
+            if (task instanceof org.bukkit.scheduler.BukkitTask) {
+                ((org.bukkit.scheduler.BukkitTask) task).cancel();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if a task is cancelled.
+     * @return True if the task is cancelled, false otherwise.
+     */
+    public static boolean isTaskCancelled(Object task) {
+        if (ProjectKorra.isFolia()) {
+            if (task instanceof io.papermc.paper.threadedregions.scheduler.ScheduledTask) {
+                return ((io.papermc.paper.threadedregions.scheduler.ScheduledTask) task).isCancelled();
+            }
+        } else {
+            if (task instanceof org.bukkit.scheduler.BukkitTask) {
+                return ((org.bukkit.scheduler.BukkitTask) task).isCancelled();
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/com/projectkorra/projectkorra/util/ThreadUtil.java
+++ b/core/src/com/projectkorra/projectkorra/util/ThreadUtil.java
@@ -5,6 +5,7 @@ import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.TimeUnit;
 
@@ -26,6 +27,10 @@ public class ThreadUtil {
      */
     public static void ensureEntity(Entity entity, Runnable runnable) {
         if (ProjectKorra.isFolia()) {
+            if (Bukkit.isOwnedByCurrentRegion(entity)) {
+                runnable.run();
+                return;
+            }
             entity.getScheduler().execute(ProjectKorra.plugin, runnable, null, 1L);
         } else {
             if (Bukkit.isPrimaryThread()) {
@@ -77,6 +82,10 @@ public class ThreadUtil {
      */
     public static void ensureLocation(Location location, Runnable runnable) {
         if (ProjectKorra.isFolia()) {
+            if (Bukkit.isOwnedByCurrentRegion(location)) {
+                runnable.run();
+                return;
+            }
             RegionScheduler scheduler = Bukkit.getRegionScheduler();
             scheduler.execute(ProjectKorra.plugin, location, runnable);
         } else {
@@ -95,7 +104,7 @@ public class ThreadUtil {
      * @param runnable The task to run.
      * @param delay The delay in ticks before running the task.
      */
-    public static void ensureLocationDelay(Location location, Runnable runnable, long delay) {
+    public static void ensureLocationDelay(@NotNull Location location, Runnable runnable, long delay) {
         delay = Math.max(1, delay);
         if (ProjectKorra.isFolia()) {
             RegionScheduler scheduler = Bukkit.getRegionScheduler();

--- a/core/src/com/projectkorra/projectkorra/util/ThreadUtil.java
+++ b/core/src/com/projectkorra/projectkorra/util/ThreadUtil.java
@@ -27,7 +27,7 @@ public class ThreadUtil {
      */
     public static void ensureEntity(Entity entity, Runnable runnable) {
         if (ProjectKorra.isFolia()) {
-            if (Bukkit.isOwnedByCurrentRegion(entity)) {
+            if (Bukkit.isOwnedByCurrentRegion(entity) || Bukkit.isStopping()) {
                 runnable.run();
                 return;
             }
@@ -82,7 +82,7 @@ public class ThreadUtil {
      */
     public static void ensureLocation(Location location, Runnable runnable) {
         if (ProjectKorra.isFolia()) {
-            if (Bukkit.isOwnedByCurrentRegion(location)) {
+            if (Bukkit.isOwnedByCurrentRegion(location) || Bukkit.isStopping()) {
                 runnable.run();
                 return;
             }
@@ -141,6 +141,10 @@ public class ThreadUtil {
      */
     public static void runAsync(Runnable runnable) {
         if (ProjectKorra.isFolia()) {
+            if (Bukkit.isStopping()) {
+                runnable.run();
+                return;
+            }
             Bukkit.getAsyncScheduler().runNow(ProjectKorra.plugin, (task) -> runnable.run());
         } else {
             Bukkit.getScheduler().runTaskAsynchronously(ProjectKorra.plugin, runnable);
@@ -183,6 +187,10 @@ public class ThreadUtil {
      */
     public static void runSync(Runnable runnable) {
         if (ProjectKorra.isFolia()) {
+            if (Bukkit.isStopping()) {
+                runnable.run();
+                return;
+            }
             Bukkit.getGlobalRegionScheduler().run(ProjectKorra.plugin, (task) -> runnable.run());
         } else {
             Bukkit.getScheduler().runTask(ProjectKorra.plugin, runnable);

--- a/core/src/com/projectkorra/projectkorra/util/Updater.java
+++ b/core/src/com/projectkorra/projectkorra/util/Updater.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.net.URLConnection;
 
 import com.projectkorra.projectkorra.ProjectKorra;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -84,7 +85,8 @@ public class Updater {
 	}
 
 	private void runAsync(final Plugin plugin, final Runnable run) {
-		plugin.getServer().getScheduler().runTaskAsynchronously(plugin, run);
+		if (ProjectKorra.isFolia()) Bukkit.getAsyncScheduler().runNow(plugin, (task) -> run.run());
+		else plugin.getServer().getScheduler().runTaskAsynchronously(plugin, run);
 	}
 
 	/**

--- a/core/src/com/projectkorra/projectkorra/util/logging/LogFilter.java
+++ b/core/src/com/projectkorra/projectkorra/util/logging/LogFilter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;
 
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Bukkit;
 
 import com.projectkorra.projectkorra.ProjectKorra;
@@ -64,7 +65,7 @@ public class LogFilter implements Filter {
 		}
 
 		final String toRecord = recordString;
-		Bukkit.getScheduler().runTaskLater(ProjectKorra.plugin, (Runnable) () -> LogFilter.this.loggedRecords.add(toRecord), 10);
+		ThreadUtil.runAsyncLater(() -> LogFilter.this.loggedRecords.add(toRecord), 10);
 		return true;
 	}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -12,7 +13,6 @@ import org.bukkit.block.data.Levelled;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.GeneralMethods;
@@ -478,14 +478,8 @@ public class OctopusForm extends WaterAbility {
 		for (final TempBlock block : this.blocks) {
 			block.revertBlock();
 		}
-		new BukkitRunnable() {
+		ThreadUtil.ensureLocationDelay(this.sourceBlock.getLocation(), () -> OctopusForm.this.pc.remove(), 1000L);
 
-			@Override
-			public void run() {
-				OctopusForm.this.pc.remove();
-			}
-
-		}.runTaskLater(ProjectKorra.plugin, 1000);
 	}
 
 	private void returnWater() {

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import com.projectkorra.projectkorra.region.RegionProtection;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -513,12 +514,12 @@ public class SurgeWall extends WaterAbility {
 
 	public static void removeAllCleanup() {
 		for (final Block block : AFFECTED_BLOCKS.keySet()) {
-			TempBlock.revertBlock(block, Material.AIR);
+			ThreadUtil.ensureLocation(block.getLocation(), () -> TempBlock.revertBlock(block, Material.AIR));
 			AFFECTED_BLOCKS.remove(block);
 			WALL_BLOCKS.remove(block);
 		}
 		for (final Block block : WALL_BLOCKS.keySet()) {
-			TempBlock.revertBlock(block, Material.AIR);
+			ThreadUtil.ensureLocation(block.getLocation(), () -> TempBlock.revertBlock(block, Material.AIR));
 			AFFECTED_BLOCKS.remove(block);
 			WALL_BLOCKS.remove(block);
 		}

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
 import com.projectkorra.projectkorra.region.RegionProtection;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -450,12 +451,12 @@ public class SurgeWave extends WaterAbility {
 	public static void removeAllCleanup() {
 		for (final SurgeWave surgeWave : getAbilities(SurgeWave.class)) {
 			for (final Block block : surgeWave.waveBlocks.keySet()) {
-				block.setType(Material.AIR, false);
+				ThreadUtil.ensureLocation(block.getLocation(), () -> block.setType(Material.AIR, false));
 				surgeWave.waveBlocks.remove(block);
 			}
 			for (final Block block : surgeWave.frozenBlocks.keySet()) {
 				if (TempBlock.isTempBlock(block)) {
-					TempBlock.get(block).revertBlock();
+					ThreadUtil.ensureLocation(block.getLocation(), () -> TempBlock.get(block).revertBlock());
 				}
 			}
 		}

--- a/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -8,6 +8,7 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.bukkit.Location;
@@ -643,21 +644,19 @@ public class Torrent extends WaterAbility {
 		for (final TempBlock block : FROZEN_BLOCKS.keySet()) {
 			final Player player = FROZEN_BLOCKS.get(block).getLeft();
 			final BendingPlayer bPlayer = BendingPlayer.getBendingPlayer(player);
-			if (bPlayer == null) {
-				FROZEN_BLOCKS.remove(block);
-				continue;
-			} else if (block.getBlock().getType() != Material.ICE) {
-				FROZEN_BLOCKS.remove(block);
-				continue;
-			} else if (!player.isOnline()) {
-				thaw(block);
-				continue;
-			} else if (block.getBlock().getWorld() != player.getWorld()) {
-				thaw(block);
-				continue;
-			} else if (block.getLocation().distanceSquared(player.getLocation()) > CLEANUP_RANGE * CLEANUP_RANGE || !bPlayer.canBendIgnoreBindsCooldowns(getAbility("Torrent"))) {
-				thaw(block);
-			}
+			ThreadUtil.ensureLocation(block.getLocation(), () -> {
+				if (bPlayer == null) {
+					FROZEN_BLOCKS.remove(block);
+				} else if (block.getBlock().getType() != Material.ICE) {
+					FROZEN_BLOCKS.remove(block);
+				} else if (!player.isOnline()) {
+					thaw(block);
+				} else if (block.getBlock().getWorld() != player.getWorld()) {
+					thaw(block);
+				} else if (block.getLocation().distanceSquared(player.getLocation()) > CLEANUP_RANGE * CLEANUP_RANGE || !bPlayer.canBendIgnoreBindsCooldowns(getAbility("Torrent"))) {
+					thaw(block);
+				}
+			});
 		}
 	}
 

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.projectkorra.projectkorra.attribute.markers.DayNightFactor;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -15,7 +16,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import com.projectkorra.projectkorra.Element;
@@ -83,7 +83,6 @@ public class WaterSpoutWave extends WaterAbility {
 	private Location origin;
 	private Location location;
 	private ArrayList<Entity> affectedEntities;
-	private ArrayList<BukkitRunnable> tasks;
 	private ConcurrentHashMap<Block, TempBlock> affectedBlocks;
 
 	public WaterSpoutWave(final Player player, final AbilityType type) {
@@ -110,7 +109,6 @@ public class WaterSpoutWave extends WaterAbility {
 		this.trailRevertTime = getConfig().getLong("Abilities.Water.WaterSpout.Wave.TrailRevertTime");
 		this.affectedBlocks = new ConcurrentHashMap<>();
 		this.affectedEntities = new ArrayList<>();
-		this.tasks = new ArrayList<>();
 
 		if (!this.bPlayer.canBend(this) || bPlayer.isOnCooldown("WaterSpoutWave")) {
 			return;
@@ -314,12 +312,10 @@ public class WaterSpoutWave extends WaterAbility {
 							final Player fplayer = this.player;
 							final Entity fent = entity;
 
-							new BukkitRunnable() {
-								@Override
-								public void run() {
-									WaterSpoutWave.this.createIceSphere(fplayer, fent, iceSphereRadius);
-								}
-							}.runTaskLater(ProjectKorra.plugin, 6);
+							ThreadUtil.ensureLocationDelay(entity.getLocation(), () -> {
+								if (WaterSpoutWave.this.isRemoved()) return;
+								WaterSpoutWave.this.createIceSphere(fplayer, fent, iceSphereRadius);
+							}, 6);
 						}
 					}
 					for (final Block block : FROZEN_BLOCKS.keySet()) {
@@ -356,20 +352,13 @@ public class WaterSpoutWave extends WaterAbility {
 			this.bPlayer.addCooldown("WaterSpoutWave", getCooldown());
 		}
 		this.revertBlocks();
-		for (final BukkitRunnable task : this.tasks) {
-			task.cancel();
-		}
 	}
 
 	public void createBlockDelay(final Block block, final Material mat, final long delay) {
-		final BukkitRunnable br = new BukkitRunnable() {
-			@Override
-			public void run() {
-				WaterSpoutWave.this.createBlock(block, block.getLocation().distance(player.getLocation()) >= 1.6 ? mat : Material.WATER);
-			}
-		};
-		br.runTaskLater(ProjectKorra.plugin, delay);
-		this.tasks.add(br);
+		ThreadUtil.ensureLocationDelay(block.getLocation(), () -> {
+			if (WaterSpoutWave.this.isRemoved()) return;
+			WaterSpoutWave.this.createBlock(block, block.getLocation().distance(player.getLocation()) >= 1.6 ? mat : Material.WATER);
+		}, delay);
 	}
 
 	public void createBlock(final Block block, final Material mat) {
@@ -690,10 +679,6 @@ public class WaterSpoutWave extends WaterAbility {
 
 	public ArrayList<Entity> getAffectedEntities() {
 		return this.affectedEntities;
-	}
-
-	public ArrayList<BukkitRunnable> getTasks() {
-		return this.tasks;
 	}
 
 	public ConcurrentHashMap<Block, TempBlock> getAffectedBlocks() {

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArms.java
@@ -2,6 +2,7 @@ package com.projectkorra.projectkorra.waterbending.multiabilities;
 
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.ElementalAbility;
 import com.projectkorra.projectkorra.ability.FireAbility;
 import com.projectkorra.projectkorra.ability.WaterAbility;
@@ -14,6 +15,7 @@ import com.projectkorra.projectkorra.util.DamageHandler;
 import com.projectkorra.projectkorra.util.LightManager;
 import com.projectkorra.projectkorra.util.ParticleEffect;
 import com.projectkorra.projectkorra.util.TempBlock;
+import com.projectkorra.projectkorra.util.ThreadUtil;
 import com.projectkorra.projectkorra.waterbending.multiabilities.WaterArmsWhip.Whip;
 import com.projectkorra.projectkorra.waterbending.plant.PlantRegrowth;
 import com.projectkorra.projectkorra.waterbending.util.WaterReturn;
@@ -371,7 +373,7 @@ public class WaterArms extends WaterAbility {
 			final long time = WaterArmsSpear.getIceBlocks().get(block);
 			if (System.currentTimeMillis() > time || ignoreTime) {
 				if (TempBlock.isTempBlock(block)) {
-					TempBlock.revertBlock(block, Material.AIR);
+					ThreadUtil.ensureLocation(block.getLocation(), () -> TempBlock.revertBlock(block, Material.AIR));
 				}
 				WaterArmsSpear.getIceBlocks().remove(block);
 			}
@@ -430,17 +432,18 @@ public class WaterArms extends WaterAbility {
 
 	public static void progressAllCleanup() {
 		progressRevert(false);
+
 		/*
 		 * There is currently a bug where waterArms will display the arms and
 		 * then progressRevert will revert the same blocks in the same tick
 		 * before the user is able to see them, thus causing invisible arms.
 		 * Simple fix is just to display the arms again.
 		 */
+		if (ProjectKorra.isFolia()) return; //TODO The following code is NOT thread safe, so don't run it for now.
 		for (final WaterArms waterArms : getAbilities(WaterArms.class)) {
 			waterArms.displayLeftArm();
 			waterArms.displayRightArm();
 		}
-		WaterArmsWhip.progressAllCleanup();
 	}
 
 	public static void removeAllCleanup() {

--- a/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/multiabilities/WaterArmsWhip.java
@@ -378,10 +378,6 @@ public class WaterArmsWhip extends WaterAbility {
 		}
 	}
 
-	public static void checkValidEntities() {
-		GRABBED_ENTITIES.entrySet().removeIf(entry -> entry.getValue().isRemoved() || entry.getValue().grabbedEntity == null);
-	}
-
 	@Override
 	public void remove() {
 		super.remove();
@@ -400,10 +396,11 @@ public class WaterArmsWhip extends WaterAbility {
 
 			this.waterArms.setMaxUses(this.waterArms.getMaxUses() - 1);
 		}
-	}
 
-	public static void progressAllCleanup() {
-		checkValidEntities();
+		if (this.grabbedEntity != null) {
+			GRABBED_ENTITIES.remove(this.grabbedEntity);
+			this.grabbedEntity = null;
+		}
 	}
 
 	public static void removeAllCleanup() {

--- a/core/src/com/projectkorra/projectkorra/waterbending/util/WaterbendingManager.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/util/WaterbendingManager.java
@@ -16,7 +16,7 @@ public class WaterbendingManager implements Runnable {
 	@Override
 	public void run() {
 		// WaterPassive.handlePassive(); # Fast Swim is now managed in FastSwim.java.
-		Torrent.progressAllCleanup();
+		Torrent.progressAllCleanup(); //Folia compatible now
 		WaterArms.progressAllCleanup();
 		WaterSpoutWave.progressAllCleanup();
 	}

--- a/core/src/plugin.yml
+++ b/core/src/plugin.yml
@@ -2,6 +2,7 @@ name: ProjectKorra
 author: ProjectKorra
 api-version: 1.16
 version: ${project.version}
+folia-supported: true
 main: com.projectkorra.projectkorra.ProjectKorra
 softdepend: [GriefDefender, WorldGuard, WorldEdit, Factions, GriefPrevention, Towny, NoCheatPlus, LWC, Residence, RedProtect, PlaceholderAPI, Lands, Plan]
 commands:

--- a/luminol/pom.xml
+++ b/luminol/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.projectkorra</groupId>
+    <artifactId>projectkorra-parent</artifactId>
+    <version>1.12.1</version>
+  </parent>
+
+  <artifactId>luminol</artifactId>
+  <repositories>
+    <!-- local jar files, add more using: mvn install:install-file -Dfile=aaa.jar -DgroupId=aaa -DartifactId=aaa -Dversion=aaa -Dpackaging=jar -DlocalRepositoryPath=path/to/ProjectKorra/localrepo/ -->
+    <repository>
+      <id>project.local</id>
+      <name>project</name>
+      <url>file://${project.basedir}/localrepo/</url>
+    </repository>
+    <!-- Spigot Repo -->
+    <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+    </repository>
+    <!-- Paper Repo -->
+    <repository>
+      <id>papermc</id>
+      <url>https://repo.papermc.io/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>menthamc</id>
+      <url>https://repo.menthamc.com/repository/maven-public/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <!-- Spigot API -->
+    <dependency>
+      <groupId>me.earthme.luminol</groupId>
+      <artifactId>luminol-api</artifactId>
+      <version>1.21.4-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>clean package install</defaultGoal>
+    <finalName>${project.name}-${project.version}</finalName>
+    <sourceDirectory>${project.basedir}/src/</sourceDirectory>
+    <resources>
+      <resource>
+        <targetPath>.</targetPath>
+        <filtering>true</filtering>
+        <directory>${project.basedir}/src/</directory>
+        <includes>
+          <include>*.yml</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <outputDirectory>${dir}</outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <properties>
+    <dir>${project.build.directory}</dir>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/luminol/src/com/projectkorra/projectkorra/versions/LuminolIntermediate.java
+++ b/luminol/src/com/projectkorra/projectkorra/versions/LuminolIntermediate.java
@@ -1,0 +1,22 @@
+package com.projectkorra.projectkorra.versions;
+
+import me.earthme.luminol.api.ThreadedRegion;
+import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+
+public class LuminolIntermediate {
+
+    public static Object getRegion(Location location) {
+        return location.getWorld().getThreadedRegionizer().getAtSynchronized(location);
+    }
+
+    public static boolean isRegionActive(@NotNull Object region) {
+        //((ThreadedRegion) region).getWorld().getThreadedRegionizer().getAllRegions().forEach(r -> System.out.println(r));
+
+        return ((ThreadedRegion) region).getTickRegionData().getRegionStats().getPlayerCount() > 0;
+    }
+
+    public static long getRegionId(@NotNull Object region) {
+        return ((ThreadedRegion) region).getId();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.projectkorra</groupId>
     <artifactId>projectkorra-parent</artifactId>
-    <version>1.12.0</version>
+    <version>1.12.1</version>
     <name>ProjectKorra-Parent</name>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>core</module>
         <module>core-legacy</module>
         <module>core-modern</module>
+        <module>luminol</module>
     </modules>
 
     <build>


### PR DESCRIPTION
# Summary
Adds Folia support to ProjectKorra. The main change is a lot of scheduled tasks can no longer be run as they are and have to be run individually/per player. 

This does not break API for addons, and as long as addons do not use the Bukkit scheduler to delay tasks (which cannot be done in Folia), all addons will be inherently compatible.

Instead, if an addon needs to run a task on a delay, there is a new class to help with this.

# ThreadUtil class
This is a new class that will run a task with the appropriate scheduler, no matter if the server is running Folia or Spigot/Paper.

If you are unsure what one to use, if the ability affects blocks or the world, use `ensureLocation`. If it is for an entity/player, use `ensureEntity`.

- `ThreadUtil#ensureEntity(Entity, Runnable)` - Runs a task on an entity with no delay, if possible
- `ThreadUtil#ensureEntityDelay(Entity, Runnable, long)` - Runs a task after a specified amount of ticks on an entity.
- `ThreadUtil#ensureEntityTimer(Entity, Runnable, long, long)` - Runs a repeating task on an entity. Task is automatically cancelled when the entity is dead or no longer on the server.
- `ThreadUtil#ensureLocation(Location, Runnable)` - Runs a task at a location with no delay, if possible
- `ThreadUtil#ensureLocationDelay(Location, Runnable, long)` - Runs a task after a specified amount of ticks at a location
- `ThreadUtil#ensureLocationTimer(Entity, Runnable, long, long)` - Runs a repeating task at a location. Task is automatically cancelled when the location's chunk is unloading from memory

There are a few more methods for running stuff async and canceling the timers created from the methods above.

# Luminol and Issues
Due to the current limitations of the Folia API, Collisions will not work unless you use a fork of Folia called Luminol. This fork has additional API that is needed for collisions to work. Without running Luminol, ProjectKorra will work as normal without ability vs ability collisions.

Additionally, due to [this issue](https://github.com/PaperMC/Folia/issues/353) and [this issue](https://github.com/PaperMC/Folia/issues/358) in Folia, abilities will not revert before a server closes. Making some bending permanent. As a workaround, kick all players from the server, use `/b reload`, then stop the server instantly.

Finally, due to lack of Scoreboard API present in Folia, the bending board cannot natively run. Instead, PAPI placeholders have been added for the bending board so you can use a scoreboard plugin that uses packets to have the bending board. `%projectkorra_bb_slot1%` etc.

# PaperLib
PaperLib is incompatible with Folia, so instead, it has been recreated as a util class inside PK with support for Folia. As a result, the old paper lib is no longer shaded into PK. And a lot of methods we don't use are not included.

# ComboStream
A lot of runnables in the code had to be completely phased out. In their place, they are either lambdas, timer objects from ThreadUtil, or a new util class called ComboStream. ComboStream replaces FireComboStream and is a hidden ability class used to tick via `progress()` instead of being a BukkitRunnable. 