### PR TITLE
[FIX] EarthBenders receive fall damage when EarthPillars is disabled and hovered slot is Catapult

### DIFF
--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -943,7 +943,9 @@ public class PKListener implements Listener {
 				if (bPlayer.getBoundAbilityName().equalsIgnoreCase("Shockwave")) {
 					new Shockwave(player, true);
 				} else if (bPlayer.getBoundAbilityName().equalsIgnoreCase("Catapult")) {
-					new EarthPillars(player, true);
+					if (CoreAbility.getAbility(EarthPillars.class).isEnabled()) {
+						new EarthPillars(player, true);
+					}
 				}
 			}
 


### PR DESCRIPTION
## Fixes
* Fixes
    > * https://github.com/ProjectKorra/ProjectKorra/issues/1357

If a player would receive FallDamage while having the Earth element, the DensityShift passive would enable if falling on Earth-Bendable block. But if `EarthPillars` is disabled and `Catapult` is the hovered slot, the plugin tries to instantiate a `EarthPillars` instance which isn't possible due to it being disabled and it throws an exception in the event which leads to fall damage.

### How I fixed it
Simply check if EarthPillars is enabled before trying to instantiate it.