### PR TITLE
Prevent bending board update when PlayerBindChangeEvent is cancelled

### DIFF
--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -2196,6 +2196,7 @@ public class PKListener implements Listener {
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onBindChange(final PlayerBindChangeEvent event) {
 		if (!event.isOnline()) return;
+		if (event.isCancelled()) return;
 		final Player player = (Player) event.getPlayer();
 		if (player == null) return;
 		if (event.isMultiAbility()) {


### PR DESCRIPTION
Adds a check to ensure the bending board respects PlayerBindChangeEvent cancellation. Fixes issue https://github.com/ProjectKorra/ProjectKorra/issues/1391