### PR TITLE
Relocate getSourceBlock method definition to abstract parents

### DIFF
--- a/core/src/com/projectkorra/projectkorra/ability/EarthAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/EarthAbility.java
@@ -86,6 +86,10 @@ public abstract class EarthAbility extends ElementalAbility {
 		return false;
 	}
 
+	public Block getSourceBlock() {
+		return null;
+	}
+
 	@Override
 	public void handleCollision(final Collision collision) {
 		super.handleCollision(collision);

--- a/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
+++ b/core/src/com/projectkorra/projectkorra/ability/WaterAbility.java
@@ -76,6 +76,10 @@ public abstract class WaterAbility extends ElementalAbility {
 		return false;
 	}
 
+	public Block getSourceBlock() {
+		return null;
+	}
+
 	@Override
 	public void handleCollision(final Collision collision) {
 		super.handleCollision(collision);

--- a/core/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/EarthArmor.java
@@ -692,6 +692,9 @@ public class EarthArmor extends EarthAbility {
 		this.interval = interval;
 	}
 
+	@Override
+	public Block getSourceBlock() { return getHeadBlock(); }
+
 	public Block getHeadBlock() {
 		return this.headBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
+++ b/core/src/com/projectkorra/projectkorra/earthbending/EarthBlast.java
@@ -672,6 +672,7 @@ public class EarthBlast extends EarthAbility {
 		this.firstDestination = firstDestination;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/OctopusForm.java
@@ -680,6 +680,7 @@ public class OctopusForm extends WaterAbility {
 		this.angleIncrement = angleIncrement;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWall.java
@@ -644,6 +644,7 @@ public class SurgeWall extends WaterAbility {
 		this.range = range;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/SurgeWave.java
@@ -624,6 +624,7 @@ public class SurgeWave extends WaterAbility {
 		this.maxFreezeRadius = maxFreezeRadius;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/Torrent.java
@@ -936,6 +936,7 @@ public class Torrent extends WaterAbility {
 		this.selectRange = selectRange;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterManipulation.java
@@ -741,6 +741,7 @@ public class WaterManipulation extends WaterAbility {
 		this.deflectRange = deflectRange;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/WaterSpoutWave.java
@@ -568,6 +568,9 @@ public class WaterSpoutWave extends WaterAbility {
 	}
 
 	@Override
+	public Block getSourceBlock() { return this.sourceBlock; }
+
+	@Override
 	public boolean isEnabled() {
 		return getConfig().getBoolean("Abilities.Water.WaterSpout.Wave.Enabled");
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/ice/IceBlast.java
@@ -451,6 +451,7 @@ public class IceBlast extends IceAbility {
 		this.deflectRange = deflectRange;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}

--- a/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
+++ b/core/src/com/projectkorra/projectkorra/waterbending/ice/IceSpikeBlast.java
@@ -555,6 +555,7 @@ public class IceSpikeBlast extends IceAbility {
 		this.deflectRange = deflectRange;
 	}
 
+	@Override
 	public Block getSourceBlock() {
 		return this.sourceBlock;
 	}


### PR DESCRIPTION
Made source blocks generically accessible.

## Additions
* Moved the definition of the `getSourceBlock()` methods (used in water and some earth abilities) to `WaterAbility` and `EarthAbility`.
    > * With this, it's easier for 3rd party code to retrieve an ability source without having the context of the ability's implementation.