### PR TITLE
AirBreath (Core)

### DIFF
--- a/core/src/com/projectkorra/projectkorra/GeneralMethods.java
+++ b/core/src/com/projectkorra/projectkorra/GeneralMethods.java
@@ -62,12 +62,18 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.ElderGuardian;
+import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityCategory;
 import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.IronGolem;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Ravager;
+import org.bukkit.entity.Sniffer;
 import org.bukkit.entity.TNTPrimed;
+import org.bukkit.entity.Warden;
+import org.bukkit.entity.Wither;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
@@ -1540,6 +1546,16 @@ public class GeneralMethods {
                  "OCHRE_FROGLIGHT", "PEARLESCENT_FROGLIGHT", "VERDANT_FROGLIGHT", "SCULK_CATALYST" -> true;
             default -> false;
         };
+	}
+
+	public static boolean isHeavyEntity(Entity entity) {
+        return entity instanceof IronGolem
+                || entity instanceof Sniffer
+                || entity instanceof Ravager
+                || entity instanceof Warden
+                || entity instanceof EnderDragon
+                || entity instanceof Wither
+                || entity instanceof ElderGuardian;
 	}
 
 	@Deprecated

--- a/core/src/com/projectkorra/projectkorra/PKListener.java
+++ b/core/src/com/projectkorra/projectkorra/PKListener.java
@@ -1,5 +1,7 @@
 package com.projectkorra.projectkorra;
 
+import com.bekvon.bukkit.residence.commands.message;
+import com.projectkorra.projectkorra.airbending.AirBreath;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -978,25 +980,29 @@ public class PKListener implements Listener {
 			final Player killer = deathInfo.getRight();
 			final String tempAbility = ChatColor.stripColor(ability).replaceAll(" ", "");
 			final CoreAbility coreAbil = CoreAbility.getAbility(tempAbility);
-			String message = ConfigManager.languageConfig.get().getString("DeathMessages.Default");
+			String deathMessage = ConfigManager.languageConfig.get().getString("DeathMessages.Default");
 			Element element = coreAbil != null ? coreAbil.getElement() : null;
 			
 			if (HorizontalVelocityTracker.hasBeenDamagedByHorizontalVelocity(player) && Arrays.asList(HorizontalVelocityTracker.abils).contains(tempAbility)) {
 				if (ConfigManager.languageConfig.get().contains("Abilities." + element.getName() + "." + tempAbility + ".HorizontalVelocityDeath")) {
-					message = ConfigManager.languageConfig.get().getString("Abilities." + element.getName() + "." + tempAbility + ".HorizontalVelocityDeath");
+					deathMessage = ConfigManager.languageConfig.get().getString("Abilities." + element.getName() + "." + tempAbility + ".HorizontalVelocityDeath");
 				}
 			} else if (element != null) {
 				if (element instanceof SubElement subElement) {
 					element = subElement.getParentElement();
 				}
 				if (ConfigManager.languageConfig.get().contains("Abilities." + element.getName() + "." + tempAbility + ".DeathMessage")) {
-					message = ConfigManager.languageConfig.get().getString("Abilities." + element.getName() + "." + tempAbility + ".DeathMessage");
+					deathMessage = ConfigManager.languageConfig.get().getString("Abilities." + element.getName() + "." + tempAbility + ".DeathMessage");
 				} else if (ConfigManager.languageConfig.get().contains("Abilities." + element.getName() + ".Combo." + tempAbility + ".DeathMessage")) {
-					message = ConfigManager.languageConfig.get().getString("Abilities." + element.getName() + ".Combo." + tempAbility + ".DeathMessage");
+					deathMessage = ConfigManager.languageConfig.get().getString("Abilities." + element.getName() + ".Combo." + tempAbility + ".DeathMessage");
 				}
 			}
-			message = message.replace("{victim}", event.getEntity().getName()).replace("{attacker}", killer.getName()).replace("{ability}", ability);
-			event.setDeathMessage(message);
+			deathMessage = deathMessage
+							.replace("{victim}", event.getEntity().getName())
+							.replace("{attacker}", killer.getName())
+							.replace("{ability}", ability);
+
+			event.setDeathMessage(deathMessage);
 		}
 	}
 
@@ -1345,6 +1351,7 @@ public class PKListener implements Listener {
 			case AirSuction ignored -> new AirSuction(player);
 			case AirSwipe ignored -> new AirSwipe(player, true);
 			case AirShield ignored -> new AirShield(player);
+			case AirBreath ignored -> new AirBreath(player);
 			case Suffocate ignored -> new Suffocate(player);
 			case Bloodbending ignored -> new Bloodbending(player);
 			case IceBlast ignored -> new IceBlast(player);

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -40,6 +40,9 @@ import org.bukkit.util.Vector;
  */
 public class AirBreath extends AirAbility {
 
+    private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
+    private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
+
     private static final String CONFIG_ROOT_PATH = "Abilities.Air.AirBreath.";
 
     private static final double MOUTH_Y_OFFSET = 0.2;
@@ -423,14 +426,14 @@ public class AirBreath extends AirAbility {
             entitiesInCone.add(entity);
 
             // Add to existing velocity each tick, slight Y lift so entities arc upward
-            Vector push = breathContext.lookDirection().clone().multiply(strength);
-            push.setY(push.getY() + KNOCKBACK_VERTICAL_LIFT);
+             Vector push = breathContext.lookDirection().clone().multiply(strength);
+             push.setY(push.getY() + KNOCKBACK_VERTICAL_LIFT);
 
-            Vector newVelocity = entity.getVelocity().add(push);
-            if (newVelocity.length() > knockback) {
-                newVelocity = newVelocity.normalize().multiply(knockback);
-            }
-            GeneralMethods.setVelocity(this, entity, newVelocity);
+             Vector newVelocity = entity.getVelocity().add(push);
+             if (newVelocity.length() > knockback) {
+                 newVelocity = newVelocity.normalize().multiply(knockback);
+             }
+             GeneralMethods.setVelocity(this, entity, newVelocity);
         }
 
         // Entities that just left the cone get a final burst so they fly past the range boundary (makes it seem more like a wind burst)
@@ -635,8 +638,13 @@ public class AirBreath extends AirAbility {
 
     // How far the breath currently reaches, grows linearly from 0 to range over given growtime
     private double currentReach() {
+        if (growTime <= 0) {
+            return range;
+        }
         double elapsed = System.currentTimeMillis() - getStartTime();
-        return Math.min(range, range * elapsed / growTime);
+        double progress = elapsed / growTime;
+
+        return Math.min(range, range * progress);
     }
 
     public double getSelfPushFactor() {
@@ -678,10 +686,5 @@ public class AirBreath extends AirAbility {
     public static String getConfigRootPath() {
         return CONFIG_ROOT_PATH;
     }
-
-    // DATA HOLDING RECORDS FOR BETTER READABILITY
-    private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
-
-    private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
 
 }

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -379,6 +379,9 @@ public class AirBreath extends AirAbility {
         world.spawnParticle(Particle.SMOKE, center, 4, 0.15, 0.15, 0.15, 0.01);
     }
 
+    /**
+     * Extinguish all candles in given parameters.
+     */
     private void extinguishCandleInCone(Location center, double distance) {
         if (isInvalidEffectLocation(center)) return;
 

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -97,9 +97,15 @@ public class AirBreath extends AirAbility {
     public AirBreath(Player player) {
         super(player);
 
-        if (getMouthLocation().getBlock().isLiquid()) return;
-        if (!bPlayer.canBend(this)) return;
-        if (CoreAbility.getAbility(player, AirBreath.class) != null) return;
+        if (getMouthLocation().getBlock().isLiquid()) {
+            return;
+        }
+        if (!bPlayer.canBend(this)) {
+            return;
+        }
+        if (CoreAbility.getAbility(player, AirBreath.class) != null) {
+            return;
+        }
 
         this.selfPushFactor = getConfig().getDouble(CONFIG_ROOT_PATH + "SelfPushFactor");
         this.selfPushStrength = getConfig().getDouble(CONFIG_ROOT_PATH + "SelfPushStrength");
@@ -177,6 +183,7 @@ public class AirBreath extends AirAbility {
             }
 
             if (isLitCandle(block)) {
+                extinguishCandle(block);
                 extinguishCandleInCone(center, distance);
                 hitDistance = distance;
                 hitType = HitType.SOLID;
@@ -379,23 +386,25 @@ public class AirBreath extends AirAbility {
         world.spawnParticle(Particle.SMOKE, center, 4, 0.15, 0.15, 0.15, 0.01);
     }
 
+    private void extinguishCandle(Block block) {
+        if (!isLitCandle(block) || RegionProtection.isRegionProtected(this, block.getLocation())) {
+            return;
+        }
+
+        BlockData unlitData = block.getBlockData();
+        if (unlitData instanceof Candle candle) {
+            candle.setLit(false);
+            new TempBlock(block, unlitData, TEMP_BLOCK_DURATION, this);
+        }
+    }
+
     /**
      * Extinguish all candles in given parameters.
      */
     private void extinguishCandleInCone(Location center, double distance) {
         if (isInvalidEffectLocation(center)) return;
 
-        forEachBlockInRadius(center, getConeRadius(distance), block -> {
-            if (!isLitCandle(block)) return;
-
-            // Copy the existing block data and switch lit to false so the candle keeps its
-            // state and reverts fully when the TempBlock expires.
-            BlockData unlitData = block.getBlockData();
-            if (unlitData instanceof Candle candle) {
-                candle.setLit(false);
-            }
-            new TempBlock(block, unlitData, TEMP_BLOCK_DURATION, this);
-        });
+        forEachBlockInRadius(center, getConeRadius(distance), this::isLitCandle, this::extinguishCandle);
 
         World world = center.getWorld();
         if (world == null) return;
@@ -532,9 +541,11 @@ public class AirBreath extends AirAbility {
                 FluidCollisionMode.NEVER,
                 true);
 
-        double hitDistance = blockResult != null && blockResult.getHitBlock() != null
-                ? blockResult.getHitPosition().distance(breathContext.mouthLocation().toVector())
-                : breathContext.reach() + 1;
+        double hitDistance = breathContext.reach() + 1;
+
+        if (blockResult != null && blockResult.getHitBlock() != null && isSolidRecoilSurface(blockResult.getHitBlock())) {
+            hitDistance = blockResult.getHitPosition().distance(breathContext.mouthLocation().toVector());
+        }
 
         if (bPlayer.isAvatarState()) {
             return hitDistance;
@@ -553,6 +564,24 @@ public class AirBreath extends AirAbility {
         }
 
         return hitDistance;
+    }
+
+    private boolean isSolidRecoilSurface(Block block) {
+        Material type = block.getType();
+
+        if (type.isAir()) {
+            return false;
+        }
+
+        if (isFireBlock(block)) {
+            return false;
+        }
+
+        if (isLitCandle(block) || block.getBlockData() instanceof Candle) {
+            return false;
+        }
+
+        return !block.isPassable();
     }
 
     /**
@@ -633,9 +662,7 @@ public class AirBreath extends AirAbility {
     }
 
     private boolean isInvalidEffectLocation(Location location) {
-        return location.getWorld() == null
-                || RegionProtection.isRegionProtected(this, location)
-                || location.getBlock().isLiquid();
+        return location.getWorld() == null || RegionProtection.isRegionProtected(this, location);
     }
 
     private boolean isOutsideBreathCone(Location origin, Vector direction, Location target) {

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -54,17 +54,15 @@ public class AirBreath extends AirAbility {
     private static final int LAVA_WAVE_TICK_PERIOD = 2;
     private static final double BREATH_SOUND_CHANCE = 0.4;
 
-    private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
-
-    private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
-
-    private record BreathTraceResult(double hitDistance, HitType hitType, Location hitLocation) {}
-
     private enum HitType {
         NONE,
         LAVA,
         SOLID
     }
+
+    private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
+    private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
+    private record BreathTraceResult(double hitDistance, HitType hitType, Location hitLocation) {}
 
     @Attribute(Attribute.SELF_PUSH) // Maximum velocity the player can reach from self-push recoil
     private double selfPushFactor;

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -259,7 +259,7 @@ public class AirBreath extends AirAbility {
     }
 
     private void handleLavaSplash(Location location, double hitDistance) {
-        if (isInvalidEffectLocation(location)) return;
+        if (location.getWorld() == null || RegionProtection.isRegionProtected(this, location)) return;
 
         location.getWorld().spawnParticle(Particle.LAVA, location.clone().add(0, .2, 0), 8, 0.3, 0.3, 0.3, 0);
         location.getWorld().spawnParticle(Particle.ASH, location, 12, 0.3, 0.5, 0.3, 0.04);
@@ -479,6 +479,9 @@ public class AirBreath extends AirAbility {
         }
 
         if (hitDistance > breathContext.reach()) return;
+
+        // Skip self-push when entities are being knocked back by the breath
+        if (!previouslyInCone.isEmpty()) return;
 
         double strength = selfPushStrength * (1.0 + (range - hitDistance) / range);
         Vector recoil = breathContext.lookDirection.clone().multiply(-strength);

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -1,7 +1,6 @@
 package com.projectkorra.projectkorra.airbending;
 
 import com.projectkorra.projectkorra.GeneralMethods;
-import com.projectkorra.projectkorra.ProjectKorra;
 import com.projectkorra.projectkorra.ability.AirAbility;
 import com.projectkorra.projectkorra.ability.CoreAbility;
 import com.projectkorra.projectkorra.attribute.Attribute;
@@ -19,6 +18,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BrushableBlock;
 import org.bukkit.block.data.BlockData;
@@ -30,8 +30,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.loot.LootContext;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
@@ -51,9 +49,22 @@ public class AirBreath extends AirAbility {
     private static final double EXIT_BURST_FACTOR = 0.4;
     private static final long TEMP_BLOCK_DURATION = 10000L;
 
+    private static final double MIN_SPLASH_RADIUS = 1.0;
+    private static final double LAVA_WAVE_STEP = 0.5;
+    private static final int LAVA_WAVE_TICK_PERIOD = 2;
+    private static final double BREATH_SOUND_CHANCE = 0.4;
+
     private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
 
     private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
+
+    private record BreathTraceResult(double hitDistance, HitType hitType, Location hitLocation) {}
+
+    private enum HitType {
+        NONE,
+        LAVA,
+        SOLID
+    }
 
     @Attribute(Attribute.SELF_PUSH) // Maximum velocity the player can reach from self-push recoil
     private double selfPushFactor;
@@ -73,11 +84,15 @@ public class AirBreath extends AirAbility {
     private long growTime;
     private boolean canExcavateSuspiciousBlocks;
 
-    // The currently running lava-freeze wave, or null when no wave is active
-    private BukkitTask lavaSplashTask = null;
-
     // Entities that were inside the breath cone last tick
     private final Set<Entity> previouslyInCone = new HashSet<>();
+
+    // Lava solidifying fields
+    private Location lavaWaveCenter;
+    private double lavaWaveRadius;
+    private double lavaWaveMaxRadius;
+    private int lavaWaveTickCounter;
+    private boolean lavaWaveActive;
 
     public AirBreath(Player player) {
         super(player);
@@ -101,98 +116,115 @@ public class AirBreath extends AirAbility {
 
     @Override
     public void progress() {
-        if (!player.isOnline() || player.isDead()) {
+        if (shouldRemoveImmediately()) {
             remove();
             return;
         }
 
-        if (!bPlayer.canBend(this) || !player.isSneaking() || hasExpired()) {
+        if (shouldRemoveWithCooldown()) {
             removeWithCooldown();
             return;
         }
 
-        if (isInvalidEffectLocation(getMouthLocation())) {
-            removeWithCooldown();
-            return;
-        }
+        BreathContext breathContext = createBreathContext();
+        BreathTraceResult breathTraceResult = traceBreathPath(breathContext);
 
-        playBreathAnimation();
-        handleKnockback();
-        handleProjectileRedirect();
-        handleSelfPush();
+        playBreathAnimation(breathContext, breathTraceResult);
+        applyBreathImpact(breathTraceResult);
+        advanceLavaWave();
+
+        handleKnockback(breathContext);
+        handleProjectileRedirect(breathContext);
+        handleSelfPush(breathContext);
     }
 
     @Override
     public void remove() {
-        if (lavaSplashTask != null) {
-            lavaSplashTask.cancel();
-            lavaSplashTask = null;
-        }
+        clearLavaWave();
+        previouslyInCone.clear();
         super.remove();
     }
 
-    /**
-     * Marches along the player's look lookDirection spawning cone-shaped air particles.
-     * Particles are placed randomly within a circle that widens with distance, forming a cone.
-     * Stops at the first solid block.
-     */
-    private void playBreathAnimation() {
-        BreathContext breathContext = createBreathContext();
+    private boolean shouldRemoveImmediately() {
+        return !player.isOnline() || player.isDead();
+    }
 
-        if (ThreadLocalRandom.current().nextDouble() < 0.4) {
+    private boolean shouldRemoveWithCooldown() {
+        return !bPlayer.canBend(this)
+                || !player.isSneaking()
+                || hasExpired()
+                || isInvalidEffectLocation(getMouthLocation());
+    }
+
+    /**
+     * Traces the breath forward and returns the first impactful hit.
+     * Any environmental interactions that are not purely visual are handled here.
+     *
+     * @return BreathTraceResult.
+     */
+    private BreathTraceResult traceBreathPath(BreathContext breathContext) {
+        double hitDistance = breathContext.reach();
+        HitType hitType = HitType.NONE;
+
+        for (double distance = PARTICLE_STEP; distance <= breathContext.reach(); distance += PARTICLE_STEP) {
+            Location center = breathContext.mouthLocation().clone().add(breathContext.lookDirection().clone().multiply(distance));
+            Block block = center.getBlock();
+
+            if (block.isLiquid()) {
+                hitDistance = distance;
+                hitType = block.getType() == Material.LAVA ? HitType.LAVA : HitType.NONE;
+                break;
+            }
+
+            if (isLitCandle(block)) {
+                extinguishCandleInCone(center, distance);
+                hitDistance = distance;
+                hitType = HitType.SOLID;
+                break;
+            }
+
+            if (canExcavateSuspiciousBlocks && isSuspiciousBlock(block)) {
+                excavateSuspiciousBlocksInCone(center, distance);
+                hitDistance = distance;
+                hitType = HitType.SOLID;
+                break;
+            }
+
+            if (!block.isPassable()) {
+                hitDistance = distance;
+                hitType = HitType.SOLID;
+                break;
+            }
+
+            if (isFireBlock(block)) {
+                extinguishFireInCone(center, distance);
+            }
+        }
+
+        Location hitLocation = breathContext.mouthLocation().clone().add(breathContext.lookDirection().clone().multiply(hitDistance));
+        return new BreathTraceResult(hitDistance, hitType, hitLocation);
+    }
+
+    /**
+     * Purely visual / audio breath rendering.
+     */
+    private void playBreathAnimation(BreathContext breathContext, BreathTraceResult breathTraceResult) {
+        if (ThreadLocalRandom.current().nextDouble() < BREATH_SOUND_CHANCE) {
             playAirbendingSound(breathContext.mouthLocation());
         }
 
         ConeBasis coneBasis = createConeBasis(breathContext.lookDirection());
 
-        double hitRange = breathContext.reach();
-        boolean hitWater = false;
-        boolean hitLava = false;
-
-        for (double dist = PARTICLE_STEP; dist <= breathContext.reach(); dist += PARTICLE_STEP) {
-            Location center = breathContext.mouthLocation().clone().add(breathContext.lookDirection().clone().multiply(dist));
-            Block block = center.getBlock();
-
-            if (block.isLiquid()) {
-                hitRange = dist;
-                hitWater = block.getType() == Material.WATER;
-                hitLava = !hitWater;
-                break;
-            }
-
-            // Candles extinguishing check
-            if (isLitCandle(block)) {
-                extinguishCandleInCone(center, dist);
-                hitRange = dist;
-                break;
-            }
-
-            // Suspicious sand / gravel, excavate it
-            if (isSuspiciousBlock(block) && canExcavateSuspiciousBlocks) {
-                excavateSuspiciousBlocksInCone(center, dist);
-                hitRange = dist;
-                break;
-            }
-
-            // Not further up due to candle and suspicious blocks checks
-            if (!block.isPassable()) {
-                hitRange = dist;
-                break;
-            }
-
-            // Extinguish fire blocks inside the cone cross-section at this distance
-            if (isFireBlock(block)) {
-                extinguishFireInCone(center, dist);
-            }
-
-            spawnBreathParticles(center, breathContext.lookDirection(), coneBasis, dist, breathContext.reach());
+        for (double distance = PARTICLE_STEP; distance <= breathTraceResult.hitDistance(); distance += PARTICLE_STEP) {
+            Location center = breathContext.mouthLocation().clone().add(breathContext.lookDirection().clone().multiply(distance));
+            spawnBreathParticles(center, breathContext.lookDirection(), coneBasis, distance, breathContext.reach());
         }
+    }
 
-        Location hitLocation = breathContext.mouthLocation().clone().add(breathContext.lookDirection().clone().multiply(hitRange));
-        if (hitWater) {
-            handleWaterSplash(hitLocation);
-        } else if (hitLava) {
-            handleLavaSplash(hitLocation, hitRange);
+    private void applyBreathImpact(BreathTraceResult breathTraceResult) {
+        switch (breathTraceResult.hitType()) {
+            case LAVA -> handleLavaSplash(breathTraceResult.hitLocation(), breathTraceResult.hitDistance());
+            case NONE, SOLID -> {}
         }
     }
 
@@ -212,12 +244,12 @@ public class AirBreath extends AirAbility {
 
             double angle = random.nextDouble(Math.PI * 2);
             // sqrt distribution biases toward the outer edge while still filling the interior
-            double r = coneRadius * Math.sqrt(random.nextDouble());
+            double radialDistance = coneRadius * Math.sqrt(random.nextDouble());
             // small forward jitter breaks up the uniform slice look
             double forwardJitter = random.nextDouble(-0.15, 0.15);
 
-            Vector offset = coneBasis.perpendicular1().clone().multiply(Math.cos(angle) * r)
-                    .add(coneBasis.perpendicular2().clone().multiply(Math.sin(angle) * r))
+            Vector offset = coneBasis.perpendicular1().clone().multiply(Math.cos(angle) * radialDistance)
+                    .add(coneBasis.perpendicular2().clone().multiply(Math.sin(angle) * radialDistance))
                     .add(lookDirection.clone().multiply(forwardJitter));
 
             playAirbendingParticles(center.clone().add(offset), 1, 0.02, 0.02, 0.02);
@@ -244,70 +276,87 @@ public class AirBreath extends AirAbility {
         return new ConeBasis(perpendicular1, perpendicular2);
     }
 
-    private void handleWaterSplash(Location location) {
-        if (isInvalidEffectLocation(location)) return;
-
-        if (ThreadLocalRandom.current().nextDouble() < 0.3) {
-            location.getWorld().spawnParticle(Particle.SPLASH, location.clone().add(0, .2, 0), 20, 0.35, 0.35, 0.35, 0.15);
-            location.getWorld().playSound(location, Sound.ENTITY_GENERIC_SPLASH, 0.4f, 1.3f);
-        }
-
-        Block block = location.getBlock();
-        if (block.isLiquid() && TempBlock.isTempBlock(block)) {
-            TempBlock.removeBlock(block);
-        }
-    }
-
     private void handleLavaSplash(Location location, double hitDistance) {
-        if (location.getWorld() == null || RegionProtection.isRegionProtected(this, location)) return;
+        World world = location.getWorld();
+        if (world == null || RegionProtection.isRegionProtected(this, location)) return;
 
-        location.getWorld().spawnParticle(Particle.LAVA, location.clone().add(0, .2, 0), 8, 0.3, 0.3, 0.3, 0);
-        location.getWorld().spawnParticle(Particle.ASH, location, 12, 0.3, 0.5, 0.3, 0.04);
-
-        if (ThreadLocalRandom.current().nextDouble() < 0.6) {
-            location.getWorld().playSound(location, Sound.BLOCK_LAVA_EXTINGUISH, 1.0f, 1.0f);
-        }
+        playLavaSplashEffects(world, location);
 
         // Always harden the exact hit block immediately, regardless of any running wave.
         hardenLavaBlock(location.getBlock());
 
-        // Only start a new outward ripple if no wave is already expanding.
-        if (lavaSplashTask != null && !lavaSplashTask.isCancelled()) return;
+        if (!lavaWaveActive) {
+            startLavaFreezeWave(location, computeSplashRadius(hitDistance));
+        }
+    }
 
-        final double splashRadius = Math.max(1.0, radius * (hitDistance / range));
-        final Location frozen = location.clone();
-        final double[] waveRadius = { 0 };
+    /**
+     * Effects for lava hardening.
+     */
+    private void playLavaSplashEffects(World world, Location location) {
+        world.spawnParticle(Particle.LAVA, location.clone().add(0, .2, 0), 8, 0.3, 0.3, 0.3, 0);
+        world.spawnParticle(Particle.ASH, location, 12, 0.3, 0.5, 0.3, 0.04);
 
-        // A single repeating task expands the freeze wave outward every 3 ticks.
-        // Makes the Lava hardening feel more natural.
-        lavaSplashTask = new BukkitRunnable() {
-            @Override
-            public void run() {
-                double previousRadius = waveRadius[0];
-                waveRadius[0] += 0.5;
+        if (ThreadLocalRandom.current().nextDouble() < BREATH_SOUND_CHANCE) {
+            world.playSound(location, Sound.BLOCK_LAVA_EXTINGUISH, 1.0f, 1.0f);
+        }
+    }
 
-                if (waveRadius[0] > splashRadius) {
-                    lavaSplashTask = null;
-                    cancel();
-                    return;
-                }
+    private void startLavaFreezeWave(Location center, double maxRadius) {
+        lavaWaveCenter = center.clone();
+        lavaWaveRadius = 0.0;
+        lavaWaveMaxRadius = maxRadius;
+        lavaWaveTickCounter = 0;
+        lavaWaveActive = true;
+    }
 
-                forEachBlockInRadius(
-                        frozen,
-                        waveRadius[0],
-                        block -> block.getLocation().add(0.5, 0.5, 0.5).distance(frozen) > previousRadius,
-                        AirBreath.this::hardenLavaBlock);
-            }
-        }.runTaskTimer(ProjectKorra.plugin, 0L, 2L);
+    private void advanceLavaWave() {
+        if (!lavaWaveActive || lavaWaveCenter == null) return;
+
+        lavaWaveTickCounter++;
+        if (lavaWaveTickCounter < LAVA_WAVE_TICK_PERIOD) return;
+
+        lavaWaveTickCounter = 0;
+
+        double previousRadius = lavaWaveRadius;
+        lavaWaveRadius += LAVA_WAVE_STEP;
+
+        if (lavaWaveRadius > lavaWaveMaxRadius) {
+            clearLavaWave();
+            return;
+        }
+
+        forEachBlockInRadius(
+                lavaWaveCenter,
+                lavaWaveRadius,
+                block -> isInNewWaveRing(block, lavaWaveCenter, previousRadius),
+                this::hardenLavaBlock);
+    }
+
+    private void clearLavaWave() {
+        lavaWaveCenter = null;
+        lavaWaveRadius = 0.0;
+        lavaWaveMaxRadius = 0.0;
+        lavaWaveTickCounter = 0;
+        lavaWaveActive = false;
+    }
+
+    private boolean isInNewWaveRing(Block block, Location center, double previousRadius) {
+        Location blockCenter = block.getLocation().add(0.5, 0.5, 0.5);
+        return blockCenter.distance(center) > previousRadius;
+    }
+
+    private double computeSplashRadius(double hitDistance) {
+        return Math.max(MIN_SPLASH_RADIUS, radius * (hitDistance / range));
     }
 
     private void hardenLavaBlock(Block block) {
-        if (block.getType() == Material.LAVA) {
-            if (block.getBlockData() instanceof Levelled levelled && levelled.getLevel() == 0) {
-                new TempBlock(block, Material.OBSIDIAN.createBlockData(), TEMP_BLOCK_DURATION, this);
-            } else {
-                new TempBlock(block, Material.COBBLESTONE.createBlockData(), TEMP_BLOCK_DURATION, this);
-            }
+        if (block.getType() != Material.LAVA) return;
+
+        if (block.getBlockData() instanceof Levelled levelled && levelled.getLevel() == 0) {
+            new TempBlock(block, Material.OBSIDIAN.createBlockData(), TEMP_BLOCK_DURATION, this);
+        } else {
+            new TempBlock(block, Material.COBBLESTONE.createBlockData(), TEMP_BLOCK_DURATION, this);
         }
     }
 
@@ -323,8 +372,11 @@ public class AirBreath extends AirAbility {
             }
         });
 
-        center.getWorld().playSound(center, Sound.BLOCK_FIRE_EXTINGUISH, 1.0f, 1.0f);
-        center.getWorld().spawnParticle(Particle.SMOKE, center, 4, 0.15, 0.15, 0.15, 0.01);
+        World world = center.getWorld();
+        if (world == null) return;
+
+        world.playSound(center, Sound.BLOCK_FIRE_EXTINGUISH, 1.0f, 1.0f);
+        world.spawnParticle(Particle.SMOKE, center, 4, 0.15, 0.15, 0.15, 0.01);
     }
 
     private void extinguishCandleInCone(Location center, double distance) {
@@ -342,8 +394,11 @@ public class AirBreath extends AirAbility {
             new TempBlock(block, unlitData, TEMP_BLOCK_DURATION, this);
         });
 
-        center.getWorld().playSound(center, Sound.BLOCK_CANDLE_EXTINGUISH, 1.0f, 1.0f);
-        center.getWorld().spawnParticle(Particle.SMOKE, center, 2, 0.1, 0.1, 0.1, 0.01);
+        World world = center.getWorld();
+        if (world == null) return;
+
+        world.playSound(center, Sound.BLOCK_CANDLE_EXTINGUISH, 1.0f, 1.0f);
+        world.spawnParticle(Particle.SMOKE, center, 2, 0.1, 0.1, 0.1, 0.01);
     }
 
     private boolean isLitCandle(Block block) {
@@ -402,8 +457,7 @@ public class AirBreath extends AirAbility {
      * Continuously accelerates entities inside the cone, then gives them a final burst
      * the moment they leave, carrying them well past the breath range like a wind gust.
      */
-    private void handleKnockback() {
-        BreathContext breathContext = createBreathContext();
+    private void handleKnockback(BreathContext breathContext) {
         Set<Entity> entitiesInCone = new HashSet<>();
 
         for (Entity entity : GeneralMethods.getEntitiesAroundPoint(breathContext.mouthLocation(), breathContext.reach())) {
@@ -427,6 +481,7 @@ public class AirBreath extends AirAbility {
              if (newVelocity.length() > knockback) {
                  newVelocity = newVelocity.normalize().multiply(knockback);
              }
+
              GeneralMethods.setVelocity(this, entity, newVelocity);
         }
 
@@ -447,36 +502,8 @@ public class AirBreath extends AirAbility {
      * entity (iron golem, sniffer, warden, ravager). Heavy entities act as walls
      * unless the player is in avatar state.
      */
-    private void handleSelfPush() {
-        BreathContext breathContext = createBreathContext();
-
-        RayTraceResult blockResult = player.getWorld().rayTraceBlocks(
-                breathContext.mouthLocation(),
-                breathContext.lookDirection(),
-                breathContext.reach(),
-                FluidCollisionMode.NEVER,
-                true);
-
-        double hitDistance = blockResult != null && blockResult.getHitBlock() != null
-                ? blockResult.getHitPosition().distance(breathContext.mouthLocation().toVector())
-                : breathContext.reach() + 1;
-
-        // Heavy entities act as a wall for recoil, but only when not in avatar state
-        if (!bPlayer.isAvatarState()) {
-            RayTraceResult entityRayTraceResult = player.getWorld().rayTraceEntities(
-                    breathContext.mouthLocation(),
-                    breathContext.lookDirection(),
-                    breathContext.reach(),
-                    0.5,
-                    entity -> !entity.equals(player) && GeneralMethods.isHeavyEntity(entity));
-
-            if (entityRayTraceResult != null && entityRayTraceResult.getHitEntity() != null) {
-                double entityDistance = entityRayTraceResult.getHitPosition().distance(breathContext.mouthLocation().toVector());
-                if (entityDistance < hitDistance) {
-                    hitDistance = entityDistance;
-                }
-            }
-        }
+    private void handleSelfPush(BreathContext breathContext) {
+        double hitDistance = findSelfPushHitDistance(breathContext);
 
         if (hitDistance > breathContext.reach()) return;
 
@@ -494,15 +521,44 @@ public class AirBreath extends AirAbility {
         GeneralMethods.setVelocity(this, player, playerVelocity);
     }
 
+    private double findSelfPushHitDistance(BreathContext breathContext) {
+        RayTraceResult blockResult = player.getWorld().rayTraceBlocks(
+                breathContext.mouthLocation(),
+                breathContext.lookDirection(),
+                breathContext.reach(),
+                FluidCollisionMode.NEVER,
+                true);
+
+        double hitDistance = blockResult != null && blockResult.getHitBlock() != null
+                ? blockResult.getHitPosition().distance(breathContext.mouthLocation().toVector())
+                : breathContext.reach() + 1;
+
+        if (bPlayer.isAvatarState()) {
+            return hitDistance;
+        }
+
+        RayTraceResult entityResult = player.getWorld().rayTraceEntities(
+                breathContext.mouthLocation(),
+                breathContext.lookDirection(),
+                breathContext.reach(),
+                0.5,
+                entity -> !entity.equals(player) && GeneralMethods.isHeavyEntity(entity));
+
+        if (entityResult != null && entityResult.getHitEntity() != null) {
+            double entityDistance = entityResult.getHitPosition().distance(breathContext.mouthLocation().toVector());
+            hitDistance = Math.min(hitDistance, entityDistance);
+        }
+
+        return hitDistance;
+    }
+
     /**
      * Deflects projectiles inside the breath cone.
      * The breath force is added to each projectile's current velocity so faster projectiles are
      * bent less than slow ones, which feels physically natural.
      * Projectiles fired by the bender themselves are ignored.
      */
-    private void handleProjectileRedirect() {
-        BreathContext breathContext = createBreathContext();
-
+    private void handleProjectileRedirect(BreathContext breathContext) {
         for (Entity entity : GeneralMethods.getEntitiesAroundPoint(breathContext.mouthLocation(), breathContext.reach())) {
             if (!(entity instanceof Projectile projectile)) continue;
             if (player.equals(projectile.getShooter())) continue;
@@ -549,7 +605,7 @@ public class AirBreath extends AirAbility {
 
     @Override
     public Location getLocation() {
-        return player != null ? player.getEyeLocation().subtract(0, .2, 0) : null;
+        return player != null ? player.getEyeLocation().subtract(0, MOUTH_Y_OFFSET, 0) : null;
     }
 
     private BreathContext createBreathContext() {
@@ -574,7 +630,9 @@ public class AirBreath extends AirAbility {
     }
 
     private boolean isInvalidEffectLocation(Location location) {
-        return location.getWorld() == null || RegionProtection.isRegionProtected(this, location) || location.getBlock().isLiquid();
+        return location.getWorld() == null
+                || RegionProtection.isRegionProtected(this, location)
+                || location.getBlock().isLiquid();
     }
 
     private boolean isOutsideBreathCone(Location origin, Vector direction, Location target) {
@@ -585,7 +643,7 @@ public class AirBreath extends AirAbility {
             return true;
         }
 
-        return !(toTarget.normalize().angle(direction) <= getConeHalfAngle(distance));
+        return toTarget.normalize().angle(direction) > getConeHalfAngle(distance);
     }
 
     private boolean isFireBlock(Block block) {
@@ -638,9 +696,9 @@ public class AirBreath extends AirAbility {
         if (growTime <= 0) {
             return range;
         }
+
         double elapsed = System.currentTimeMillis() - getStartTime();
         double progress = elapsed / growTime;
-
         return Math.min(range, range * progress);
     }
 
@@ -670,10 +728,6 @@ public class AirBreath extends AirAbility {
 
     public long getGrowTime() {
         return growTime;
-    }
-
-    public BukkitTask getLavaSplashTask() {
-        return lavaSplashTask;
     }
 
     public Set<Entity> getPreviouslyInCone() {

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -1,0 +1,628 @@
+package com.projectkorra.projectkorra.airbending;
+
+import com.projectkorra.projectkorra.GeneralMethods;
+import com.projectkorra.projectkorra.ProjectKorra;
+import com.projectkorra.projectkorra.ability.AirAbility;
+import com.projectkorra.projectkorra.ability.CoreAbility;
+import com.projectkorra.projectkorra.attribute.Attribute;
+import com.projectkorra.projectkorra.command.Commands;
+import com.projectkorra.projectkorra.region.RegionProtection;
+import com.projectkorra.projectkorra.util.TempBlock;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.block.Block;
+import org.bukkit.block.BrushableBlock;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Levelled;
+import org.bukkit.block.data.type.Candle;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.loot.LootContext;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+
+public class AirBreath extends AirAbility {
+
+    private static final String CONFIG_ROOT_PATH = "Abilities.Air.AirBreath.";
+
+    @Attribute(Attribute.SELF_PUSH) // Maximum velocity the player can reach from self-push recoil
+    private double selfPushFactor;
+    @Attribute(Attribute.SELF_PUSH) // Per tick recoil acceleration applied when breath hits a surface
+    private double selfPushStrength;
+    @Attribute(Attribute.KNOCKBACK)
+    private double knockback;
+    @Attribute(Attribute.RADIUS)
+    private double radius;
+    @Attribute(Attribute.RANGE)
+    private double range;
+    @Attribute(Attribute.DURATION)
+    private long duration;
+    @Attribute(Attribute.COOLDOWN)
+    private long cooldown;
+    @Attribute(Attribute.CHARGE_DURATION)
+    private long growTime;
+
+    // The currently running lava-freeze wave, or null when no wave is active
+    private BukkitTask lavaSplashTask = null;
+
+    // Entities that were inside the breath cone last tick
+    private Set<Entity> previouslyInCone = new HashSet<>();
+
+    public AirBreath(Player player) {
+        super(player);
+
+        if (player.getEyeLocation().getBlock().isLiquid()) return;
+        if (bPlayer.isOnCooldown(this)) return;
+        if (!bPlayer.canBend(this)) return;
+        if (CoreAbility.getAbility(player, AirBreath.class) != null) return;
+
+        this.selfPushFactor = getConfig().getDouble(CONFIG_ROOT_PATH + "SelfPushFactor");
+        this.selfPushStrength = getConfig().getDouble(CONFIG_ROOT_PATH + "SelfPushStrength");
+        this.knockback = getConfig().getDouble(CONFIG_ROOT_PATH + "Knockback");
+        this.radius = getConfig().getDouble(CONFIG_ROOT_PATH + "Radius");
+        this.range = getConfig().getDouble(CONFIG_ROOT_PATH + "Range");
+        this.duration = getConfig().getLong(CONFIG_ROOT_PATH + "Duration");
+        this.cooldown = getConfig().getLong(CONFIG_ROOT_PATH + "Cooldown");
+        this.growTime = getConfig().getLong(CONFIG_ROOT_PATH + "GrowTime");
+
+        start();
+    }
+
+    @Override
+    public void progress() {
+        if (!player.isOnline() || player.isDead()) {
+            remove();
+            return;
+        }
+
+        if (!bPlayer.canBend(this)) {
+            bPlayer.addCooldown(this);
+            remove();
+            return;
+        }
+
+        if (!player.isSneaking()) {
+            bPlayer.addCooldown(this);
+            remove();
+            return;
+        }
+
+        if (System.currentTimeMillis() - getStartTime() > duration) {
+            bPlayer.addCooldown(this);
+            remove();
+            return;
+        }
+
+        if (player.getEyeLocation().getBlock().isLiquid()) {
+            remove();
+            return;
+        }
+
+        if (RegionProtection.isRegionProtected(this, player.getEyeLocation())) {
+            remove();
+            return;
+        }
+
+        playBreathAnimation();
+        handleKnockback();
+        handleProjectileRedirect();
+        handleSelfPush();
+    }
+
+    @Override
+    public void remove() {
+        if (lavaSplashTask != null) {
+            lavaSplashTask.cancel();
+            lavaSplashTask = null;
+        }
+        super.remove();
+    }
+
+    // How far the breath currently reaches, grows linearly from 0 to range over given growtime
+    private double currentReach() {
+        double elapsed = System.currentTimeMillis() - getStartTime();
+        return Math.min(range, range * elapsed / growTime);
+    }
+
+    /**
+     * Marches along the player's look lookDirection spawning cone-shaped air particles.
+     * Particles are placed randomly within a circle that widens with distance, forming a cone.
+     * Stops at the first solid block.
+     */
+    private void playBreathAnimation() {
+        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
+        Vector lookDirection = mouthLocation.getDirection().normalize();
+
+        if (ThreadLocalRandom.current().nextDouble() < .4) {
+            playAirbendingSound(mouthLocation);
+        }
+
+        // Build two vectors perpendicular to dir to form the cone's cross-section plane
+        Vector up = new Vector(0, 1, 0);
+
+        Vector perpendicular1 = lookDirection.clone().crossProduct(up).normalize();
+        Vector perpendicular2 = lookDirection.clone().crossProduct(perpendicular1).normalize();
+
+        final double step = 0.5;
+        final double reach = currentReach();
+
+        double hitRange = reach;
+        boolean hitWater = false;
+        boolean hitLava = false;
+
+        for (double dist = step; dist <= reach; dist += step) {
+            Location center = mouthLocation.clone().add(lookDirection.clone().multiply(dist));
+            Block block = center.getBlock();
+
+            if (block.isLiquid()) {
+                hitRange = dist;
+                hitWater = block.getType() == Material.WATER;
+                hitLava = !hitWater;
+                break;
+            }
+
+            // Candles extinguishing check
+            if (isLitCandle(block)) {
+                extinguishCandleInCone(center, dist);
+                hitRange = dist;
+                break;
+            }
+
+            // Suspicious sand / gravel, excavate it
+            if (block.getType() == Material.SUSPICIOUS_SAND || block.getType() == Material.SUSPICIOUS_GRAVEL) {
+                excavateSuspiciousBlocksInCone(center, dist);
+                hitRange = dist;
+                break;
+            }
+
+            // Not further up due to candle and suspicious blocks checks
+            if (!block.isPassable()) {
+                hitRange = dist;
+                break;
+            }
+
+            // Extinguish fire blocks inside the cone cross-section at this distance
+            if (block.getType() == Material.FIRE || block.getType() == Material.SOUL_FIRE) {
+                extinguishFireInCone(center, dist);
+            }
+
+            double coneRadius = radius * (dist / range);
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+
+            // Scatter random particles within the cone cross-section at this distance.
+            // Using polar coordinates with a slight radius bias toward the edge so the cone outline reads
+            // densityFactor scales from 0.25 near the mouth to 1.0 at full reach so the
+            // area close to the player stays open and visibility is not blocked.
+            double densityFactor = 0.25 + 0.75 * (dist / reach);
+            int count = random.nextInt(2, 4);
+            for (int i = 0; i < count; i++) {
+                if (random.nextDouble() > densityFactor) continue;
+
+                double angle = random.nextDouble(Math.PI * 2);
+                // sqrt distribution biases toward the outer edge while still filling the interior
+                double r = coneRadius * Math.sqrt(random.nextDouble());
+                // small forward jitter breaks up the uniform slice look
+                double forwardJitter = random.nextDouble(-0.15, 0.15);
+
+                Vector offset = perpendicular1.clone().multiply(Math.cos(angle) * r)
+                        .add(perpendicular2.clone().multiply(Math.sin(angle) * r))
+                        .add(lookDirection.clone().multiply(forwardJitter));
+
+                playAirbendingParticles(center.clone().add(offset), 1, 0.02, 0.02, 0.02);
+            }
+
+            // Occasional central particle keeps the core of the breath visible.
+            if (random.nextDouble() < 0.35 * densityFactor) {
+                playAirbendingParticles(center, 1, 0.04, 0.04, 0.04);
+            }
+        }
+
+        Location hitLoc = mouthLocation.clone().add(lookDirection.clone().multiply(hitRange));
+        if (hitWater) {
+            handleWaterSplash(hitLoc);
+        } else if (hitLava) {
+            handleLavaSplash(hitLoc, hitRange);
+        }
+    }
+
+    private void handleWaterSplash(Location location) {
+        if (location.getWorld() == null) return;
+        if (RegionProtection.isRegionProtected(this, location)) return;
+
+        if (ThreadLocalRandom.current().nextDouble() < .3) {
+            location.getWorld().spawnParticle(Particle.SPLASH, location.add(0, .2, 0), 20, 0.35, 0.35, 0.35, 0.15);
+            location.getWorld().playSound(location, Sound.ENTITY_GENERIC_SPLASH, 0.4f, 1.3f);
+        }
+
+        Block block = location.getBlock();
+        if (block.isLiquid() && TempBlock.isTempBlock(block)) {
+            TempBlock.removeBlock(block);
+        }
+    }
+
+    private void handleLavaSplash(Location location, double hitDistance) {
+        if (location.getWorld() == null) return;
+        if (RegionProtection.isRegionProtected(this, location)) return;
+
+        location.getWorld().spawnParticle(Particle.LAVA, location.add(0, .2, 0), 8, 0.3, 0.3, 0.3, 0);
+        location.getWorld().spawnParticle(Particle.ASH, location, 12, 0.3, 0.5, 0.3, 0.04);
+
+        if (ThreadLocalRandom.current().nextDouble() < .6) {
+            location.getWorld().playSound(location, Sound.BLOCK_LAVA_EXTINGUISH, 1.0f, 1.0f);
+        }
+
+        // Always harden the exact hit block immediately, regardless of any running wave.
+        hardenLavaBlock(location.getBlock());
+
+        // Only start a new outward ripple if no wave is already expanding.
+        if (lavaSplashTask != null && !lavaSplashTask.isCancelled()) return;
+
+        final double splashRadius = Math.max(1.0, radius * (hitDistance / range));
+        final Location frozen = location.clone();
+        final double[] waveRadius = {0};
+
+        // A single repeating task expands the freeze wave outward every 3 ticks.
+        // Makes the Lava hardening feel more natural.
+        lavaSplashTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                double prevRadius = waveRadius[0];
+                waveRadius[0] += 0.5;
+
+                if (waveRadius[0] > splashRadius) {
+                    lavaSplashTask = null;
+                    cancel();
+                    return;
+                }
+
+                int r = (int) Math.ceil(waveRadius[0]);
+                for (int dx = -r; dx <= r; dx++) {
+                    for (int dy = -r; dy <= r; dy++) {
+                        for (int dz = -r; dz <= r; dz++) {
+                            Block block = frozen.clone().add(dx, dy, dz).getBlock();
+                            double dist = block.getLocation().add(0.5, 0.5, 0.5).distance(frozen);
+                            // Process only the new ring added this step.
+                            if (dist > waveRadius[0] || dist <= prevRadius) continue;
+                            hardenLavaBlock(block);
+                        }
+                    }
+                }
+            }
+        }.runTaskTimer(ProjectKorra.plugin, 0L, 2L);
+    }
+
+    private void hardenLavaBlock(Block block) {
+        if (block.getType() == Material.LAVA) {
+            if (block.getBlockData() instanceof Levelled lev && lev.getLevel() == 0) {
+                new TempBlock(block, Material.OBSIDIAN.createBlockData(), 10000L, this);
+            } else {
+                new TempBlock(block, Material.COBBLESTONE.createBlockData(), 10000L, this);
+            }
+        }
+    }
+
+    /**
+     * Extinguishes all fire blocks within the cone's cross-section radius at the given distance.
+     */
+    private void extinguishFireInCone(Location center, double distance) {
+        if (center.getWorld() == null) return;
+        if (RegionProtection.isRegionProtected(this, center)) return;
+
+        double coneRadius = radius * (distance / range);
+        int r = (int) Math.ceil(coneRadius);
+
+        for (int dx = -r; dx <= r; dx++) {
+            for (int dy = -r; dy <= r; dy++) {
+                for (int dz = -r; dz <= r; dz++) {
+                    Block nearby = center.clone().add(dx, dy, dz).getBlock();
+
+                    if (nearby.getType() != Material.FIRE && nearby.getType() != Material.SOUL_FIRE) continue;
+                    if (nearby.getLocation().add(0.5, 0.5, 0.5).distance(center) > coneRadius) continue;
+
+                    new TempBlock(nearby, Material.AIR.createBlockData(), 10000L, this);
+                }
+            }
+        }
+        center.getWorld().playSound(center, Sound.BLOCK_FIRE_EXTINGUISH, 1.0f, 1.0f);
+        center.getWorld().spawnParticle(Particle.SMOKE, center, 4, 0.15, 0.15, 0.15, 0.01);
+    }
+
+    private void extinguishCandleInCone(Location center, double distance) {
+        if (center.getWorld() == null) return;
+        if (RegionProtection.isRegionProtected(this, center)) return;
+
+        double coneRadius = radius * (distance / range);
+        int r = (int) Math.ceil(coneRadius);
+
+        for (int dx = -r; dx <= r; dx++) {
+            for (int dy = -r; dy <= r; dy++) {
+                for (int dz = -r; dz <= r; dz++) {
+                    Block nearby = center.clone().add(dx, dy, dz).getBlock();
+
+                    if (!isLitCandle(nearby)) continue;
+                    if (nearby.getLocation().add(0.5, 0.5, 0.5).distance(center) > coneRadius) continue;
+
+                    // Copy the existing block data and switch lit to false so the candle keeps its
+                    // state and reverts fully when the TempBlock expires.
+                    BlockData unlitData = nearby.getBlockData();
+                    if (unlitData instanceof Candle candle) {
+                        candle.setLit(false);
+                    }
+                    new TempBlock(nearby, unlitData, 10000L, this);
+                }
+            }
+        }
+        center.getWorld().playSound(center, Sound.BLOCK_CANDLE_EXTINGUISH, 1.0f, 1.0f);
+        center.getWorld().spawnParticle(Particle.SMOKE, center, 2, 0.1, 0.1, 0.1, 0.01);
+    }
+
+    private boolean isLitCandle(Block block) {
+        return block.getBlockData() instanceof Candle candle && candle.isLit();
+    }
+
+    /**
+     * Blows suspicious sand / gravel blocks apart within the cone cross-section, dropping their
+     * hidden item exactly as vanilla brushing does and replacing the block with plain sand / gravel.
+     * If the loot table hasn't been resolved yet (block never brushed before), it is resolved now.
+     */
+    private void excavateSuspiciousBlocksInCone(Location center, double distance) {
+        if (center.getWorld() == null) return;
+        if (RegionProtection.isRegionProtected(this, center)) return;
+
+        double coneRadius = radius * (distance / range);
+        int r = (int) Math.ceil(coneRadius);
+
+        for (int dx = -r; dx <= r; dx++) {
+            for (int dy = -r; dy <= r; dy++) {
+                for (int dz = -r; dz <= r; dz++) {
+                    Block nearby = center.clone().add(dx, dy, dz).getBlock();
+
+                    if (nearby.getType() != Material.SUSPICIOUS_SAND && nearby.getType() != Material.SUSPICIOUS_GRAVEL) continue;
+                    if (nearby.getLocation().add(0.5, 0.5, 0.5).distance(center) > coneRadius) continue;
+                    if (RegionProtection.isRegionProtected(this, nearby.getLocation())) continue;
+
+                    Location dropLoc = nearby.getLocation().add(0.5, 0.7, 0.5);
+
+                    // Resolve and drop the stored item, matching vanilla loot behavior.
+                    if (nearby.getState() instanceof BrushableBlock brushable) {
+                        ItemStack item = brushable.getItem();
+                        if (item != null && item.getType() != Material.AIR) {
+                            // Item was already resolved by prior brushing. drop it directly
+                            nearby.getWorld().dropItemNaturally(dropLoc, item);
+                        } else if (brushable.getLootTable() != null) {
+                            // Block never brushed: resolve using the block's own seed so the
+                            // result is deterministic, matching vanilla behavior exactly.
+                            LootContext context = new LootContext.Builder(dropLoc).build();
+                            for (ItemStack drop : brushable.getLootTable().populateLoot(new Random(brushable.getSeed()), context)) {
+                                nearby.getWorld().dropItemNaturally(dropLoc, drop);
+                            }
+                        }
+                    }
+
+                    Sound brushSound = nearby.getType() == Material.SUSPICIOUS_SAND
+                            ? Sound.ITEM_BRUSH_BRUSHING_SAND_COMPLETE
+                            : Sound.ITEM_BRUSH_BRUSHING_GRAVEL_COMPLETE;
+                    nearby.getWorld().spawnParticle(Particle.BLOCK, nearby.getLocation().add(0.5, 0.5, 0.5), 12, 0.3, 0.3, 0.3, nearby.getBlockData());
+                    nearby.getWorld().playSound(nearby.getLocation(), brushSound, 1.0f, 1.0f);
+                    nearby.setType(nearby.getType() == Material.SUSPICIOUS_SAND ? Material.SAND : Material.GRAVEL);
+                }
+            }
+        }
+    }
+
+    /**
+     * Continuously accelerates entities inside the cone, then gives them a final burst
+     * the moment they leave, carrying them well past the breath range like a wind gust.
+     */
+    private void handleKnockback() {
+        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
+        Vector lookDirection = mouthLocation.getDirection().normalize();
+        double reach = currentReach();
+
+        Set<Entity> entitiesInCone = new HashSet<>();
+
+        for (Entity entity : GeneralMethods.getEntitiesAroundPoint(mouthLocation, reach)) {
+            if (entity.equals(player)) continue;
+            if (Commands.invincible.contains(entity.getName())) continue;
+            if (RegionProtection.isRegionProtected(this, entity.getLocation())) continue;
+            if (GeneralMethods.isHeavyEntity(entity) && !bPlayer.isAvatarState()) continue;
+
+            Vector toEntity = entity.getLocation().toVector().subtract(mouthLocation.toVector());
+            double dist = toEntity.length();
+            if (dist < 0.1) continue;
+
+            double coneHalfAngle = Math.toRadians(25.0 + dist * 1.5);
+            if (toEntity.clone().normalize().angle(lookDirection) > coneHalfAngle) continue;
+
+            double strength = knockback * (1.0 - dist / (range * 0.8));
+            if (strength <= 0) continue;
+
+            entitiesInCone.add(entity);
+
+            // Add to existing velocity each tick, slight Y lift so entities arc upward
+            Vector push = lookDirection.clone().multiply(strength);
+            push.setY(push.getY() + 0.04);
+            Vector newVelocity = entity.getVelocity().add(push);
+            if (newVelocity.length() > knockback) {
+                newVelocity = newVelocity.normalize().multiply(knockback);
+            }
+            GeneralMethods.setVelocity(this, entity, newVelocity);
+        }
+
+        // Entities that just left the cone get a final burst so they fly past the range boundary (makes it seem more like a wind burst)
+        for (Entity entity : previouslyInCone) {
+            if (entitiesInCone.contains(entity)) continue;
+            Vector burst = lookDirection.clone().multiply(knockback * 0.4);
+            GeneralMethods.setVelocity(this, entity, entity.getVelocity().add(burst));
+        }
+
+        previouslyInCone = entitiesInCone;
+    }
+
+    /**
+     * Propels the player via recoil when their breath hits a solid surface or a heavy
+     * entity (iron golem, sniffer, warden, ravager). Heavy entities act as walls
+     * unless the player is in avatar state.
+     */
+    private void handleSelfPush() {
+        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
+        Vector lookDirection = mouthLocation.getDirection().normalize();
+        double reach = currentReach();
+
+        RayTraceResult blockResult = player.getWorld().rayTraceBlocks(mouthLocation, lookDirection, reach, FluidCollisionMode.NEVER, true);
+        double hitDistance = blockResult != null && blockResult.getHitBlock() != null
+                ? blockResult.getHitPosition().distance(mouthLocation.toVector())
+                : reach + 1;
+
+        // Heavy entities act as a wall for recoil, but only when not in avatar state
+        if (!bPlayer.isAvatarState()) {
+            RayTraceResult entityRayTraceResult = player.getWorld().rayTraceEntities(mouthLocation, lookDirection, reach, 0.5, entity -> !entity.equals(player) && GeneralMethods.isHeavyEntity(entity));
+            if (entityRayTraceResult != null && entityRayTraceResult.getHitEntity() != null) {
+                double entityDist = entityRayTraceResult.getHitPosition().distance(mouthLocation.toVector());
+                if (entityDist < hitDistance) {
+                    hitDistance = entityDist;
+                }
+            }
+        }
+
+        if (hitDistance > reach) return;
+
+        double strength = selfPushStrength * (1.0 + (range - hitDistance) / range);
+        Vector recoil = lookDirection.clone().multiply(-strength);
+        Vector playerVelocity = player.getVelocity().add(recoil);
+
+        if (playerVelocity.length() > selfPushFactor) {
+            playerVelocity = playerVelocity.normalize().multiply(selfPushFactor);
+        }
+        GeneralMethods.setVelocity(this, player, playerVelocity);
+    }
+
+    /**
+     * Deflects projectiles inside the breath cone.
+     * The breath force is added to each projectile's current velocity so faster projectiles are
+     * bent less than slow ones, which feels physically natural.
+     * Projectiles fired by the bender themselves are ignored.
+     */
+    private void handleProjectileRedirect() {
+        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
+        Vector lookDirection = mouthLocation.getDirection().normalize();
+        double reach = currentReach();
+
+        for (Entity entity : GeneralMethods.getEntitiesAroundPoint(mouthLocation, reach)) {
+            if (!(entity instanceof Projectile projectile)) continue;
+            if (player.equals(projectile.getShooter())) continue;
+            if (RegionProtection.isRegionProtected(this, entity.getLocation())) continue;
+
+            Vector toProjectile = entity.getLocation().toVector().subtract(mouthLocation.toVector());
+            double dist = toProjectile.length();
+            if (dist < 0.1) continue;
+
+            double coneHalfAngle = Math.toRadians(25.0 + dist * 1.5);
+            if (toProjectile.clone().normalize().angle(lookDirection) > coneHalfAngle) continue;
+
+            double strength = knockback * (1.0 - dist / (range * 0.8));
+            if (strength <= 0) continue;
+
+            Vector newVelocity = entity.getVelocity().add(lookDirection.clone().multiply(strength));
+            entity.setVelocity(newVelocity);
+
+            // Fireballs are self-propelled via an internal lookDirection vector
+            // updating velocity alone isn't enough to actually steer them
+            if (projectile instanceof Fireball fireball) {
+                fireball.setDirection(newVelocity.clone().normalize());
+            }
+
+            // Transfer ownership to the player so kill credit and advancements are correctly attributed
+            projectile.setShooter(player);
+        }
+    }
+
+    private BreathContext createBreathContext() {
+        Location mouth = getMouthLocation();
+        return new BreathContext(mouth, mouth.getDirection().normalize(), currentReach());
+    }
+
+    private Location getMouthLocation() {
+        return player.getEyeLocation().subtract(0, 0.2, 0);
+    }
+
+    @Override
+    public boolean isSneakAbility() {
+        return true;
+    }
+
+    @Override
+    public boolean isHarmlessAbility() {
+        return false;
+    }
+
+    @Override
+    public long getCooldown() {
+        return cooldown;
+    }
+
+    @Override
+    public String getName() {
+        return "AirBreath";
+    }
+
+    @Override
+    public Location getLocation() {
+        return player != null ? player.getEyeLocation().subtract(0, .2, 0) : null;
+    }
+
+    public double getSelfPushFactor() {
+        return selfPushFactor;
+    }
+
+    public double getSelfPushStrength() {
+        return selfPushStrength;
+    }
+
+    public double getKnockback() {
+        return knockback;
+    }
+
+    public double getRadius() {
+        return radius;
+    }
+
+    public double getRange() {
+        return range;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public long getGrowTime() {
+        return growTime;
+    }
+
+    public BukkitTask getLavaSplashTask() {
+        return lavaSplashTask;
+    }
+
+    public Set<Entity> getPreviouslyInCone() {
+        return previouslyInCone;
+    }
+
+    public static String getConfigRootPath() {
+        return CONFIG_ROOT_PATH;
+    }
+
+    private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
+
+}

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -40,9 +40,6 @@ import org.bukkit.util.Vector;
  */
 public class AirBreath extends AirAbility {
 
-    private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
-    private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
-
     private static final String CONFIG_ROOT_PATH = "Abilities.Air.AirBreath.";
 
     private static final double MOUTH_Y_OFFSET = 0.2;
@@ -53,6 +50,10 @@ public class AirBreath extends AirAbility {
     private static final double KNOCKBACK_VERTICAL_LIFT = 0.04;
     private static final double EXIT_BURST_FACTOR = 0.4;
     private static final long TEMP_BLOCK_DURATION = 10000L;
+
+    private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
+
+    private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
 
     @Attribute(Attribute.SELF_PUSH) // Maximum velocity the player can reach from self-push recoil
     private double selfPushFactor;
@@ -110,14 +111,7 @@ public class AirBreath extends AirAbility {
             return;
         }
 
-        Location mouthLocation = getMouthLocation();
-
-        if (mouthLocation.getBlock().isLiquid()) {
-            removeWithCooldown();
-            return;
-        }
-
-        if (isInvalidEffectLocation(mouthLocation)) {
+        if (isInvalidEffectLocation(getMouthLocation())) {
             removeWithCooldown();
             return;
         }
@@ -577,7 +571,7 @@ public class AirBreath extends AirAbility {
     }
 
     private boolean isInvalidEffectLocation(Location location) {
-        return location.getWorld() == null || RegionProtection.isRegionProtected(this, location);
+        return location.getWorld() == null || RegionProtection.isRegionProtected(this, location) || location.getBlock().isLiquid();
     }
 
     private boolean isOutsideBreathCone(Location origin, Vector direction, Location target) {

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -12,6 +12,8 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -35,6 +37,15 @@ import org.bukkit.util.Vector;
 
 public class AirBreath extends AirAbility {
 
+    private static final double MOUTH_Y_OFFSET = 0.2;
+    private static final double PARTICLE_STEP = 0.5;
+    private static final double BASE_CONE_ANGLE_DEGREES = 25.0;
+    private static final double CONE_ANGLE_GROWTH_PER_BLOCK = 1.5;
+    private static final double KNOCKBACK_FALLOFF_RANGE_FACTOR = 0.8;
+    private static final double KNOCKBACK_VERTICAL_LIFT = 0.04;
+    private static final double EXIT_BURST_FACTOR = 0.4;
+    private static final long TEMP_BLOCK_DURATION = 10000L;
+
     private static final String CONFIG_ROOT_PATH = "Abilities.Air.AirBreath.";
 
     @Attribute(Attribute.SELF_PUSH) // Maximum velocity the player can reach from self-push recoil
@@ -54,11 +65,13 @@ public class AirBreath extends AirAbility {
     @Attribute(Attribute.CHARGE_DURATION)
     private long growTime;
 
+    private boolean canExcavateSuspiciousBlocks;
+
     // The currently running lava-freeze wave, or null when no wave is active
     private BukkitTask lavaSplashTask = null;
 
     // Entities that were inside the breath cone last tick
-    private Set<Entity> previouslyInCone = new HashSet<>();
+    private final Set<Entity> previouslyInCone = new HashSet<>();
 
     public AirBreath(Player player) {
         super(player);
@@ -76,6 +89,7 @@ public class AirBreath extends AirAbility {
         this.duration = getConfig().getLong(CONFIG_ROOT_PATH + "Duration");
         this.cooldown = getConfig().getLong(CONFIG_ROOT_PATH + "Cooldown");
         this.growTime = getConfig().getLong(CONFIG_ROOT_PATH + "GrowTime");
+        this.canExcavateSuspiciousBlocks = getConfig().getBoolean(CONFIG_ROOT_PATH + "CanExcavateSuspiciousBlocks");
 
         start();
     }
@@ -87,31 +101,20 @@ public class AirBreath extends AirAbility {
             return;
         }
 
-        if (!bPlayer.canBend(this)) {
-            bPlayer.addCooldown(this);
-            remove();
+        if (!bPlayer.canBend(this) || !player.isSneaking() || hasExpired()) {
+            removeWithCooldown();
             return;
         }
 
-        if (!player.isSneaking()) {
-            bPlayer.addCooldown(this);
-            remove();
+        Location mouthLocation = getMouthLocation();
+
+        if (mouthLocation.getBlock().isLiquid()) {
+            removeWithCooldown();
             return;
         }
 
-        if (System.currentTimeMillis() - getStartTime() > duration) {
-            bPlayer.addCooldown(this);
-            remove();
-            return;
-        }
-
-        if (player.getEyeLocation().getBlock().isLiquid()) {
-            remove();
-            return;
-        }
-
-        if (RegionProtection.isRegionProtected(this, player.getEyeLocation())) {
-            remove();
+        if (isInvalidEffectLocation(mouthLocation)) {
+            removeWithCooldown();
             return;
         }
 
@@ -130,40 +133,26 @@ public class AirBreath extends AirAbility {
         super.remove();
     }
 
-    // How far the breath currently reaches, grows linearly from 0 to range over given growtime
-    private double currentReach() {
-        double elapsed = System.currentTimeMillis() - getStartTime();
-        return Math.min(range, range * elapsed / growTime);
-    }
-
     /**
      * Marches along the player's look lookDirection spawning cone-shaped air particles.
      * Particles are placed randomly within a circle that widens with distance, forming a cone.
      * Stops at the first solid block.
      */
     private void playBreathAnimation() {
-        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
-        Vector lookDirection = mouthLocation.getDirection().normalize();
+        BreathContext breathContext = createBreathContext();
 
-        if (ThreadLocalRandom.current().nextDouble() < .4) {
-            playAirbendingSound(mouthLocation);
+        if (ThreadLocalRandom.current().nextDouble() < 0.4) {
+            playAirbendingSound(breathContext.mouthLocation());
         }
 
-        // Build two vectors perpendicular to dir to form the cone's cross-section plane
-        Vector up = new Vector(0, 1, 0);
+        ConeBasis coneBasis = createConeBasis(breathContext.lookDirection());
 
-        Vector perpendicular1 = lookDirection.clone().crossProduct(up).normalize();
-        Vector perpendicular2 = lookDirection.clone().crossProduct(perpendicular1).normalize();
-
-        final double step = 0.5;
-        final double reach = currentReach();
-
-        double hitRange = reach;
+        double hitRange = breathContext.reach();
         boolean hitWater = false;
         boolean hitLava = false;
 
-        for (double dist = step; dist <= reach; dist += step) {
-            Location center = mouthLocation.clone().add(lookDirection.clone().multiply(dist));
+        for (double dist = PARTICLE_STEP; dist <= breathContext.reach(); dist += PARTICLE_STEP) {
+            Location center = breathContext.mouthLocation().clone().add(breathContext.lookDirection().clone().multiply(dist));
             Block block = center.getBlock();
 
             if (block.isLiquid()) {
@@ -181,7 +170,7 @@ public class AirBreath extends AirAbility {
             }
 
             // Suspicious sand / gravel, excavate it
-            if (block.getType() == Material.SUSPICIOUS_SAND || block.getType() == Material.SUSPICIOUS_GRAVEL) {
+            if (isSuspiciousBlock(block) && canExcavateSuspiciousBlocks) {
                 excavateSuspiciousBlocksInCone(center, dist);
                 hitRange = dist;
                 break;
@@ -194,55 +183,74 @@ public class AirBreath extends AirAbility {
             }
 
             // Extinguish fire blocks inside the cone cross-section at this distance
-            if (block.getType() == Material.FIRE || block.getType() == Material.SOUL_FIRE) {
+            if (isFireBlock(block)) {
                 extinguishFireInCone(center, dist);
             }
 
-            double coneRadius = radius * (dist / range);
-            ThreadLocalRandom random = ThreadLocalRandom.current();
-
-            // Scatter random particles within the cone cross-section at this distance.
-            // Using polar coordinates with a slight radius bias toward the edge so the cone outline reads
-            // densityFactor scales from 0.25 near the mouth to 1.0 at full reach so the
-            // area close to the player stays open and visibility is not blocked.
-            double densityFactor = 0.25 + 0.75 * (dist / reach);
-            int count = random.nextInt(2, 4);
-            for (int i = 0; i < count; i++) {
-                if (random.nextDouble() > densityFactor) continue;
-
-                double angle = random.nextDouble(Math.PI * 2);
-                // sqrt distribution biases toward the outer edge while still filling the interior
-                double r = coneRadius * Math.sqrt(random.nextDouble());
-                // small forward jitter breaks up the uniform slice look
-                double forwardJitter = random.nextDouble(-0.15, 0.15);
-
-                Vector offset = perpendicular1.clone().multiply(Math.cos(angle) * r)
-                        .add(perpendicular2.clone().multiply(Math.sin(angle) * r))
-                        .add(lookDirection.clone().multiply(forwardJitter));
-
-                playAirbendingParticles(center.clone().add(offset), 1, 0.02, 0.02, 0.02);
-            }
-
-            // Occasional central particle keeps the core of the breath visible.
-            if (random.nextDouble() < 0.35 * densityFactor) {
-                playAirbendingParticles(center, 1, 0.04, 0.04, 0.04);
-            }
+            spawnBreathParticles(center, breathContext.lookDirection(), coneBasis, dist, breathContext.reach());
         }
 
-        Location hitLoc = mouthLocation.clone().add(lookDirection.clone().multiply(hitRange));
+        Location hitLocation = breathContext.mouthLocation().clone().add(breathContext.lookDirection().clone().multiply(hitRange));
         if (hitWater) {
-            handleWaterSplash(hitLoc);
+            handleWaterSplash(hitLocation);
         } else if (hitLava) {
-            handleLavaSplash(hitLoc, hitRange);
+            handleLavaSplash(hitLocation, hitRange);
         }
     }
 
-    private void handleWaterSplash(Location location) {
-        if (location.getWorld() == null) return;
-        if (RegionProtection.isRegionProtected(this, location)) return;
+    private void spawnBreathParticles(Location center, Vector lookDirection, ConeBasis coneBasis, double distance, double reach) {
+        double coneRadius = getConeRadius(distance);
+        ThreadLocalRandom random = ThreadLocalRandom.current();
 
-        if (ThreadLocalRandom.current().nextDouble() < .3) {
-            location.getWorld().spawnParticle(Particle.SPLASH, location.add(0, .2, 0), 20, 0.35, 0.35, 0.35, 0.15);
+        // Scatter random particles within the cone cross-section at this distance.
+        // Using polar coordinates with a slight radius bias toward the edge so the cone outline reads
+        // densityFactor scales from 0.25 near the mouth to 1.0 at full reach so the
+        // area close to the player stays open and visibility is not blocked.
+        double densityFactor = 0.25 + 0.75 * (distance / reach);
+        int count = random.nextInt(2, 4);
+
+        for (int i = 0; i < count; i++) {
+            if (random.nextDouble() > densityFactor) continue;
+
+            double angle = random.nextDouble(Math.PI * 2);
+            // sqrt distribution biases toward the outer edge while still filling the interior
+            double r = coneRadius * Math.sqrt(random.nextDouble());
+            // small forward jitter breaks up the uniform slice look
+            double forwardJitter = random.nextDouble(-0.15, 0.15);
+
+            Vector offset = coneBasis.perpendicular1().clone().multiply(Math.cos(angle) * r)
+                    .add(coneBasis.perpendicular2().clone().multiply(Math.sin(angle) * r))
+                    .add(lookDirection.clone().multiply(forwardJitter));
+
+            playAirbendingParticles(center.clone().add(offset), 1, 0.02, 0.02, 0.02);
+        }
+
+        // Occasional central particle keeps the core of the breath visible.
+        if (random.nextDouble() < 0.35 * densityFactor) {
+            playAirbendingParticles(center, 1, 0.04, 0.04, 0.04);
+        }
+    }
+
+    private ConeBasis createConeBasis(Vector lookDirection) {
+        // Build two vectors perpendicular to dir to form the cone's cross-section plane
+        Vector up = new Vector(0, 1, 0);
+        Vector perpendicular1 = lookDirection.clone().crossProduct(up);
+
+        // Fallback if the look direction is nearly vertical and cross product degenerates.
+        if (perpendicular1.lengthSquared() < 1.0E-6) {
+            perpendicular1 = lookDirection.clone().crossProduct(new Vector(1, 0, 0));
+        }
+
+        perpendicular1.normalize();
+        Vector perpendicular2 = lookDirection.clone().crossProduct(perpendicular1).normalize();
+        return new ConeBasis(perpendicular1, perpendicular2);
+    }
+
+    private void handleWaterSplash(Location location) {
+        if (isInvalidEffectLocation(location)) return;
+
+        if (ThreadLocalRandom.current().nextDouble() < 0.3) {
+            location.getWorld().spawnParticle(Particle.SPLASH, location.clone().add(0, .2, 0), 20, 0.35, 0.35, 0.35, 0.15);
             location.getWorld().playSound(location, Sound.ENTITY_GENERIC_SPLASH, 0.4f, 1.3f);
         }
 
@@ -253,13 +261,12 @@ public class AirBreath extends AirAbility {
     }
 
     private void handleLavaSplash(Location location, double hitDistance) {
-        if (location.getWorld() == null) return;
-        if (RegionProtection.isRegionProtected(this, location)) return;
+        if (isInvalidEffectLocation(location)) return;
 
-        location.getWorld().spawnParticle(Particle.LAVA, location.add(0, .2, 0), 8, 0.3, 0.3, 0.3, 0);
+        location.getWorld().spawnParticle(Particle.LAVA, location.clone().add(0, .2, 0), 8, 0.3, 0.3, 0.3, 0);
         location.getWorld().spawnParticle(Particle.ASH, location, 12, 0.3, 0.5, 0.3, 0.04);
 
-        if (ThreadLocalRandom.current().nextDouble() < .6) {
+        if (ThreadLocalRandom.current().nextDouble() < 0.6) {
             location.getWorld().playSound(location, Sound.BLOCK_LAVA_EXTINGUISH, 1.0f, 1.0f);
         }
 
@@ -271,14 +278,14 @@ public class AirBreath extends AirAbility {
 
         final double splashRadius = Math.max(1.0, radius * (hitDistance / range));
         final Location frozen = location.clone();
-        final double[] waveRadius = {0};
+        final double[] waveRadius = { 0 };
 
         // A single repeating task expands the freeze wave outward every 3 ticks.
         // Makes the Lava hardening feel more natural.
         lavaSplashTask = new BukkitRunnable() {
             @Override
             public void run() {
-                double prevRadius = waveRadius[0];
+                double previousRadius = waveRadius[0];
                 waveRadius[0] += 0.5;
 
                 if (waveRadius[0] > splashRadius) {
@@ -287,28 +294,21 @@ public class AirBreath extends AirAbility {
                     return;
                 }
 
-                int r = (int) Math.ceil(waveRadius[0]);
-                for (int dx = -r; dx <= r; dx++) {
-                    for (int dy = -r; dy <= r; dy++) {
-                        for (int dz = -r; dz <= r; dz++) {
-                            Block block = frozen.clone().add(dx, dy, dz).getBlock();
-                            double dist = block.getLocation().add(0.5, 0.5, 0.5).distance(frozen);
-                            // Process only the new ring added this step.
-                            if (dist > waveRadius[0] || dist <= prevRadius) continue;
-                            hardenLavaBlock(block);
-                        }
-                    }
-                }
+                forEachBlockInRadius(
+                        frozen,
+                        waveRadius[0],
+                        block -> block.getLocation().add(0.5, 0.5, 0.5).distance(frozen) > previousRadius,
+                        AirBreath.this::hardenLavaBlock);
             }
         }.runTaskTimer(ProjectKorra.plugin, 0L, 2L);
     }
 
     private void hardenLavaBlock(Block block) {
         if (block.getType() == Material.LAVA) {
-            if (block.getBlockData() instanceof Levelled lev && lev.getLevel() == 0) {
-                new TempBlock(block, Material.OBSIDIAN.createBlockData(), 10000L, this);
+            if (block.getBlockData() instanceof Levelled levelled && levelled.getLevel() == 0) {
+                new TempBlock(block, Material.OBSIDIAN.createBlockData(), TEMP_BLOCK_DURATION, this);
             } else {
-                new TempBlock(block, Material.COBBLESTONE.createBlockData(), 10000L, this);
+                new TempBlock(block, Material.COBBLESTONE.createBlockData(), TEMP_BLOCK_DURATION, this);
             }
         }
     }
@@ -317,53 +317,33 @@ public class AirBreath extends AirAbility {
      * Extinguishes all fire blocks within the cone's cross-section radius at the given distance.
      */
     private void extinguishFireInCone(Location center, double distance) {
-        if (center.getWorld() == null) return;
-        if (RegionProtection.isRegionProtected(this, center)) return;
+        if (isInvalidEffectLocation(center)) return;
 
-        double coneRadius = radius * (distance / range);
-        int r = (int) Math.ceil(coneRadius);
-
-        for (int dx = -r; dx <= r; dx++) {
-            for (int dy = -r; dy <= r; dy++) {
-                for (int dz = -r; dz <= r; dz++) {
-                    Block nearby = center.clone().add(dx, dy, dz).getBlock();
-
-                    if (nearby.getType() != Material.FIRE && nearby.getType() != Material.SOUL_FIRE) continue;
-                    if (nearby.getLocation().add(0.5, 0.5, 0.5).distance(center) > coneRadius) continue;
-
-                    new TempBlock(nearby, Material.AIR.createBlockData(), 10000L, this);
-                }
+        forEachBlockInRadius(center, getConeRadius(distance), block -> {
+            if (isFireBlock(block)) {
+                new TempBlock(block, Material.AIR.createBlockData(), TEMP_BLOCK_DURATION, this);
             }
-        }
+        });
+
         center.getWorld().playSound(center, Sound.BLOCK_FIRE_EXTINGUISH, 1.0f, 1.0f);
         center.getWorld().spawnParticle(Particle.SMOKE, center, 4, 0.15, 0.15, 0.15, 0.01);
     }
 
     private void extinguishCandleInCone(Location center, double distance) {
-        if (center.getWorld() == null) return;
-        if (RegionProtection.isRegionProtected(this, center)) return;
+        if (isInvalidEffectLocation(center)) return;
 
-        double coneRadius = radius * (distance / range);
-        int r = (int) Math.ceil(coneRadius);
+        forEachBlockInRadius(center, getConeRadius(distance), block -> {
+            if (!isLitCandle(block)) return;
 
-        for (int dx = -r; dx <= r; dx++) {
-            for (int dy = -r; dy <= r; dy++) {
-                for (int dz = -r; dz <= r; dz++) {
-                    Block nearby = center.clone().add(dx, dy, dz).getBlock();
-
-                    if (!isLitCandle(nearby)) continue;
-                    if (nearby.getLocation().add(0.5, 0.5, 0.5).distance(center) > coneRadius) continue;
-
-                    // Copy the existing block data and switch lit to false so the candle keeps its
-                    // state and reverts fully when the TempBlock expires.
-                    BlockData unlitData = nearby.getBlockData();
-                    if (unlitData instanceof Candle candle) {
-                        candle.setLit(false);
-                    }
-                    new TempBlock(nearby, unlitData, 10000L, this);
-                }
+            // Copy the existing block data and switch lit to false so the candle keeps its
+            // state and reverts fully when the TempBlock expires.
+            BlockData unlitData = block.getBlockData();
+            if (unlitData instanceof Candle candle) {
+                candle.setLit(false);
             }
-        }
+            new TempBlock(block, unlitData, TEMP_BLOCK_DURATION, this);
+        });
+
         center.getWorld().playSound(center, Sound.BLOCK_CANDLE_EXTINGUISH, 1.0f, 1.0f);
         center.getWorld().spawnParticle(Particle.SMOKE, center, 2, 0.1, 0.1, 0.1, 0.01);
     }
@@ -378,48 +358,46 @@ public class AirBreath extends AirAbility {
      * If the loot table hasn't been resolved yet (block never brushed before), it is resolved now.
      */
     private void excavateSuspiciousBlocksInCone(Location center, double distance) {
-        if (center.getWorld() == null) return;
-        if (RegionProtection.isRegionProtected(this, center)) return;
+        if (isInvalidEffectLocation(center)) return;
 
-        double coneRadius = radius * (distance / range);
-        int r = (int) Math.ceil(coneRadius);
+        forEachBlockInRadius(center, getConeRadius(distance), block -> {
+            if (!isSuspiciousBlock(block)) return;
+            if (RegionProtection.isRegionProtected(this, block.getLocation())) return;
 
-        for (int dx = -r; dx <= r; dx++) {
-            for (int dy = -r; dy <= r; dy++) {
-                for (int dz = -r; dz <= r; dz++) {
-                    Block nearby = center.clone().add(dx, dy, dz).getBlock();
+            Location dropLocation = block.getLocation().add(0.5, 0.7, 0.5);
 
-                    if (nearby.getType() != Material.SUSPICIOUS_SAND && nearby.getType() != Material.SUSPICIOUS_GRAVEL) continue;
-                    if (nearby.getLocation().add(0.5, 0.5, 0.5).distance(center) > coneRadius) continue;
-                    if (RegionProtection.isRegionProtected(this, nearby.getLocation())) continue;
-
-                    Location dropLoc = nearby.getLocation().add(0.5, 0.7, 0.5);
-
-                    // Resolve and drop the stored item, matching vanilla loot behavior.
-                    if (nearby.getState() instanceof BrushableBlock brushable) {
-                        ItemStack item = brushable.getItem();
-                        if (item != null && item.getType() != Material.AIR) {
-                            // Item was already resolved by prior brushing. drop it directly
-                            nearby.getWorld().dropItemNaturally(dropLoc, item);
-                        } else if (brushable.getLootTable() != null) {
-                            // Block never brushed: resolve using the block's own seed so the
-                            // result is deterministic, matching vanilla behavior exactly.
-                            LootContext context = new LootContext.Builder(dropLoc).build();
-                            for (ItemStack drop : brushable.getLootTable().populateLoot(new Random(brushable.getSeed()), context)) {
-                                nearby.getWorld().dropItemNaturally(dropLoc, drop);
-                            }
-                        }
+            // Resolve and drop the stored item, matching vanilla loot behavior.
+            if (block.getState() instanceof BrushableBlock brushable) {
+                ItemStack item = brushable.getItem();
+                if (item != null && item.getType() != Material.AIR) {
+                    // Item was already resolved by prior brushing. drop it directly
+                    block.getWorld().dropItemNaturally(dropLocation, item);
+                } else if (brushable.getLootTable() != null) {
+                    // Block never brushed: resolve using the block's own seed so the
+                    // result is deterministic, matching vanilla behavior exactly.
+                    LootContext lootContext = new LootContext.Builder(dropLocation).build();
+                    for (ItemStack drop : brushable.getLootTable().populateLoot(new Random(brushable.getSeed()), lootContext)) {
+                        block.getWorld().dropItemNaturally(dropLocation, drop);
                     }
-
-                    Sound brushSound = nearby.getType() == Material.SUSPICIOUS_SAND
-                            ? Sound.ITEM_BRUSH_BRUSHING_SAND_COMPLETE
-                            : Sound.ITEM_BRUSH_BRUSHING_GRAVEL_COMPLETE;
-                    nearby.getWorld().spawnParticle(Particle.BLOCK, nearby.getLocation().add(0.5, 0.5, 0.5), 12, 0.3, 0.3, 0.3, nearby.getBlockData());
-                    nearby.getWorld().playSound(nearby.getLocation(), brushSound, 1.0f, 1.0f);
-                    nearby.setType(nearby.getType() == Material.SUSPICIOUS_SAND ? Material.SAND : Material.GRAVEL);
                 }
             }
-        }
+
+            Sound brushSound = block.getType() == Material.SUSPICIOUS_SAND
+                    ? Sound.ITEM_BRUSH_BRUSHING_SAND_COMPLETE
+                    : Sound.ITEM_BRUSH_BRUSHING_GRAVEL_COMPLETE;
+
+            block.getWorld().spawnParticle(
+                    Particle.BLOCK,
+                    block.getLocation().add(0.5, 0.5, 0.5),
+                    12,
+                    0.3,
+                    0.3,
+                    0.3,
+                    block.getBlockData());
+
+            block.getWorld().playSound(block.getLocation(), brushSound, 1.0f, 1.0f);
+            block.setType(block.getType() == Material.SUSPICIOUS_SAND ? Material.SAND : Material.GRAVEL);
+        });
     }
 
     /**
@@ -427,33 +405,26 @@ public class AirBreath extends AirAbility {
      * the moment they leave, carrying them well past the breath range like a wind gust.
      */
     private void handleKnockback() {
-        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
-        Vector lookDirection = mouthLocation.getDirection().normalize();
-        double reach = currentReach();
-
+        BreathContext breathContext = createBreathContext();
         Set<Entity> entitiesInCone = new HashSet<>();
 
-        for (Entity entity : GeneralMethods.getEntitiesAroundPoint(mouthLocation, reach)) {
+        for (Entity entity : GeneralMethods.getEntitiesAroundPoint(breathContext.mouthLocation(), breathContext.reach())) {
             if (entity.equals(player)) continue;
             if (Commands.invincible.contains(entity.getName())) continue;
             if (RegionProtection.isRegionProtected(this, entity.getLocation())) continue;
             if (GeneralMethods.isHeavyEntity(entity) && !bPlayer.isAvatarState()) continue;
+            if (isInsideBreathCone(breathContext.mouthLocation(), breathContext.lookDirection(), entity.getLocation())) continue;
 
-            Vector toEntity = entity.getLocation().toVector().subtract(mouthLocation.toVector());
-            double dist = toEntity.length();
-            if (dist < 0.1) continue;
-
-            double coneHalfAngle = Math.toRadians(25.0 + dist * 1.5);
-            if (toEntity.clone().normalize().angle(lookDirection) > coneHalfAngle) continue;
-
-            double strength = knockback * (1.0 - dist / (range * 0.8));
+            double distance = entity.getLocation().distance(breathContext.mouthLocation());
+            double strength = getDistanceScaledKnockback(distance);
             if (strength <= 0) continue;
 
             entitiesInCone.add(entity);
 
             // Add to existing velocity each tick, slight Y lift so entities arc upward
-            Vector push = lookDirection.clone().multiply(strength);
-            push.setY(push.getY() + 0.04);
+            Vector push = breathContext.lookDirection().clone().multiply(strength);
+            push.setY(push.getY() + KNOCKBACK_VERTICAL_LIFT);
+
             Vector newVelocity = entity.getVelocity().add(push);
             if (newVelocity.length() > knockback) {
                 newVelocity = newVelocity.normalize().multiply(knockback);
@@ -464,11 +435,13 @@ public class AirBreath extends AirAbility {
         // Entities that just left the cone get a final burst so they fly past the range boundary (makes it seem more like a wind burst)
         for (Entity entity : previouslyInCone) {
             if (entitiesInCone.contains(entity)) continue;
-            Vector burst = lookDirection.clone().multiply(knockback * 0.4);
+
+            Vector burst = breathContext.lookDirection().clone().multiply(knockback * EXIT_BURST_FACTOR);
             GeneralMethods.setVelocity(this, entity, entity.getVelocity().add(burst));
         }
 
-        previouslyInCone = entitiesInCone;
+        previouslyInCone.clear();
+        previouslyInCone.addAll(entitiesInCone);
     }
 
     /**
@@ -477,35 +450,46 @@ public class AirBreath extends AirAbility {
      * unless the player is in avatar state.
      */
     private void handleSelfPush() {
-        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
-        Vector lookDirection = mouthLocation.getDirection().normalize();
-        double reach = currentReach();
+        BreathContext breathContext = createBreathContext();
 
-        RayTraceResult blockResult = player.getWorld().rayTraceBlocks(mouthLocation, lookDirection, reach, FluidCollisionMode.NEVER, true);
+        RayTraceResult blockResult = player.getWorld().rayTraceBlocks(
+                breathContext.mouthLocation(),
+                breathContext.lookDirection(),
+                breathContext.reach(),
+                FluidCollisionMode.NEVER,
+                true);
+
         double hitDistance = blockResult != null && blockResult.getHitBlock() != null
-                ? blockResult.getHitPosition().distance(mouthLocation.toVector())
-                : reach + 1;
+                ? blockResult.getHitPosition().distance(breathContext.mouthLocation().toVector())
+                : breathContext.reach() + 1;
 
         // Heavy entities act as a wall for recoil, but only when not in avatar state
         if (!bPlayer.isAvatarState()) {
-            RayTraceResult entityRayTraceResult = player.getWorld().rayTraceEntities(mouthLocation, lookDirection, reach, 0.5, entity -> !entity.equals(player) && GeneralMethods.isHeavyEntity(entity));
+            RayTraceResult entityRayTraceResult = player.getWorld().rayTraceEntities(
+                    breathContext.mouthLocation(),
+                    breathContext.lookDirection(),
+                    breathContext.reach(),
+                    0.5,
+                    entity -> !entity.equals(player) && GeneralMethods.isHeavyEntity(entity));
+
             if (entityRayTraceResult != null && entityRayTraceResult.getHitEntity() != null) {
-                double entityDist = entityRayTraceResult.getHitPosition().distance(mouthLocation.toVector());
-                if (entityDist < hitDistance) {
-                    hitDistance = entityDist;
+                double entityDistance = entityRayTraceResult.getHitPosition().distance(breathContext.mouthLocation().toVector());
+                if (entityDistance < hitDistance) {
+                    hitDistance = entityDistance;
                 }
             }
         }
 
-        if (hitDistance > reach) return;
+        if (hitDistance > breathContext.reach()) return;
 
         double strength = selfPushStrength * (1.0 + (range - hitDistance) / range);
-        Vector recoil = lookDirection.clone().multiply(-strength);
+        Vector recoil = breathContext.lookDirection.clone().multiply(-strength);
         Vector playerVelocity = player.getVelocity().add(recoil);
 
         if (playerVelocity.length() > selfPushFactor) {
             playerVelocity = playerVelocity.normalize().multiply(selfPushFactor);
         }
+
         GeneralMethods.setVelocity(this, player, playerVelocity);
     }
 
@@ -516,26 +500,19 @@ public class AirBreath extends AirAbility {
      * Projectiles fired by the bender themselves are ignored.
      */
     private void handleProjectileRedirect() {
-        Location mouthLocation = player.getEyeLocation().subtract(0, .2, 0);
-        Vector lookDirection = mouthLocation.getDirection().normalize();
-        double reach = currentReach();
+        BreathContext breathContext = createBreathContext();
 
-        for (Entity entity : GeneralMethods.getEntitiesAroundPoint(mouthLocation, reach)) {
+        for (Entity entity : GeneralMethods.getEntitiesAroundPoint(breathContext.mouthLocation(), breathContext.reach())) {
             if (!(entity instanceof Projectile projectile)) continue;
             if (player.equals(projectile.getShooter())) continue;
             if (RegionProtection.isRegionProtected(this, entity.getLocation())) continue;
+            if (isInsideBreathCone(breathContext.mouthLocation(), breathContext.lookDirection(), entity.getLocation())) continue;
 
-            Vector toProjectile = entity.getLocation().toVector().subtract(mouthLocation.toVector());
-            double dist = toProjectile.length();
-            if (dist < 0.1) continue;
-
-            double coneHalfAngle = Math.toRadians(25.0 + dist * 1.5);
-            if (toProjectile.clone().normalize().angle(lookDirection) > coneHalfAngle) continue;
-
-            double strength = knockback * (1.0 - dist / (range * 0.8));
+            double distance = entity.getLocation().distance(breathContext.mouthLocation());
+            double strength = getDistanceScaledKnockback(distance);
             if (strength <= 0) continue;
 
-            Vector newVelocity = entity.getVelocity().add(lookDirection.clone().multiply(strength));
+            Vector newVelocity = entity.getVelocity().add(breathContext.lookDirection().clone().multiply(strength));
             entity.setVelocity(newVelocity);
 
             // Fireballs are self-propelled via an internal lookDirection vector
@@ -547,15 +524,6 @@ public class AirBreath extends AirAbility {
             // Transfer ownership to the player so kill credit and advancements are correctly attributed
             projectile.setShooter(player);
         }
-    }
-
-    private BreathContext createBreathContext() {
-        Location mouth = getMouthLocation();
-        return new BreathContext(mouth, mouth.getDirection().normalize(), currentReach());
-    }
-
-    private Location getMouthLocation() {
-        return player.getEyeLocation().subtract(0, 0.2, 0);
     }
 
     @Override
@@ -581,6 +549,93 @@ public class AirBreath extends AirAbility {
     @Override
     public Location getLocation() {
         return player != null ? player.getEyeLocation().subtract(0, .2, 0) : null;
+    }
+
+    private BreathContext createBreathContext() {
+        Location mouthLocation = getMouthLocation();
+        return new BreathContext(mouthLocation, mouthLocation.getDirection().normalize(), currentReach());
+    }
+
+    private Location getMouthLocation() {
+        return player.getEyeLocation().subtract(0, MOUTH_Y_OFFSET, 0);
+    }
+
+    private double getConeHalfAngle(double distance) {
+        return Math.toRadians(BASE_CONE_ANGLE_DEGREES + distance * CONE_ANGLE_GROWTH_PER_BLOCK);
+    }
+
+    private double getConeRadius(double distance) {
+        return radius * (distance / range);
+    }
+
+    private double getDistanceScaledKnockback(double distance) {
+        return knockback * (1.0 - distance / (range * KNOCKBACK_FALLOFF_RANGE_FACTOR));
+    }
+
+    private boolean isInvalidEffectLocation(Location location) {
+        return location.getWorld() == null || RegionProtection.isRegionProtected(this, location);
+    }
+
+    private boolean isInsideBreathCone(Location origin, Vector direction, Location target) {
+        Vector toTarget = target.toVector().subtract(origin.toVector());
+        double distance = toTarget.length();
+
+        if (distance < 0.1) {
+            return true;
+        }
+
+        return !(toTarget.normalize().angle(direction) <= getConeHalfAngle(distance));
+    }
+
+    private boolean isFireBlock(Block block) {
+        Material type = block.getType();
+        return type == Material.FIRE || type == Material.SOUL_FIRE;
+    }
+
+    private boolean isSuspiciousBlock(Block block) {
+        Material type = block.getType();
+        return type == Material.SUSPICIOUS_SAND || type == Material.SUSPICIOUS_GRAVEL;
+    }
+
+    private void forEachBlockInRadius(Location center, double radius, Consumer<Block> consumer) {
+        forEachBlockInRadius(center, radius, block -> true, consumer);
+    }
+
+    private void forEachBlockInRadius(Location center, double radius, Predicate<Block> filter, Consumer<Block> consumer) {
+        int r = (int) Math.ceil(radius);
+
+        for (int dx = -r; dx <= r; dx++) {
+            for (int dy = -r; dy <= r; dy++) {
+                for (int dz = -r; dz <= r; dz++) {
+                    Block block = center.clone().add(dx, dy, dz).getBlock();
+
+                    if (block.getLocation().add(0.5, 0.5, 0.5).distance(center) > radius) {
+                        continue;
+                    }
+
+                    if (!filter.test(block)) {
+                        continue;
+                    }
+
+                    consumer.accept(block);
+                }
+            }
+        }
+    }
+
+    private void removeWithCooldown() {
+        bPlayer.addCooldown(this);
+        remove();
+    }
+
+    private boolean hasExpired() {
+        return System.currentTimeMillis() - getStartTime() > duration;
+    }
+
+    // How far the breath currently reaches, grows linearly from 0 to range over given growtime
+    private double currentReach() {
+        double elapsed = System.currentTimeMillis() - getStartTime();
+        return Math.min(range, range * elapsed / growTime);
     }
 
     public double getSelfPushFactor() {
@@ -623,6 +678,9 @@ public class AirBreath extends AirAbility {
         return CONFIG_ROOT_PATH;
     }
 
+    // DATA HOLDING RECORDS FOR BETTER READABILITY
     private record BreathContext(Location mouthLocation, Vector lookDirection, double reach) {}
+
+    private record ConeBasis(Vector perpendicular1, Vector perpendicular2) {}
 
 }

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -417,7 +417,7 @@ public class AirBreath extends AirAbility {
             if (Commands.invincible.contains(entity.getName())) continue;
             if (RegionProtection.isRegionProtected(this, entity.getLocation())) continue;
             if (GeneralMethods.isHeavyEntity(entity) && !bPlayer.isAvatarState()) continue;
-            if (isInsideBreathCone(breathContext.mouthLocation(), breathContext.lookDirection(), entity.getLocation())) continue;
+            if (isOutsideBreathCone(breathContext.mouthLocation(), breathContext.lookDirection(), entity.getBoundingBox().getCenter().toLocation(entity.getWorld()))) continue;
 
             double distance = entity.getLocation().distance(breathContext.mouthLocation());
             double strength = getDistanceScaledKnockback(distance);
@@ -510,7 +510,7 @@ public class AirBreath extends AirAbility {
             if (!(entity instanceof Projectile projectile)) continue;
             if (player.equals(projectile.getShooter())) continue;
             if (RegionProtection.isRegionProtected(this, entity.getLocation())) continue;
-            if (isInsideBreathCone(breathContext.mouthLocation(), breathContext.lookDirection(), entity.getLocation())) continue;
+            if (isOutsideBreathCone(breathContext.mouthLocation(), breathContext.lookDirection(), entity.getBoundingBox().getCenter().toLocation(entity.getWorld()))) continue;
 
             double distance = entity.getLocation().distance(breathContext.mouthLocation());
             double strength = getDistanceScaledKnockback(distance);
@@ -580,7 +580,7 @@ public class AirBreath extends AirAbility {
         return location.getWorld() == null || RegionProtection.isRegionProtected(this, location);
     }
 
-    private boolean isInsideBreathCone(Location origin, Vector direction, Location target) {
+    private boolean isOutsideBreathCone(Location origin, Vector direction, Location target) {
         Vector toTarget = target.toVector().subtract(origin.toVector());
         double distance = toTarget.length();
 

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -35,7 +35,12 @@ import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 
+/**
+ * @author Manu585
+ */
 public class AirBreath extends AirAbility {
+
+    private static final String CONFIG_ROOT_PATH = "Abilities.Air.AirBreath.";
 
     private static final double MOUTH_Y_OFFSET = 0.2;
     private static final double PARTICLE_STEP = 0.5;
@@ -45,8 +50,6 @@ public class AirBreath extends AirAbility {
     private static final double KNOCKBACK_VERTICAL_LIFT = 0.04;
     private static final double EXIT_BURST_FACTOR = 0.4;
     private static final long TEMP_BLOCK_DURATION = 10000L;
-
-    private static final String CONFIG_ROOT_PATH = "Abilities.Air.AirBreath.";
 
     @Attribute(Attribute.SELF_PUSH) // Maximum velocity the player can reach from self-push recoil
     private double selfPushFactor;
@@ -64,7 +67,6 @@ public class AirBreath extends AirAbility {
     private long cooldown;
     @Attribute(Attribute.CHARGE_DURATION)
     private long growTime;
-
     private boolean canExcavateSuspiciousBlocks;
 
     // The currently running lava-freeze wave, or null when no wave is active
@@ -76,8 +78,7 @@ public class AirBreath extends AirAbility {
     public AirBreath(Player player) {
         super(player);
 
-        if (player.getEyeLocation().getBlock().isLiquid()) return;
-        if (bPlayer.isOnCooldown(this)) return;
+        if (getMouthLocation().getBlock().isLiquid()) return;
         if (!bPlayer.canBend(this)) return;
         if (CoreAbility.getAbility(player, AirBreath.class) != null) return;
 

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -44,9 +44,6 @@ public class AirBreath extends AirAbility {
     private static final double PARTICLE_STEP = 0.5;
     private static final double BASE_CONE_ANGLE_DEGREES = 25.0;
     private static final double CONE_ANGLE_GROWTH_PER_BLOCK = 1.5;
-    private static final double KNOCKBACK_FALLOFF_RANGE_FACTOR = 0.8;
-    private static final double KNOCKBACK_VERTICAL_LIFT = 0.04;
-    private static final double EXIT_BURST_FACTOR = 0.4;
 
     private static final double MIN_SPLASH_RADIUS = 1.0;
     private static final double LAVA_WAVE_STEP = 0.5;
@@ -80,6 +77,9 @@ public class AirBreath extends AirAbility {
     @Attribute(Attribute.CHARGE_DURATION)
     private long growTime;
     private long tempBlockRevertTime;
+    private double knockBackFallOffRangeFactor;
+    private double knockBackVerticalLift;
+    private double exitBurstFactor;
     private boolean canExcavateSuspiciousBlocks;
 
     // Entities that were inside the breath cone last tick
@@ -115,6 +115,9 @@ public class AirBreath extends AirAbility {
         this.growTime = getConfig().getLong(CONFIG_ROOT_PATH + "GrowTime");
         this.canExcavateSuspiciousBlocks = getConfig().getBoolean(CONFIG_ROOT_PATH + "CanExcavateSuspiciousBlocks");
         this.tempBlockRevertTime = getConfig().getLong(CONFIG_ROOT_PATH + "TempBlockRevertTime");
+        this.knockBackFallOffRangeFactor = getConfig().getDouble(CONFIG_ROOT_PATH + "KnockBackFallOffRangeFactor");
+        this.knockBackVerticalLift = getConfig().getDouble(CONFIG_ROOT_PATH + "KnockBackVerticalLift");
+        this.exitBurstFactor =  getConfig().getDouble(CONFIG_ROOT_PATH + "ExitBurstFactor");
 
         start();
     }
@@ -486,7 +489,7 @@ public class AirBreath extends AirAbility {
 
             // Add to existing velocity each tick, slight Y lift so entities arc upward
              Vector push = breathContext.lookDirection().clone().multiply(strength);
-             push.setY(push.getY() + KNOCKBACK_VERTICAL_LIFT);
+             push.setY(push.getY() + knockBackVerticalLift);
 
              Vector newVelocity = entity.getVelocity().add(push);
              if (newVelocity.length() > knockback) {
@@ -500,7 +503,7 @@ public class AirBreath extends AirAbility {
         for (Entity entity : previouslyInCone) {
             if (entitiesInCone.contains(entity)) continue;
 
-            Vector burst = breathContext.lookDirection().clone().multiply(knockback * EXIT_BURST_FACTOR);
+            Vector burst = breathContext.lookDirection().clone().multiply(knockback * exitBurstFactor);
             GeneralMethods.setVelocity(this, entity, entity.getVelocity().add(burst));
         }
 
@@ -657,7 +660,7 @@ public class AirBreath extends AirAbility {
     }
 
     private double getDistanceScaledKnockback(double distance) {
-        return knockback * (1.0 - distance / (range * KNOCKBACK_FALLOFF_RANGE_FACTOR));
+        return knockback * (1.0 - distance / (range * knockBackFallOffRangeFactor));
     }
 
     private boolean isInvalidEffectLocation(Location location) {

--- a/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
+++ b/core/src/com/projectkorra/projectkorra/airbending/AirBreath.java
@@ -47,7 +47,6 @@ public class AirBreath extends AirAbility {
     private static final double KNOCKBACK_FALLOFF_RANGE_FACTOR = 0.8;
     private static final double KNOCKBACK_VERTICAL_LIFT = 0.04;
     private static final double EXIT_BURST_FACTOR = 0.4;
-    private static final long TEMP_BLOCK_DURATION = 10000L;
 
     private static final double MIN_SPLASH_RADIUS = 1.0;
     private static final double LAVA_WAVE_STEP = 0.5;
@@ -80,6 +79,7 @@ public class AirBreath extends AirAbility {
     private long cooldown;
     @Attribute(Attribute.CHARGE_DURATION)
     private long growTime;
+    private long tempBlockRevertTime;
     private boolean canExcavateSuspiciousBlocks;
 
     // Entities that were inside the breath cone last tick
@@ -114,6 +114,7 @@ public class AirBreath extends AirAbility {
         this.cooldown = getConfig().getLong(CONFIG_ROOT_PATH + "Cooldown");
         this.growTime = getConfig().getLong(CONFIG_ROOT_PATH + "GrowTime");
         this.canExcavateSuspiciousBlocks = getConfig().getBoolean(CONFIG_ROOT_PATH + "CanExcavateSuspiciousBlocks");
+        this.tempBlockRevertTime = getConfig().getLong(CONFIG_ROOT_PATH + "TempBlockRevertTime");
 
         start();
     }
@@ -359,9 +360,9 @@ public class AirBreath extends AirAbility {
         if (block.getType() != Material.LAVA) return;
 
         if (block.getBlockData() instanceof Levelled levelled && levelled.getLevel() == 0) {
-            new TempBlock(block, Material.OBSIDIAN.createBlockData(), TEMP_BLOCK_DURATION, this);
+            new TempBlock(block, Material.OBSIDIAN.createBlockData(), tempBlockRevertTime, this);
         } else {
-            new TempBlock(block, Material.COBBLESTONE.createBlockData(), TEMP_BLOCK_DURATION, this);
+            new TempBlock(block, Material.COBBLESTONE.createBlockData(), tempBlockRevertTime, this);
         }
     }
 
@@ -373,7 +374,7 @@ public class AirBreath extends AirAbility {
 
         forEachBlockInRadius(center, getConeRadius(distance), block -> {
             if (isFireBlock(block)) {
-                new TempBlock(block, Material.AIR.createBlockData(), TEMP_BLOCK_DURATION, this);
+                new TempBlock(block, Material.AIR.createBlockData(), tempBlockRevertTime, this);
             }
         });
 
@@ -392,7 +393,7 @@ public class AirBreath extends AirAbility {
         BlockData unlitData = block.getBlockData();
         if (unlitData instanceof Candle candle) {
             candle.setLit(false);
-            new TempBlock(block, unlitData, TEMP_BLOCK_DURATION, this);
+            new TempBlock(block, unlitData, tempBlockRevertTime, this);
         }
     }
 

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -920,13 +920,13 @@ public class ConfigManager {
 
 			config.addDefault("Abilities.Air.AirBreath.Enabled", true);
 			config.addDefault("Abilities.Air.AirBreath.Cooldown", 8000);
-			config.addDefault("Abilities.Air.AirBreath.Duration", 3000);
-			config.addDefault("Abilities.Air.AirBreath.Range", 7.0);
-			config.addDefault("Abilities.Air.AirBreath.Radius", 2.5);
-			config.addDefault("Abilities.Air.AirBreath.Knockback", 1.6);
-			config.addDefault("Abilities.Air.AirBreath.SelfPushFactor", 2.5);
-			config.addDefault("Abilities.Air.AirBreath.SelfPushStrength", 0.06);
-			config.addDefault("Abilities.Air.AirBreath.GrowTime", 350);
+			config.addDefault("Abilities.Air.AirBreath.Duration", 3500);
+			config.addDefault("Abilities.Air.AirBreath.Range", 8.0);
+			config.addDefault("Abilities.Air.AirBreath.Radius", 3.0);
+			config.addDefault("Abilities.Air.AirBreath.Knockback", 2.0);
+			config.addDefault("Abilities.Air.AirBreath.SelfPushFactor", 3.0);
+			config.addDefault("Abilities.Air.AirBreath.SelfPushStrength", 0.2);
+			config.addDefault("Abilities.Air.AirBreath.GrowTime", 0);
 			config.addDefault("Abilities.Air.AirBreath.CanExcavateSuspiciousBlocks", false);
 
 			config.addDefault("Abilities.Air.AirShield.Enabled", true);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -679,18 +679,18 @@ public class ConfigManager {
 
 			/* Dry biomes for FrostBreath */
 			final List<String> dryBiomes = new ArrayList<>();
-			dryBiomes.add(Biome.DESERT.getKey().getKey());
-			dryBiomes.add(Biome.BADLANDS.getKey().getKey());
-			dryBiomes.add(Biome.ERODED_BADLANDS.getKey().getKey());
-			dryBiomes.add(Biome.WOODED_BADLANDS.getKey().getKey());
-			dryBiomes.add(Biome.SAVANNA.getKey().getKey());
-			dryBiomes.add(Biome.SAVANNA_PLATEAU.getKey().getKey());
-			dryBiomes.add(Biome.WINDSWEPT_SAVANNA.getKey().getKey());
-			dryBiomes.add(Biome.BASALT_DELTAS.getKey().getKey());
-			dryBiomes.add(Biome.CRIMSON_FOREST.getKey().getKey());
-			dryBiomes.add(Biome.WARPED_FOREST.getKey().getKey());
-			dryBiomes.add(Biome.NETHER_WASTES.getKey().getKey());
-			dryBiomes.add(Biome.SOUL_SAND_VALLEY.getKey().getKey());
+			dryBiomes.add(Biome.DESERT.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.BADLANDS.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.ERODED_BADLANDS.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.WOODED_BADLANDS.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.SAVANNA.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.SAVANNA_PLATEAU.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.WINDSWEPT_SAVANNA.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.BASALT_DELTAS.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.CRIMSON_FOREST.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.WARPED_FOREST.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.NETHER_WASTES.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.SOUL_SAND_VALLEY.getKeyOrThrow().getKey());
 
 			final List<String> plantBlocks = new ArrayList<>();
 			plantBlocks.add("#bee_growables");
@@ -785,7 +785,7 @@ public class ConfigManager {
 			config.addDefault("Properties.Air.CanBendWithWeapons", false);
 			config.addDefault("Properties.Air.Particles", Particle.EFFECT.name());
 			config.addDefault("Properties.Air.PlaySound", true);
-			config.addDefault("Properties.Air.Sound.Sound", Sound.ENTITY_CREEPER_HURT.getKey().getKey());
+			config.addDefault("Properties.Air.Sound.Sound", Sound.ENTITY_CREEPER_HURT.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Air.Sound.Volume", 1);
 			config.addDefault("Properties.Air.Sound.Pitch", 2);
 
@@ -799,16 +799,16 @@ public class ConfigManager {
 			// config.addDefault("Properties.Water.TransformableBlocks", waterTransformableBlocks);
 			config.addDefault("Properties.Water.NightFactor", 1.25);
 			config.addDefault("Properties.Water.PlaySound", true);
-			config.addDefault("Properties.Water.WaterSound.Sound", Sound.BLOCK_WATER_AMBIENT.getKey().getKey());
+			config.addDefault("Properties.Water.WaterSound.Sound", Sound.BLOCK_WATER_AMBIENT.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Water.WaterSound.Volume", 1);
 			config.addDefault("Properties.Water.WaterSound.Pitch", 1);
-			config.addDefault("Properties.Water.IceSound.Sound", Sound.ITEM_FLINTANDSTEEL_USE.getKey().getKey());
+			config.addDefault("Properties.Water.IceSound.Sound", Sound.ITEM_FLINTANDSTEEL_USE.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Water.IceSound.Volume", 1);
 			config.addDefault("Properties.Water.IceSound.Pitch", 1);
-			config.addDefault("Properties.Water.PlantSound.Sound", Sound.BLOCK_GRASS_STEP.getKey().getKey());
+			config.addDefault("Properties.Water.PlantSound.Sound", Sound.BLOCK_GRASS_STEP.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Water.IceSound.Volume", 1);
 			config.addDefault("Properties.Water.IceSound.Pitch", 1);
-			config.addDefault("Properties.Water.MudSound.Sound", Sound.BLOCK_MUD_STEP.getKey().getKey());
+			config.addDefault("Properties.Water.MudSound.Sound", Sound.BLOCK_MUD_STEP.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Water.MudSound.Volume", 1);
 			config.addDefault("Properties.Water.MudSound.Pitch", 1);
 
@@ -822,19 +822,19 @@ public class ConfigManager {
 			config.addDefault("Properties.Earth.SandBlocks", sandBlocks);
 			config.addDefault("Properties.Earth.MetalPowerFactor", 1.5);
 			config.addDefault("Properties.Earth.PlaySound", true);
-			config.addDefault("Properties.Earth.EarthSound.Sound", Sound.ENTITY_GHAST_SHOOT.getKey().getKey());
+			config.addDefault("Properties.Earth.EarthSound.Sound", Sound.ENTITY_GHAST_SHOOT.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Earth.EarthSound.Volume", 1);
 			config.addDefault("Properties.Earth.EarthSound.Pitch", 1);
-			config.addDefault("Properties.Earth.MetalSound.Sound", Sound.ENTITY_IRON_GOLEM_HURT.getKey().getKey());
+			config.addDefault("Properties.Earth.MetalSound.Sound", Sound.ENTITY_IRON_GOLEM_HURT.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Earth.MetalSound.Volume", 1);
 			config.addDefault("Properties.Earth.MetalSound.Pitch", 1.25);
-			config.addDefault("Properties.Earth.SandSound.Sound", Sound.BLOCK_SAND_BREAK.getKey().getKey());
+			config.addDefault("Properties.Earth.SandSound.Sound", Sound.BLOCK_SAND_BREAK.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Earth.SandSound.Volume", 1);
 			config.addDefault("Properties.Earth.SandSound.Pitch", 1);
-			config.addDefault("Properties.Earth.LavaSound.Sound", Sound.BLOCK_LAVA_AMBIENT.getKey().getKey());
+			config.addDefault("Properties.Earth.LavaSound.Sound", Sound.BLOCK_LAVA_AMBIENT.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Earth.LavaSound.Volume", 1);
 			config.addDefault("Properties.Earth.LavaSound.Pitch", 1);
-			config.addDefault("Properties.Earth.MudSound.Sound", Sound.BLOCK_MUD_PLACE.getKey().getKey());
+			config.addDefault("Properties.Earth.MudSound.Sound", Sound.BLOCK_MUD_PLACE.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Earth.MudSound.Volume", 1);
 			config.addDefault("Properties.Earth.MudSound.Pitch", 1);
 
@@ -843,19 +843,19 @@ public class ConfigManager {
 			config.addDefault("Properties.Fire.PlaySound", true);
 			config.addDefault("Properties.Fire.FireGriefing", false);
 			config.addDefault("Properties.Fire.RevertTicks", 12000L);
-			config.addDefault("Properties.Fire.FireSound.Sound", Sound.BLOCK_FIRE_AMBIENT.getKey().getKey());
+			config.addDefault("Properties.Fire.FireSound.Sound", Sound.BLOCK_FIRE_AMBIENT.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Fire.FireSound.Volume", 1);
 			config.addDefault("Properties.Fire.FireSound.Pitch", 1);
-			config.addDefault("Properties.Fire.CombustionSound.Sound", Sound.ENTITY_FIREWORK_ROCKET_BLAST.getKey().getKey());
+			config.addDefault("Properties.Fire.CombustionSound.Sound", Sound.ENTITY_FIREWORK_ROCKET_BLAST.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Fire.CombustionSound.Volume", 1);
 			config.addDefault("Properties.Fire.CombustionSound.Pitch", 0);
-			config.addDefault("Properties.Fire.LightningSound.Sound", Sound.ENTITY_CREEPER_HURT.getKey().getKey());
+			config.addDefault("Properties.Fire.LightningSound.Sound", Sound.ENTITY_CREEPER_HURT.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Fire.LightningSound.Volume", 1);
 			config.addDefault("Properties.Fire.LightningSound.Pitch", 0);
-			config.addDefault("Properties.Fire.LightningCharge.Sound", Sound.BLOCK_BEEHIVE_WORK.getKey().getKey());
+			config.addDefault("Properties.Fire.LightningCharge.Sound", Sound.BLOCK_BEEHIVE_WORK.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Fire.LightningCharge.Volume", 2);
 			config.addDefault("Properties.Fire.LightningCharge.Pitch", .5);
-			config.addDefault("Properties.Fire.LightningHit.Sound", Sound.ENTITY_LIGHTNING_BOLT_THUNDER.getKey().getKey());
+			config.addDefault("Properties.Fire.LightningHit.Sound", Sound.ENTITY_LIGHTNING_BOLT_THUNDER.getKeyOrThrow().getKey());
 			config.addDefault("Properties.Fire.LightningHit.Volume", 1);
 			config.addDefault("Properties.Fire.LightningHit.Pitch", 2);
 			config.addDefault("Properties.Fire.BlueFire.DamageFactor", 1.1);
@@ -1757,7 +1757,7 @@ public class ConfigManager {
 			config.addDefault("AvatarState.PlaySound", true);
 			config.addDefault("AvatarState.ShowParticles", true);
 			config.addDefault("AvatarState.GlowEnabled", false);
-			config.addDefault("AvatarState.Sound.Sound", Sound.BLOCK_BEACON_ACTIVATE.getKey().getKey());
+			config.addDefault("AvatarState.Sound.Sound", Sound.BLOCK_BEACON_ACTIVATE.getKeyOrThrow().getKey());
 			config.addDefault("AvatarState.Sound.Volume", 1);
 			config.addDefault("AvatarState.Sound.Pitch", 1.5);
 			config.addDefault("AvatarState.CanBeChiblocked", false);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -384,6 +384,8 @@ public class ConfigManager {
 			config.addDefault("Abilities.Air.Tornado.Instructions", "Hold sneak and a tornado will form gradually wherever you look.");
 			config.addDefault("Abilities.Air.AirShield.Description", "AirShield is one of the most powerful defensive techniques in existence. This ability is mainly used when you are low health and need protection. It's also useful when you're surrounded by mobs.");
 			config.addDefault("Abilities.Air.AirShield.Instructions", "Hold sneak and a shield of air will form around you, blocking projectiles and pushing entities back.");
+			config.addDefault("Abilities.Air.AirBreath.Description", "An airbender can channel their breath into a powerful swirling current of air, pushing all entities caught in its path. Directing the breath downward or at a surface propels the bender skyward. Water is scattered with a splash on contact, and lava is rapidly cooled by the force of the breath.");
+			config.addDefault("Abilities.Air.AirBreath.Instructions", "Hold sneak to exhale a swirling vortex of air that blows away nearby entities. Aim at the ground or a wall to launch yourself into the air. The breath scatters water on contact and rapidly cools lava.");
 			config.addDefault("Abilities.Air.AirSpout.Description", "This ability gives the airbender limited sustained levitation. It allows an airbender to gain a height advantage to escape from mobs, players or just to dodge from attacks. This ability is also useful for building as it allows you to reach great heights.");
 			config.addDefault("Abilities.Air.AirSpout.Instructions", "Left click to activate a spout beneath you and hold spacebar to go higher. If you wish to go lower, simply hold sneak. To disable this ability, left click once again.");
 			config.addDefault("Abilities.Air.AirSuction.Description", "AirSuction is a basic ability that allows you to manipulation an entity's movement. It can be used to bring someone back to you when they're running away, or even to get yourself to great heights.");
@@ -677,18 +679,18 @@ public class ConfigManager {
 
 			/* Dry biomes for FrostBreath */
 			final List<String> dryBiomes = new ArrayList<>();
-			dryBiomes.add(Biome.DESERT.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.BADLANDS.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.ERODED_BADLANDS.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.WOODED_BADLANDS.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.SAVANNA.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.SAVANNA_PLATEAU.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.WINDSWEPT_SAVANNA.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.BASALT_DELTAS.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.CRIMSON_FOREST.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.WARPED_FOREST.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.NETHER_WASTES.getKeyOrThrow().getKey());
-			dryBiomes.add(Biome.SOUL_SAND_VALLEY.getKeyOrThrow().getKey());
+			dryBiomes.add(Biome.DESERT.getKey().getKey());
+			dryBiomes.add(Biome.BADLANDS.getKey().getKey());
+			dryBiomes.add(Biome.ERODED_BADLANDS.getKey().getKey());
+			dryBiomes.add(Biome.WOODED_BADLANDS.getKey().getKey());
+			dryBiomes.add(Biome.SAVANNA.getKey().getKey());
+			dryBiomes.add(Biome.SAVANNA_PLATEAU.getKey().getKey());
+			dryBiomes.add(Biome.WINDSWEPT_SAVANNA.getKey().getKey());
+			dryBiomes.add(Biome.BASALT_DELTAS.getKey().getKey());
+			dryBiomes.add(Biome.CRIMSON_FOREST.getKey().getKey());
+			dryBiomes.add(Biome.WARPED_FOREST.getKey().getKey());
+			dryBiomes.add(Biome.NETHER_WASTES.getKey().getKey());
+			dryBiomes.add(Biome.SOUL_SAND_VALLEY.getKey().getKey());
 
 			final List<String> plantBlocks = new ArrayList<>();
 			plantBlocks.add("#bee_growables");
@@ -783,7 +785,7 @@ public class ConfigManager {
 			config.addDefault("Properties.Air.CanBendWithWeapons", false);
 			config.addDefault("Properties.Air.Particles", Particle.EFFECT.name());
 			config.addDefault("Properties.Air.PlaySound", true);
-			config.addDefault("Properties.Air.Sound.Sound", Sound.ENTITY_CREEPER_HURT.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Air.Sound.Sound", Sound.ENTITY_CREEPER_HURT.getKey().getKey());
 			config.addDefault("Properties.Air.Sound.Volume", 1);
 			config.addDefault("Properties.Air.Sound.Pitch", 2);
 
@@ -797,16 +799,16 @@ public class ConfigManager {
 			// config.addDefault("Properties.Water.TransformableBlocks", waterTransformableBlocks);
 			config.addDefault("Properties.Water.NightFactor", 1.25);
 			config.addDefault("Properties.Water.PlaySound", true);
-			config.addDefault("Properties.Water.WaterSound.Sound", Sound.BLOCK_WATER_AMBIENT.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Water.WaterSound.Sound", Sound.BLOCK_WATER_AMBIENT.getKey().getKey());
 			config.addDefault("Properties.Water.WaterSound.Volume", 1);
 			config.addDefault("Properties.Water.WaterSound.Pitch", 1);
-			config.addDefault("Properties.Water.IceSound.Sound", Sound.ITEM_FLINTANDSTEEL_USE.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Water.IceSound.Sound", Sound.ITEM_FLINTANDSTEEL_USE.getKey().getKey());
 			config.addDefault("Properties.Water.IceSound.Volume", 1);
 			config.addDefault("Properties.Water.IceSound.Pitch", 1);
-			config.addDefault("Properties.Water.PlantSound.Sound", Sound.BLOCK_GRASS_STEP.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Water.PlantSound.Sound", Sound.BLOCK_GRASS_STEP.getKey().getKey());
 			config.addDefault("Properties.Water.IceSound.Volume", 1);
 			config.addDefault("Properties.Water.IceSound.Pitch", 1);
-			config.addDefault("Properties.Water.MudSound.Sound", Sound.BLOCK_MUD_STEP.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Water.MudSound.Sound", Sound.BLOCK_MUD_STEP.getKey().getKey());
 			config.addDefault("Properties.Water.MudSound.Volume", 1);
 			config.addDefault("Properties.Water.MudSound.Pitch", 1);
 
@@ -820,19 +822,19 @@ public class ConfigManager {
 			config.addDefault("Properties.Earth.SandBlocks", sandBlocks);
 			config.addDefault("Properties.Earth.MetalPowerFactor", 1.5);
 			config.addDefault("Properties.Earth.PlaySound", true);
-			config.addDefault("Properties.Earth.EarthSound.Sound", Sound.ENTITY_GHAST_SHOOT.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Earth.EarthSound.Sound", Sound.ENTITY_GHAST_SHOOT.getKey().getKey());
 			config.addDefault("Properties.Earth.EarthSound.Volume", 1);
 			config.addDefault("Properties.Earth.EarthSound.Pitch", 1);
-			config.addDefault("Properties.Earth.MetalSound.Sound", Sound.ENTITY_IRON_GOLEM_HURT.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Earth.MetalSound.Sound", Sound.ENTITY_IRON_GOLEM_HURT.getKey().getKey());
 			config.addDefault("Properties.Earth.MetalSound.Volume", 1);
 			config.addDefault("Properties.Earth.MetalSound.Pitch", 1.25);
-			config.addDefault("Properties.Earth.SandSound.Sound", Sound.BLOCK_SAND_BREAK.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Earth.SandSound.Sound", Sound.BLOCK_SAND_BREAK.getKey().getKey());
 			config.addDefault("Properties.Earth.SandSound.Volume", 1);
 			config.addDefault("Properties.Earth.SandSound.Pitch", 1);
-			config.addDefault("Properties.Earth.LavaSound.Sound", Sound.BLOCK_LAVA_AMBIENT.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Earth.LavaSound.Sound", Sound.BLOCK_LAVA_AMBIENT.getKey().getKey());
 			config.addDefault("Properties.Earth.LavaSound.Volume", 1);
 			config.addDefault("Properties.Earth.LavaSound.Pitch", 1);
-			config.addDefault("Properties.Earth.MudSound.Sound", Sound.BLOCK_MUD_PLACE.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Earth.MudSound.Sound", Sound.BLOCK_MUD_PLACE.getKey().getKey());
 			config.addDefault("Properties.Earth.MudSound.Volume", 1);
 			config.addDefault("Properties.Earth.MudSound.Pitch", 1);
 
@@ -841,19 +843,19 @@ public class ConfigManager {
 			config.addDefault("Properties.Fire.PlaySound", true);
 			config.addDefault("Properties.Fire.FireGriefing", false);
 			config.addDefault("Properties.Fire.RevertTicks", 12000L);
-			config.addDefault("Properties.Fire.FireSound.Sound", Sound.BLOCK_FIRE_AMBIENT.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Fire.FireSound.Sound", Sound.BLOCK_FIRE_AMBIENT.getKey().getKey());
 			config.addDefault("Properties.Fire.FireSound.Volume", 1);
 			config.addDefault("Properties.Fire.FireSound.Pitch", 1);
-			config.addDefault("Properties.Fire.CombustionSound.Sound", Sound.ENTITY_FIREWORK_ROCKET_BLAST.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Fire.CombustionSound.Sound", Sound.ENTITY_FIREWORK_ROCKET_BLAST.getKey().getKey());
 			config.addDefault("Properties.Fire.CombustionSound.Volume", 1);
 			config.addDefault("Properties.Fire.CombustionSound.Pitch", 0);
-			config.addDefault("Properties.Fire.LightningSound.Sound", Sound.ENTITY_CREEPER_HURT.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Fire.LightningSound.Sound", Sound.ENTITY_CREEPER_HURT.getKey().getKey());
 			config.addDefault("Properties.Fire.LightningSound.Volume", 1);
 			config.addDefault("Properties.Fire.LightningSound.Pitch", 0);
-			config.addDefault("Properties.Fire.LightningCharge.Sound", Sound.BLOCK_BEEHIVE_WORK.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Fire.LightningCharge.Sound", Sound.BLOCK_BEEHIVE_WORK.getKey().getKey());
 			config.addDefault("Properties.Fire.LightningCharge.Volume", 2);
 			config.addDefault("Properties.Fire.LightningCharge.Pitch", .5);
-			config.addDefault("Properties.Fire.LightningHit.Sound", Sound.ENTITY_LIGHTNING_BOLT_THUNDER.getKeyOrThrow().getKey());
+			config.addDefault("Properties.Fire.LightningHit.Sound", Sound.ENTITY_LIGHTNING_BOLT_THUNDER.getKey().getKey());
 			config.addDefault("Properties.Fire.LightningHit.Volume", 1);
 			config.addDefault("Properties.Fire.LightningHit.Pitch", 2);
 			config.addDefault("Properties.Fire.BlueFire.DamageFactor", 1.1);
@@ -915,6 +917,16 @@ public class ConfigManager {
 			config.addDefault("Abilities.Air.AirScooter.Cooldown", 7000);
 			config.addDefault("Abilities.Air.AirScooter.Duration", 0);
 			config.addDefault("Abilities.Air.AirScooter.MaxHeightFromGround", 7);
+
+			config.addDefault("Abilities.Air.AirBreath.Enabled", true);
+			config.addDefault("Abilities.Air.AirBreath.Cooldown", 8000);
+			config.addDefault("Abilities.Air.AirBreath.Duration", 5000);
+			config.addDefault("Abilities.Air.AirBreath.Range", 10.0);
+			config.addDefault("Abilities.Air.AirBreath.Radius", 1.5);
+			config.addDefault("Abilities.Air.AirBreath.Knockback", 1.4);
+			config.addDefault("Abilities.Air.AirBreath.SelfPushFactor", 2.0);
+			config.addDefault("Abilities.Air.AirBreath.SelfPushStrength", 0.07);
+			config.addDefault("Abilities.Air.AirBreath.GrowTime", 500);
 
 			config.addDefault("Abilities.Air.AirShield.Enabled", true);
 			config.addDefault("Abilities.Air.AirShield.Cooldown", 0);
@@ -1744,7 +1756,7 @@ public class ConfigManager {
 			config.addDefault("AvatarState.PlaySound", true);
 			config.addDefault("AvatarState.ShowParticles", true);
 			config.addDefault("AvatarState.GlowEnabled", false);
-			config.addDefault("AvatarState.Sound.Sound", Sound.BLOCK_BEACON_ACTIVATE.getKeyOrThrow().getKey());
+			config.addDefault("AvatarState.Sound.Sound", Sound.BLOCK_BEACON_ACTIVATE.getKey().getKey());
 			config.addDefault("AvatarState.Sound.Volume", 1);
 			config.addDefault("AvatarState.Sound.Pitch", 1.5);
 			config.addDefault("AvatarState.CanBeChiblocked", false);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -920,13 +920,14 @@ public class ConfigManager {
 
 			config.addDefault("Abilities.Air.AirBreath.Enabled", true);
 			config.addDefault("Abilities.Air.AirBreath.Cooldown", 8000);
-			config.addDefault("Abilities.Air.AirBreath.Duration", 5000);
-			config.addDefault("Abilities.Air.AirBreath.Range", 10.0);
-			config.addDefault("Abilities.Air.AirBreath.Radius", 1.5);
-			config.addDefault("Abilities.Air.AirBreath.Knockback", 1.4);
-			config.addDefault("Abilities.Air.AirBreath.SelfPushFactor", 2.0);
-			config.addDefault("Abilities.Air.AirBreath.SelfPushStrength", 0.07);
-			config.addDefault("Abilities.Air.AirBreath.GrowTime", 500);
+			config.addDefault("Abilities.Air.AirBreath.Duration", 3000);
+			config.addDefault("Abilities.Air.AirBreath.Range", 7.0);
+			config.addDefault("Abilities.Air.AirBreath.Radius", 2.5);
+			config.addDefault("Abilities.Air.AirBreath.Knockback", 1.6);
+			config.addDefault("Abilities.Air.AirBreath.SelfPushFactor", 2.5);
+			config.addDefault("Abilities.Air.AirBreath.SelfPushStrength", 0.06);
+			config.addDefault("Abilities.Air.AirBreath.GrowTime", 350);
+			config.addDefault("Abilities.Air.AirBreath.CanExcavateSuspiciousBlocks", false);
 
 			config.addDefault("Abilities.Air.AirShield.Enabled", true);
 			config.addDefault("Abilities.Air.AirShield.Cooldown", 0);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -928,6 +928,7 @@ public class ConfigManager {
 			config.addDefault("Abilities.Air.AirBreath.SelfPushStrength", 0.2);
 			config.addDefault("Abilities.Air.AirBreath.GrowTime", 0);
 			config.addDefault("Abilities.Air.AirBreath.CanExcavateSuspiciousBlocks", false);
+            config.addDefault("Abilities.Air.AirBreath.TempBlockRevertTime", 10000L);
 
 			config.addDefault("Abilities.Air.AirShield.Enabled", true);
 			config.addDefault("Abilities.Air.AirShield.Cooldown", 0);

--- a/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
+++ b/core/src/com/projectkorra/projectkorra/configuration/ConfigManager.java
@@ -929,8 +929,11 @@ public class ConfigManager {
 			config.addDefault("Abilities.Air.AirBreath.GrowTime", 0);
 			config.addDefault("Abilities.Air.AirBreath.CanExcavateSuspiciousBlocks", false);
             config.addDefault("Abilities.Air.AirBreath.TempBlockRevertTime", 10000L);
+            config.addDefault("Abilities.Air.AirBreath.KnockBackFallOffRangeFactor", 0.8);
+            config.addDefault("Abilities.Air.AirBreath.KnockBackVerticalLift", 0.04);
+            config.addDefault("Abilities.Air.AirBreath.ExitBurstFactor", 0.4);
 
-			config.addDefault("Abilities.Air.AirShield.Enabled", true);
+            config.addDefault("Abilities.Air.AirShield.Enabled", true);
 			config.addDefault("Abilities.Air.AirShield.Cooldown", 0);
 			config.addDefault("Abilities.Air.AirShield.Duration", 0);
 			config.addDefault("Abilities.Air.AirShield.MaxRadius", 7);


### PR DESCRIPTION
## Additions
### AirBreath
An official implementation of an airbending classic allowing benders to channel their breath into a powerful swirling current of air, pushing (most) entities caught in its path. In addition to simply blowing away targets, users can also direct their breath downward or at a surface propelling themselves in the opposite direction. Water is scattered with a splash on contact, and lava is rapidly cooled by the force of the breath. Depending on the server config, the ability can also be used to potentially uncover hidden treasures within suspicious blocks!

AirBreath is unable to affect Iron Golems, Sniffers, Ravagers, Wardens, Withers, Elder Guardians, or the EnderDragon. They are treated the same way as a wall or floor unless in the AvatarState.

Config Options:

- `Cooldown` - The amount of time a bender needs to wait before they can use the ability again. Defaults to 8000ms.
- `Duration` - The amount of time a bender can continue using the ability before it goes on cooldown. Defaults to 3500ms.
- `Range` - The maximum linear distance a bender's AirBreath can travel. Defaults to 8.0 blocks.
- `Radius` - The maximum conical distance entities and/or blocks can be affected by a bender's AirBreath at the maximum range. Defaults to `3.0` blocks.
- `Knockback` - The maximum force applied to entities affected by a bender's AirBreath. Falls off with distance from this maximum. Defaults to `2.0`.
- `KnockBackFallOffRangeFactor` - The strength any knockback applied by AirBreath decreased with respect to an entity's distance from the bender. Defaults to `0.8`.
- `KnockBackVerticalLift` - The vertical force applied to entities while being affected by a bender's AirBreath. Defaults to `0.04` blocks.
- `SelfPushFactor` - The maximum velocity a bender can achieve when their AirBreath hits a solid surface or heavy entity and recoils. Defaults to `3.0` blocks per tick.
- `SelfPushStrength` - The knockback force multiplier applied to a bender per tick when their AirBreath hits a solid surface or heavy entity and recoils. Defaults to `0.2`x
- `GrowTime` - The amount of time required before a bender's AirBreath reaches its maximum range after starting. Defaults to `0`.
- `CanExcavateSuspiciousBlocks` - Determines whether suspicious sand or gravel within a bender's AirBreath will be excavated. Defaults to `false`.
- `TempBlockRevertTime` - The amount of time until any blocks affected by a bender's AirBreath will return to their original state. Defaults to `10000`ms.
- `ExitBurstFactor` - A multiplier applied to a target's the last knockback force before leaving a bender's AirBreath range. Defaults to `0.4`x.