### PR TITLE
Preset Command Additions (Import/Export)

### DIFF
--- a/core/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -366,6 +366,8 @@ public class PresetCommand extends PKCommand {
 			l.add("delete");
 			l.add("list");
 			l.add("bind");
+			l.add("import");
+			l.add("export");
 			return l;
 		} else if (args.size() <= 1 && (Arrays.asList(new String[] { "delete", "d", "del", "bind", "b" }).contains(args.get(0).toLowerCase()))) {
 			final List<Preset> presets = Preset.presets.get(((Player) sender).getUniqueId());

--- a/core/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -51,11 +51,16 @@ public class PresetCommand extends PKCommand {
 	private final String cantEditBinds;
 	private final String playerNotFound;
 	private final String invalidName;
+	private final String exportFailed;
 	private final String exportSuccess;
 	private final String importSuccess;
 	private final String importFailed;
 	private final String exportHoverCode;
 	private final String exportHoverCommand;
+	private final String exportCommandButton;
+	private final String exportCodeButton;
+	private final String exportNotSpecified;
+	private final String importNotSpecified;
 
 	public PresetCommand() {
 		super("preset", "/bending preset <Bind/Create/Delete/List/Export/Import> [Preset]", ConfigManager.languageConfig.get().getString("Commands.Preset.Description"), new String[] { "preset", "presets", "pre", "set", "p" });
@@ -78,10 +83,15 @@ public class PresetCommand extends PKCommand {
 		this.playerNotFound = ConfigManager.languageConfig.get().getString("Commands.Preset.PlayerNotFound");
 		this.invalidName = ConfigManager.languageConfig.get().getString("Commands.Preset.InvalidName");
 		this.exportSuccess = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportSuccess");
+		this.exportFailed = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportFailed");
 		this.importSuccess = ConfigManager.languageConfig.get().getString("Commands.Preset.ImportSuccess");
 		this.importFailed = ConfigManager.languageConfig.get().getString("Commands.Preset.ImportFailed");
-		this.exportHoverCode = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportHoverCode");
-		this.exportHoverCommand = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportHoverCommand");
+		this.exportHoverCode = ConfigManager.languageConfig.get().getString("Commands.Preset.HoverCode");
+		this.exportHoverCommand = ConfigManager.languageConfig.get().getString("Commands.Preset.HoverCommand");
+		this.exportCommandButton = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportCommandButton");
+		this.exportCodeButton = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportCodeButton");
+		this.exportNotSpecified = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportNotSpecified");
+		this.importNotSpecified = ConfigManager.languageConfig.get().getString("Commands.Preset.ImportNotSpecified");
 	}
 
 	@Override
@@ -291,7 +301,7 @@ public class PresetCommand extends PKCommand {
 			Player player = (Player) sender;
 
 			if (args.size() < 2) {
-				ChatUtil.sendBrandingMessage(sender, ChatColor.RED + "Please specify a preset name to export.");
+				ChatUtil.sendBrandingMessage(sender, ChatColor.RED + this.exportNotSpecified);
 				return;
 			}
 
@@ -308,7 +318,7 @@ public class PresetCommand extends PKCommand {
 						.replace("{name}", ChatColor.YELLOW + name + ChatColor.GREEN)
 						.replace("{code}", ChatColor.AQUA + exportCode + ChatColor.GREEN);
 				ChatUtil.sendBrandingMessage(sender, ChatColor.GREEN + message);
-				TextComponent copyComponent = new TextComponent("[ Click to Copy Code ]");
+				TextComponent copyComponent = new TextComponent(this.exportCodeButton);
 				copyComponent.setColor(ChatColor.AQUA.asBungee());
 				copyComponent.setClickEvent(new ClickEvent(
 						ClickEvent.Action.COPY_TO_CLIPBOARD, exportCode));
@@ -316,7 +326,7 @@ public class PresetCommand extends PKCommand {
 						HoverEvent.Action.SHOW_TEXT,
 						new ComponentBuilder(this.exportHoverCode.replace("{code}", exportCode)).color(ChatColor.YELLOW.asBungee()).create()));
 				ChatUtil.sendBrandingMessage(sender, copyComponent);
-				TextComponent copyImportComponent = new TextComponent("[ Click to Copy Import Command ]");
+				TextComponent copyImportComponent = new TextComponent(this.exportCommandButton);
 				copyImportComponent.setColor(ChatColor.AQUA.asBungee());
 				copyImportComponent.setClickEvent(new ClickEvent(
 						ClickEvent.Action.COPY_TO_CLIPBOARD, "/bending preset import " + exportCode));
@@ -325,7 +335,7 @@ public class PresetCommand extends PKCommand {
 						new ComponentBuilder(this.exportHoverCommand).color(ChatColor.YELLOW.asBungee()).create()));
 				ChatUtil.sendBrandingMessage(sender, copyImportComponent);
 			} else {
-				ChatUtil.sendBrandingMessage(sender, ChatColor.RED + "Failed to export preset.");
+				ChatUtil.sendBrandingMessage(sender, ChatColor.RED + this.exportFailed);
 			}
 		}
 		else if (Arrays.asList(importaliases).contains(args.get(0)) && this.hasPermission(sender, "import")) { // bending preset import key.
@@ -333,7 +343,7 @@ public class PresetCommand extends PKCommand {
 			Player player = (Player) sender;
 
 			if (args.size() < 2) {
-				ChatUtil.sendBrandingMessage(sender, ChatColor.RED + "Please provide an import code.");
+				ChatUtil.sendBrandingMessage(sender, ChatColor.RED + this.importNotSpecified);
 				return;
 			}
 

--- a/core/src/com/projectkorra/projectkorra/command/PresetCommand.java
+++ b/core/src/com/projectkorra/projectkorra/command/PresetCommand.java
@@ -54,6 +54,8 @@ public class PresetCommand extends PKCommand {
 	private final String exportSuccess;
 	private final String importSuccess;
 	private final String importFailed;
+	private final String exportHoverCode;
+	private final String exportHoverCommand;
 
 	public PresetCommand() {
 		super("preset", "/bending preset <Bind/Create/Delete/List/Export/Import> [Preset]", ConfigManager.languageConfig.get().getString("Commands.Preset.Description"), new String[] { "preset", "presets", "pre", "set", "p" });
@@ -78,6 +80,8 @@ public class PresetCommand extends PKCommand {
 		this.exportSuccess = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportSuccess");
 		this.importSuccess = ConfigManager.languageConfig.get().getString("Commands.Preset.ImportSuccess");
 		this.importFailed = ConfigManager.languageConfig.get().getString("Commands.Preset.ImportFailed");
+		this.exportHoverCode = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportHoverCode");
+		this.exportHoverCommand = ConfigManager.languageConfig.get().getString("Commands.Preset.ExportHoverCommand");
 	}
 
 	@Override
@@ -304,15 +308,22 @@ public class PresetCommand extends PKCommand {
 						.replace("{name}", ChatColor.YELLOW + name + ChatColor.GREEN)
 						.replace("{code}", ChatColor.AQUA + exportCode + ChatColor.GREEN);
 				ChatUtil.sendBrandingMessage(sender, ChatColor.GREEN + message);
-				TextComponent copyComponent = new TextComponent("[ Click to Copy ]");
+				TextComponent copyComponent = new TextComponent("[ Click to Copy Code ]");
 				copyComponent.setColor(ChatColor.AQUA.asBungee());
-				copyComponent.setBold(true);
 				copyComponent.setClickEvent(new ClickEvent(
 						ClickEvent.Action.COPY_TO_CLIPBOARD, exportCode));
 				copyComponent.setHoverEvent(new HoverEvent(
 						HoverEvent.Action.SHOW_TEXT,
-						new ComponentBuilder("Copy code to clipboard").color(ChatColor.YELLOW.asBungee()).create()));
+						new ComponentBuilder(this.exportHoverCode.replace("{code}", exportCode)).color(ChatColor.YELLOW.asBungee()).create()));
 				ChatUtil.sendBrandingMessage(sender, copyComponent);
+				TextComponent copyImportComponent = new TextComponent("[ Click to Copy Import Command ]");
+				copyImportComponent.setColor(ChatColor.AQUA.asBungee());
+				copyImportComponent.setClickEvent(new ClickEvent(
+						ClickEvent.Action.COPY_TO_CLIPBOARD, "/bending preset import " + exportCode));
+				copyImportComponent.setHoverEvent(new HoverEvent(
+						HoverEvent.Action.SHOW_TEXT,
+						new ComponentBuilder(this.exportHoverCommand).color(ChatColor.YELLOW.asBungee()).create()));
+				ChatUtil.sendBrandingMessage(sender, copyImportComponent);
 			} else {
 				ChatUtil.sendBrandingMessage(sender, ChatColor.RED + "Failed to export preset.");
 			}
@@ -369,7 +380,7 @@ public class PresetCommand extends PKCommand {
 			l.add("import");
 			l.add("export");
 			return l;
-		} else if (args.size() <= 1 && (Arrays.asList(new String[] { "delete", "d", "del", "bind", "b" }).contains(args.get(0).toLowerCase()))) {
+		} else if (args.size() <= 1 && (Arrays.asList(new String[] { "delete", "d", "del", "bind", "b", "e", "export", "share" }).contains(args.get(0).toLowerCase()))) {
 			final List<Preset> presets = Preset.presets.get(((Player) sender).getUniqueId());
 			final List<String> presetNames = new ArrayList<>();
 			if (presets != null && presets.size() != 0) {

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -9,7 +9,13 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.EntityType;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class ConfigManager {
 
@@ -185,10 +191,13 @@ public class ConfigManager {
 			config.addDefault("Commands.Preset.Other.BendingPermanentlyRemoved", "That player's bending was permanently removed.");
 			config.addDefault("Commands.Preset.Other.SuccesfullyBoundConfirm", "The bound slots of {target} have been set to match the {name} preset.");
 			config.addDefault("Commands.Preset.External.NoPresetName", "No external preset found with that name.");
-			config.addDefault("Commands.Preset.External.ExportSuccess", "Preset {name} exported. Copy this code to share: {code}");
-			config.addDefault("Commands.Preset.External.ImportSuccess", "Successfully imported preset {name}");
-			config.addDefault("Commands.Preset.External.ImportFailed", "Failed to import preset. The code may be invalid or corrupted.");
-			config.addDefault("Commands.Preset.External.ImportExists", "A preset with that name already exists. Delete it first or use a different import code.");
+			config.addDefault("Commands.Preset.ExportSuccess", "Preset {name} exported. Copy this code to share: {code}");
+			config.addDefault("Commands.Preset.ImportSuccess", "Successfully imported preset {name}");
+			config.addDefault("Commands.Preset.ImportFailed", "Failed to import preset. The code may be invalid or corrupted.");
+			config.addDefault("Commands.Preset.ImportExists", "A preset with that name already exists. Delete it first or use a different import code.");
+			config.addDefault("Commands.Preset.ImportAbilityNotFound", "{ability} could not be bound, because it is not available on this server, or due to insufficient permissions.");
+			config.addDefault("Commands.Preset.ExportHoverCommand", "Click to copy the command to import your preset to your clipboard!");
+			config.addDefault("Commands.Preset.ExportHoverCode", "Copy code to clipboard;\n Code: {code}");
 
 			config.addDefault("Commands.Cooldown.Description", "Set, reset or view a cooldown for a player");
 			config.addDefault("Commands.Cooldown.InvalidPlayer", "That player has not played before!");

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -1,23 +1,15 @@
 package com.projectkorra.projectkorra.configuration;
 
-import com.google.common.collect.Sets;
 import com.projectkorra.projectkorra.Element;
 import com.projectkorra.projectkorra.GeneralMethods;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.Registry;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.EntityType;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class ConfigManager {
 
@@ -193,6 +185,10 @@ public class ConfigManager {
 			config.addDefault("Commands.Preset.Other.BendingPermanentlyRemoved", "That player's bending was permanently removed.");
 			config.addDefault("Commands.Preset.Other.SuccesfullyBoundConfirm", "The bound slots of {target} have been set to match the {name} preset.");
 			config.addDefault("Commands.Preset.External.NoPresetName", "No external preset found with that name.");
+			config.addDefault("Commands.Preset.External.ExportSuccess", "Preset {name} exported. Copy this code to share: {code}");
+			config.addDefault("Commands.Preset.External.ImportSuccess", "Successfully imported preset {name}");
+			config.addDefault("Commands.Preset.External.ImportFailed", "Failed to import preset. The code may be invalid or corrupted.");
+			config.addDefault("Commands.Preset.External.ImportExists", "A preset with that name already exists. Delete it first or use a different import code.");
 
 			config.addDefault("Commands.Cooldown.Description", "Set, reset or view a cooldown for a player");
 			config.addDefault("Commands.Cooldown.InvalidPlayer", "That player has not played before!");

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -191,13 +191,18 @@ public class ConfigManager {
 			config.addDefault("Commands.Preset.Other.BendingPermanentlyRemoved", "That player's bending was permanently removed.");
 			config.addDefault("Commands.Preset.Other.SuccesfullyBoundConfirm", "The bound slots of {target} have been set to match the {name} preset.");
 			config.addDefault("Commands.Preset.External.NoPresetName", "No external preset found with that name.");
+			config.addDefault("Commands.Preset.ExportNotSpecified", "Please specify a preset name to export.");
+			config.addDefault("Commands.Preset.ImportNotSpecified", "Please provide an import code.");
 			config.addDefault("Commands.Preset.ExportSuccess", "Preset {name} exported. Copy this code to share: {code}");
+			config.addDefault("Commands.Preset.ExportFailed", "Failed to export preset.");
 			config.addDefault("Commands.Preset.ImportSuccess", "Successfully imported preset {name}");
 			config.addDefault("Commands.Preset.ImportFailed", "Failed to import preset. The code may be invalid or corrupted.");
 			config.addDefault("Commands.Preset.ImportExists", "A preset with that name already exists. Delete it first or use a different import code.");
-			config.addDefault("Commands.Preset.ImportAbilityNotFound", "{ability} could not be bound, because it is not available on this server, or due to insufficient permissions.");
-			config.addDefault("Commands.Preset.ExportHoverCommand", "Click to copy the command to import your preset to your clipboard!");
-			config.addDefault("Commands.Preset.ExportHoverCode", "Copy code to clipboard;\n Code: {code}");
+			config.addDefault("Commands.Preset.ImportAbilityNotFound", "{ability} could not be found and was not imported.");
+			config.addDefault("Commands.Preset.ExportCodeButton", "[ Click to Copy Code ]");
+			config.addDefault("Commands.Preset.ExportCommandButton", "[ Click to Import Code ]");
+			config.addDefault("Commands.Preset.HoverCommand", "Click to copy the command to import your preset to your clipboard!");
+			config.addDefault("Commands.Preset.HoverCode", "Copy code to clipboard;\n Code: {code}");
 
 			config.addDefault("Commands.Cooldown.Description", "Set, reset or view a cooldown for a player");
 			config.addDefault("Commands.Cooldown.InvalidPlayer", "That player has not played before!");

--- a/core/src/com/projectkorra/projectkorra/object/Preset.java
+++ b/core/src/com/projectkorra/projectkorra/object/Preset.java
@@ -1,25 +1,31 @@
 package com.projectkorra.projectkorra.object;
 
-import com.projectkorra.projectkorra.BendingPlayer;
-import com.projectkorra.projectkorra.ProjectKorra;
-import com.projectkorra.projectkorra.ability.CoreAbility;
-import com.projectkorra.projectkorra.board.BendingBoardManager;
-import com.projectkorra.projectkorra.command.PresetCommand;
-import com.projectkorra.projectkorra.configuration.ConfigManager;
-import com.projectkorra.projectkorra.storage.DBConnection;
-import com.projectkorra.projectkorra.util.ChatUtil;
-import org.bukkit.ChatColor;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Base64;
+import java.io.UnsupportedEncodingException;
+
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.io.UnsupportedEncodingException;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
+import com.projectkorra.projectkorra.BendingPlayer;
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.board.BendingBoardManager;
+import com.projectkorra.projectkorra.configuration.ConfigManager;
+import com.projectkorra.projectkorra.storage.DBConnection;
+import net.md_5.bungee.api.ChatColor;
+import com.projectkorra.projectkorra.command.PresetCommand;
+import com.projectkorra.projectkorra.util.ChatUtil;
 
 /**
  * A savable association of abilities and hotbar slots, stored per player.
@@ -377,6 +383,11 @@ public class Preset {
 					try {
 						int slot = Integer.parseInt(bindData[0]);
 						if (slot >= 1 && slot <= 9) {
+							final CoreAbility coreAbil = CoreAbility.getAbility(bindData[1]);
+							if (coreAbil == null || !coreAbil.isEnabled()) {
+								ChatUtil.sendBrandingMessage(player, org.bukkit.ChatColor.RED + ConfigManager.languageConfig.get().getString("Commands.Preset.ImportAbilityNotFound").replace("{ability}", bindData[1]));
+								continue;
+							}
 							abilities.put(slot, bindData[1]);
 						}
 					} catch (NumberFormatException e) {

--- a/core/src/plugin.yml
+++ b/core/src/plugin.yml
@@ -63,6 +63,8 @@ permissions:
       bending.command.preset.create: true
       bending.command.preset.bind: true
       bending.command.preset.delete: true
+      bending.command.preset.export: true
+      bending.command.preset.import: true
       bending.air: true
       bending.water: true
       bending.earth: true


### PR DESCRIPTION
## Additions
* Added methods to serialize (exportToString) and deserialize (importFromString) presets.
* Added export and import subcommands (with aliases) to PresetCommand; with a use case in mind for easily moving presets across servers, or not completely losing configurations due to low max preset limits.